### PR TITLE
Remove the need to use to 2to3 conversion utility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -697,6 +697,9 @@ Version History
   * enhancement: new context manager ``keypad()``, which enables
     keypad application keys such as the diagonal keys on the numpad.
   * bugfix: translate keypad application keys correctly.
+  * enhancement: no longer depend on the '2to3' tool for python 3 support.
+  * enhancement: allow ``civis`` and ``cnorm`` (*hide_cursor*, *normal_hide*)
+    to work with terminal-type *ansi* by emulating support by proxy.
 
 1.8
   * enhancement: export keyboard-read function as public method ``getch()``,
@@ -704,7 +707,7 @@ Version History
   * enhancement: allow ``inkey()`` and ``kbhit()`` to return early when
     interrupted by signal by passing argument ``_intr_continue=False``.
   * enhancement: allow ``hpa`` and ``vpa`` (*move_x*, *move_y*) to work on
-    tmux(1) or screen(1) by forcibly emulating their support by a proxy.
+    tmux(1) or screen(1) by emulating support by proxy.
   * enhancement: ``setup.py develop`` ensures virtualenv and installs tox,
     and ``setup.py test`` calls tox. Requires pythons defined by tox.ini.
   * enhancement: add ``rstrip()`` and ``lstrip()``, strips both sequences

--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -9,6 +9,6 @@ if ('3', '0', '0') <= _platform.python_version_tuple() < ('3', '2', '2+'):
                       'support due to http://bugs.python.org/issue10570.')
 
 
-from terminal import Terminal
+from .terminal import Terminal
 
 __all__ = ['Terminal']

--- a/blessed/formatters.py
+++ b/blessed/formatters.py
@@ -1,5 +1,6 @@
 "This sub-module provides formatting functions."
 import curses
+import sys
 
 _derivatives = ('on', 'bright', 'on_bright',)
 
@@ -15,8 +16,14 @@ COLORS = set(['_'.join((derivitive, color))
 #: All valid compoundable names.
 COMPOUNDABLES = (COLORS | _compoundables)
 
+if sys.version_info[0] == 3:
+    text_type = str
+    basestring = str
+else:
+    text_type = unicode  # noqa
 
-class ParameterizingString(unicode):
+
+class ParameterizingString(text_type):
     """A Unicode string which can be called as a parameterizing termcap.
 
     For example::
@@ -35,7 +42,7 @@ class ParameterizingString(unicode):
         :arg name: name of this terminal capability.
         """
         assert len(args) and len(args) < 4, args
-        new = unicode.__new__(cls, args[0])
+        new = text_type.__new__(cls, args[0])
         new._normal = len(args) > 1 and args[1] or u''
         new._name = len(args) > 2 and args[2] or u'<not specified>'
         return new
@@ -74,7 +81,7 @@ class ParameterizingString(unicode):
             return NullCallableString()
 
 
-class ParameterizingProxyString(unicode):
+class ParameterizingProxyString(text_type):
     """A Unicode string which can be called to proxy missing termcap entries.
 
     For example::
@@ -102,7 +109,7 @@ class ParameterizingProxyString(unicode):
         assert len(args) and len(args) < 4, args
         assert type(args[0]) is tuple, args[0]
         assert callable(args[0][1]), args[0][1]
-        new = unicode.__new__(cls, args[0][0])
+        new = text_type.__new__(cls, args[0][0])
         new._fmt_args = args[0][1]
         new._normal = len(args) > 1 and args[1] or u''
         new._name = len(args) > 2 and args[2] or u'<not specified>'
@@ -135,7 +142,7 @@ def get_proxy_string(term, attr):
     return None
 
 
-class FormattingString(unicode):
+class FormattingString(text_type):
     """A Unicode string which can be called using ``text``,
     returning a new string, ``attr`` + ``text`` + ``normal``::
 
@@ -150,7 +157,7 @@ class FormattingString(unicode):
         :arg normal: terminating sequence for this attribute.
         """
         assert 1 <= len(args) <= 2, args
-        new = unicode.__new__(cls, args[0])
+        new = text_type.__new__(cls, args[0])
         new._normal = len(args) > 1 and args[1] or u''
         return new
 
@@ -165,12 +172,12 @@ class FormattingString(unicode):
         return text
 
 
-class NullCallableString(unicode):
+class NullCallableString(text_type):
     """A dummy callable Unicode to stand in for ``FormattingString`` and
     ``ParameterizingString`` for terminals that cannot perform styling.
     """
     def __new__(cls):
-        new = unicode.__new__(cls, u'')
+        new = text_type.__new__(cls, u'')
         return new
 
     def __call__(self, *args):

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -11,6 +11,7 @@ import functools
 import textwrap
 import warnings
 import math
+import sys
 import re
 
 # 3rd-party
@@ -19,6 +20,11 @@ import wcwidth  # https://github.com/jquast/wcwidth
 _BINTERM_UNSUPPORTED = ('kermit', 'avatar')
 _BINTERM_UNSUPPORTED_MSG = ('sequence-awareness for terminals emitting '
                             'binary-packed capabilities are not supported.')
+
+if sys.version_info[0] == 3:
+    text_type = str
+else:
+    text_type = unicode  # noqa
 
 
 def _merge_sequences(inp):
@@ -221,7 +227,7 @@ def get_wontmove_sequence_patterns(term):
         # ( not *exactly* legal, being extra forgiving. )
         bna(cap='sgr', nparams=_num) for _num in range(1, 10)
         # reset_{1,2,3}string: Reset string
-    ] + map(re.escape, (term.r1, term.r2, term.r3,)))
+    ] + list(map(re.escape, (term.r1, term.r2, term.r3,))))
 
 
 def init_sequence_patterns(term):
@@ -366,7 +372,7 @@ class SequenceTextWrapper(textwrap.TextWrapper):
 SequenceTextWrapper.__doc__ = textwrap.TextWrapper.__doc__
 
 
-class Sequence(unicode):
+class Sequence(text_type):
     """
     This unicode-derived class understands the effect of escape sequences
     of printable length, allowing a properly implemented .rjust(), .ljust(),
@@ -379,7 +385,7 @@ class Sequence(unicode):
         :arg sequence_text: A string containing sequences.
         :arg term: Terminal instance this string was created with.
         """
-        new = unicode.__new__(cls, sequence_text)
+        new = text_type.__new__(cls, sequence_text)
         new._term = term
         return new
 
@@ -518,7 +524,7 @@ class Sequence(unicode):
         """
         outp = u''
         nxt = 0
-        for idx in range(0, unicode.__len__(self)):
+        for idx in range(0, text_type.__len__(self)):
             width = horizontal_distance(self[idx:], self._term)
             if width != 0:
                 nxt = idx + measure_length(self[idx:], self._term)

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -44,20 +44,20 @@ except NameError:
     InterruptedError = select.error
 
 # local imports
-from formatters import (
+from .formatters import (
     ParameterizingString,
     NullCallableString,
     resolve_capability,
     resolve_attribute,
 )
 
-from sequences import (
+from .sequences import (
     init_sequence_patterns,
     SequenceTextWrapper,
     Sequence,
 )
 
-from keyboard import (
+from .keyboard import (
     get_keyboard_sequences,
     get_keyboard_codes,
     resolve_sequence,

--- a/blessed/tests/accessories.py
+++ b/blessed/tests/accessories.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Accessories for automated py.test runner."""
+# std
 from __future__ import with_statement
 import contextlib
 import functools
@@ -11,9 +12,16 @@ import sys
 import pty
 import os
 
+# local
 from blessed import Terminal
 
+# 3rd
 import pytest
+
+if sys.version_info[0] == 3:
+    text_type = str
+else:
+    text_type = unicode  # noqa
 
 TestTerminal = functools.partial(Terminal, kind='xterm-256color')
 SEND_SEMAPHORE = SEMAPHORE = b'SEMAPHORE\n'
@@ -78,7 +86,7 @@ class as_subprocess(object):
                     cov.save()
                 os._exit(0)
 
-        exc_output = unicode()
+        exc_output = text_type()
         decoder = codecs.getincrementaldecoder(self.encoding)()
         while True:
             try:
@@ -119,7 +127,7 @@ def read_until_semaphore(fd, semaphore=RECV_SEMAPHORE,
     # process will read xyz\\r\\n -- this is how pseudo terminals
     # behave; a virtual terminal requires both carriage return and
     # line feed, it is only for convenience that \\n does both.
-    outp = unicode()
+    outp = text_type()
     decoder = codecs.getincrementaldecoder(encoding)()
     semaphore = semaphore.decode('ascii')
     while not outp.startswith(semaphore):
@@ -139,7 +147,7 @@ def read_until_semaphore(fd, semaphore=RECV_SEMAPHORE,
 def read_until_eof(fd, encoding='utf8'):
     """Read file descriptor ``fd`` until EOF. Return decoded string."""
     decoder = codecs.getincrementaldecoder(encoding)()
-    outp = unicode()
+    outp = text_type()
     while True:
         try:
             _exc = os.read(fd, 100)

--- a/blessed/tests/test_core.py
+++ b/blessed/tests/test_core.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 "Core blessed Terminal() tests."
+
+# std
 try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
-
 import collections
 import warnings
 import platform
@@ -13,6 +14,7 @@ import sys
 import imp
 import os
 
+# local
 from accessories import (
     as_subprocess,
     TestTerminal,
@@ -20,6 +22,7 @@ from accessories import (
     all_terms
 )
 
+# 3rd party
 import mock
 import pytest
 

--- a/blessed/tests/test_keyboard.py
+++ b/blessed/tests/test_keyboard.py
@@ -2,7 +2,11 @@
 "Tests for keyboard support."
 import functools
 import tempfile
-import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    import io
+    StringIO = io.StringIO
 import signal
 import curses
 import time
@@ -26,6 +30,9 @@ from accessories import (
 )
 
 import mock
+
+if sys.version_info[0] == 3:
+    unichr = chr
 
 
 def test_kbhit_interrupted():
@@ -248,7 +255,7 @@ def test_kbhit_no_kb():
     "kbhit() always immediately returns False without a keyboard."
     @as_subprocess
     def child():
-        term = TestTerminal(stream=StringIO.StringIO())
+        term = TestTerminal(stream=StringIO())
         stime = time.time()
         assert term.keyboard_fd is None
         assert term.kbhit(timeout=1.1) is False
@@ -273,7 +280,7 @@ def test_inkey_0s_cbreak_noinput_nokb():
     "0-second inkey without data in input stream and no keyboard/tty."
     @as_subprocess
     def child():
-        term = TestTerminal(stream=StringIO.StringIO())
+        term = TestTerminal(stream=StringIO())
         with term.cbreak():
             stime = time.time()
             inp = term.inkey(timeout=0)
@@ -299,7 +306,7 @@ def test_inkey_1s_cbreak_noinput_nokb():
     "1-second inkey without input or keyboard."
     @as_subprocess
     def child():
-        term = TestTerminal(stream=StringIO.StringIO())
+        term = TestTerminal(stream=StringIO())
         with term.cbreak():
             stime = time.time()
             inp = term.inkey(timeout=1)
@@ -752,7 +759,7 @@ def test_get_keyboard_sequence(monkeypatch):
     term._cub1 = SEQ_ALT_CUB1.decode('latin1')
     keymap = blessed.keyboard.get_keyboard_sequences(term)
 
-    assert keymap.items() == [
+    assert list(keymap.items()) == [
         (SEQ_LARGE.decode('latin1'), KEY_LARGE),
         (SEQ_ALT_CUB1.decode('latin1'), curses.KEY_LEFT),
         (SEQ_ALT_CUF1.decode('latin1'), curses.KEY_RIGHT),

--- a/blessed/tests/test_sequences.py
+++ b/blessed/tests/test_sequences.py
@@ -59,7 +59,7 @@ def test_capability_with_forced_tty():
 
 
 def test_parametrization():
-    """Test parametrizing a capability."""
+    """Test parameterizing a capability."""
     @as_subprocess
     def child():
         assert TestTerminal().cup(3, 4) == unicode_parm('cup', 3, 4)

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,6 @@ def main():
     if sys.version_info < (2, 7,):
         extra['install_requires'].extend(['ordereddict>=1.1'])
 
-    elif sys.version_info >= (3,):
-        extra['use_2to3'] = True
-
     here = os.path.dirname(__file__)
     setuptools.setup(
         name='blessed',

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,9 @@ envlist = py26,
 [testenv]
 # for any python, run simple pytest
 # with pep8 and pyflake checking
+usedevelop = True
 deps = pytest
+       pytest-cov
        pytest-pep8
        pytest-flakes
        mock
@@ -21,50 +23,14 @@ setenv = PYTHONIOENCODING=UTF8
 # run each test twice -- 1. w/o tty
 commands = /bin/bash -c {envbindir}/py.test -v \
            -x --strict --pep8 --flakes \
+           --cov-report term-missing \
            blessed/tests {posargs} \
            < /dev/null 2>&1 | tee /dev/null
-# 2. w/tty
+#                     -- 2. w/tty
            {envbindir}/py.test -v \
            -x --strict --pep8 --flakes \
+           --cov-report term-missing \
            blessed/tests {posargs}
-
-[testenv:py27]
-# for python27, measure coverage
-usedevelop = True
-deps = pytest
-       pytest-cov
-       pytest-pep8
-       pytest-flakes
-       mock
-       -rrequirements.txt
-
-setenv = PYTHONIOENCODING=UTF8
-
-# run each test twice -- 1. w/o tty,
-commands = /bin/bash -c {envbindir}/py.test -v \
-               -x --strict --pep8 --flakes \
-               blessed/tests {posargs} \
-               < /dev/null 2>&1 | tee /dev/null
-# 2. w/tty, w/coverage
-           {envbindir}/py.test -v \
-                -x --strict --pep8 --flakes \
-                --cov-report term-missing \
-                --cov blessed {posargs}
-
-# for python3, test the version of blessed that is *installed*,
-# and not from source. This is because we use the 2to3 tool.
-#
-# some issue with py.test & python 3 does not allow non-tty testing.
-
-[testenv:py33]
-changedir = {toxworkdir}
-commands = {envbindir}/py.test -x --strict --pep8 --flakes \
-               {envsitepackagesdir}/blessed/tests {posargs}
-
-[testenv:py34]
-changedir = {toxworkdir}
-commands = {envbindir}/py.test -x --strict --pep8 --flakes \
-               {envsitepackagesdir}/blessed/tests {posargs}
 
 [pytest]
 # py.test fixtures conflict with pyflakes


### PR DESCRIPTION
blessed is now naturally native for both python 2
and python 3, removing the need to use the '2to3'
conversion utility or execute tests in a
round-about way for python 3.
