### PR TITLE
tox.ini: Use pytest -- -x unless -- is specified

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ skip_missing_interpreters = true
 
 [testenv]
 whitelist_externals = cp
-                      echo
 setenv = PYTHONIOENCODING=UTF8
 passenv = TEST_QUICK TEST_FULL
 deps = -rrequirements-tests.txt
@@ -12,7 +11,7 @@ commands = {envbindir}/py.test \
                --strict --verbose --verbose --color=yes \
                --junit-xml=results.{envname}.xml \
                --cov blessed blessed/tests \
-               {posargs}
+               {posargs:-x}
            coverage combine
            cp {toxinidir}/.coverage \
                {toxinidir}/._coverage.{envname}.{env:TEAMCITY_BUILDCONFNAME:xxx}


### PR DESCRIPTION
fork() is dangerous, the test runner forks quite often
under dangerous circumstances -- our CI agents need to
stop immediately by default with basic arguments. For
developers who wish to see all errors, they may simply
run::

    tox -epy27,py34 --