### PR TITLE
Allow nested FormattingString

### DIFF
--- a/blessed/tests/test_formatters.py
+++ b/blessed/tests/test_formatters.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 """Tests string formatting functions."""
+# std
 import curses
+
+# 3rd-party
 import mock
+import pytest
 
 
 def test_parameterizing_string_args_unspecified(monkeypatch):
@@ -70,7 +74,7 @@ def test_parameterizing_string_args(monkeypatch):
 
 
 def test_parameterizing_string_type_error(monkeypatch):
-    """Test formatters.ParameterizingString raising TypeError"""
+    """Test formatters.ParameterizingString raising TypeError."""
     from blessed.formatters import ParameterizingString
 
     def tparm_raises_TypeError(*args):
@@ -106,7 +110,7 @@ def test_parameterizing_string_type_error(monkeypatch):
 
 
 def test_formattingstring(monkeypatch):
-    """Test formatters.FormattingString"""
+    """Test simple __call__ behavior of formatters.FormattingString."""
     from blessed.formatters import FormattingString
 
     # given, with arg
@@ -117,9 +121,39 @@ def test_formattingstring(monkeypatch):
     assert str(pstr) == u'attr'
     assert pstr('text') == u'attrtextnorm'
 
-    # given, without arg
+    # given, with empty attribute
     pstr = FormattingString(u'', u'norm')
     assert pstr('text') == u'text'
+
+
+def test_nested_formattingstring(monkeypatch):
+    """Test nested __call__ behavior of formatters.FormattingString."""
+    from blessed.formatters import FormattingString
+
+    # given, with arg
+    pstr = FormattingString(u'a1-', u'n-')
+    zstr = FormattingString(u'a2-', u'n-')
+
+    # exercise __call__
+    assert pstr('x-', zstr('f-'), 'q-') == 'a1-x-a2-f-n-a1-q-n-'
+
+
+def test_nested_formattingstring_type_error(monkeypatch):
+    """Test formatters.FormattingString raising TypeError."""
+    from blessed.formatters import FormattingString
+
+    # given,
+    pstr = FormattingString(u'a-', u'n-')
+    expected_msg = (
+        "Positional argument #1 is {0} expected any of "
+        .format(type(1)))
+
+    # exercise,
+    with pytest.raises(TypeError) as err:
+        pstr('text', 1, '...')
+
+    # verify,
+    assert expected_msg in '{0}'.format(err)
 
 
 def test_nullcallablestring(monkeypatch):
@@ -129,11 +163,10 @@ def test_nullcallablestring(monkeypatch):
     # given, with arg
     pstr = NullCallableString()
 
-    # excersize __call__,
+    # exercise __call__,
     assert str(pstr) == u''
     assert pstr('text') == u'text'
-    assert pstr('text', 1) == u''
-    assert pstr('text', 'moretext') == u''
+    assert pstr('text', 'moretext') == u'textmoretext'
     assert pstr(99, 1) == u''
     assert pstr() == u''
     assert pstr(0) == u''

--- a/blessed/tests/test_sequences.py
+++ b/blessed/tests/test_sequences.py
@@ -441,6 +441,33 @@ def test_compound_formatting(all_terms):
     child(all_terms)
 
 
+def test_nested_formatting(all_terms):
+    """Test complex nested compound formatting, wow!"""
+    @as_subprocess
+    def child(kind):
+        t = TestTerminal(kind=kind)
+
+        # Test deeply nested styles
+        given = t.green('-a-', t.bold('-b-', t.underline('-c-'),
+                                      '-d-'),
+                        '-e-')
+        expected = u''.join((
+            t.green, '-a-', t.bold, '-b-', t.underline, '-c-', t.normal,
+            t.green, t.bold, '-d-',
+            t.normal, t.green, '-e-', t.normal))
+        assert given == expected
+
+        # Test off-and-on nested styles
+        given = t.green('off ', t.underline('ON'),
+                        ' off ', t.underline('ON'),
+                        ' off')
+        expected = u''.join((
+            t.green, 'off ', t.underline, 'ON',
+            t.normal, t.green , ' off ', t.underline, 'ON',
+            t.normal, t.green, ' off', t.normal))
+        assert given == expected
+
+
 def test_formatting_functions_without_tty(all_terms):
     """Test crazy-ass formatting wrappers when there's no tty."""
     @as_subprocess
@@ -451,6 +478,20 @@ def test_formatting_functions_without_tty(all_terms):
         # Test non-ASCII chars, no longer really necessary:
         assert (t.bold_green(u'boö') == u'boö')
         assert (t.bold_underline_green_on_red('loo') == u'loo')
+
+        # Test deeply nested styles
+        given = t.green('-a-', t.bold('-b-', t.underline('-c-'),
+                                      '-d-'),
+                        '-e-')
+        expected = u'-a--b--c--d--e-'
+        assert given == expected
+
+        # Test off-and-on nested styles
+        given = t.green('off ', t.underline('ON'),
+                        ' off ', t.underline('ON'),
+                        ' off')
+        expected = u'off ON off ON off'
+        assert given == expected
         assert (t.on_bright_red_bold_bright_green_underline('meh') == u'meh')
 
     child(all_terms)
@@ -502,9 +543,7 @@ def test_null_callable_string(all_terms):
         assert (t.move(1 == 2) == '')
         assert (t.move_x(1) == '')
         assert (t.bold() == '')
-        assert (t.bold('', 'x', 'huh?') == '')
-        assert (t.bold('', 9876) == '')
-        assert (t.uhh(9876) == '')
+        assert (t.bold('', 'x', 'huh?') == 'xhuh?')
         assert (t.clear('x') == 'x')
 
     child(all_terms)


### PR DESCRIPTION
@jimallman  brings us this convenience of allowing existing unicode strings to be joined as a call parameter to a formatting string result, allowing nestation:
```
>>> t.red('This is ', t.bold('extremely'), ' dangerous!')
```

This was rejected upstream as https://github.com/erikrose/blessings/pull/45 His words,

```python
# creates a red phrase with some bold words in the middle:
t.red('This is ', t.bold('extremely important'), ' information!')

# deeper nesting of styles (green, then bold, then underline, and back out)
t.green('foo', t.bold('bar', t.underline('baz'), 'herp'), 'derp')
```