### PR TITLE
Fix prospector complains

### DIFF
--- a/blessed/formatters.py
+++ b/blessed/formatters.py
@@ -40,7 +40,6 @@ COMPOUNDABLES = _make_compoundables(COLORS)
 
 
 class ParameterizingString(six.text_type):
-
     r"""
     A Unicode string which can be called as a parameterizing termcap.
 
@@ -104,7 +103,6 @@ class ParameterizingString(six.text_type):
 
 
 class ParameterizingProxyString(six.text_type):
-
     r"""
     A Unicode string which can be called to proxy missing termcap entries.
 
@@ -203,7 +201,6 @@ def get_proxy_string(term, attr):
 
 
 class FormattingString(six.text_type):
-
     r"""
     A Unicode string which doubles as a callable.
 
@@ -240,7 +237,6 @@ class FormattingString(six.text_type):
 
 
 class NullCallableString(six.text_type):
-
     """
     A dummy callable Unicode alternative to :class:`FormattingString`.
 

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -18,7 +18,6 @@ except ImportError:
 
 
 class Keystroke(six.text_type):
-
     """
     A unicode-derived class for describing a single keystroke.
 

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -374,7 +374,6 @@ def init_sequence_patterns(term):
 
 
 class SequenceTextWrapper(textwrap.TextWrapper):
-
     """This docstring overridden."""
 
     def __init__(self, width, term, **kwargs):
@@ -488,7 +487,6 @@ SequenceTextWrapper.__doc__ = textwrap.TextWrapper.__doc__
 
 
 class Sequence(six.text_type):
-
     """
     A "sequence-aware" version of the base :class:`str` class.
 


### PR DESCRIPTION
When running `tox` prospector complains about severael D211 violations:

    pep257: D211 / No blank lines allowed before class docstring (found 1)