### PR TITLE
Various docfix

### DIFF
--- a/blessed/formatters.py
+++ b/blessed/formatters.py
@@ -23,7 +23,7 @@ def _make_compoundables(colors):
     """
     Return given set ``colors`` along with all "compoundable" attributes.
 
-    :param set colors: set of color names as string.
+    :arg set colors: set of color names as string.
     :rtype: set
     """
     _compoundables = set('bold underline reverse blink dim italic shadow '
@@ -163,8 +163,8 @@ def get_proxy_string(term, attr):
     """
     Proxy and return callable string for proxied attributes.
 
-    :param Terminal term: :class:`~.Terminal` instance.
-    :param str attr: terminal capability name that may be proxied.
+    :arg Terminal term: :class:`~.Terminal` instance.
+    :arg str attr: terminal capability name that may be proxied.
     :rtype: None or :class:`ParameterizingProxyString`.
     :returns: :class:`ParameterizingProxyString` for some attributes
         of some terminal types that support it, where the terminfo(5)
@@ -312,8 +312,8 @@ def split_compound(compound):
     >>> split_compound('bold_underline_bright_blue_on_red')
     ['bold', 'underline', 'bright_blue', 'on_red']
 
-    :param str compound: a string that may contain compounds,
-       separated by underline (``_``).
+    :arg str compound: a string that may contain compounds, separated by
+        underline (``_``).
     :rtype: list
     """
     merged_segs = []
@@ -331,8 +331,8 @@ def resolve_capability(term, attr):
     """
     Resolve a raw terminal capability using :func:`tigetstr`.
 
-    :param Terminal term: :class:`~.Terminal` instance.
-    :param str attr: terminal capability name.
+    :arg Terminal term: :class:`~.Terminal` instance.
+    :arg str attr: terminal capability name.
     :returns: string of the given terminal capability named by ``attr``,
        which may be empty (u'') if not found or not supported by the
        given :attr:`~.Terminal.kind`.
@@ -352,8 +352,8 @@ def resolve_color(term, color):
 
     This function supports :func:`resolve_attribute`.
 
-    :param Terminal term: :class:`~.Terminal` instance.
-    :param str color: any string found in set :const:`COLORS`.
+    :arg Terminal term: :class:`~.Terminal` instance.
+    :arg str color: any string found in set :const:`COLORS`.
     :returns: a string class instance which emits the terminal sequence
         for the given color, and may be used as a callable to wrap the
         given string with such sequence.
@@ -387,8 +387,8 @@ def resolve_attribute(term, attr):
     """
     Resolve a terminal attribute name into a capability class.
 
-    :param Terminal term: :class:`~.Terminal` instance.
-    :param str attr: Sugary, ordinary, or compound formatted terminal
+    :arg Terminal term: :class:`~.Terminal` instance.
+    :arg str attr: Sugary, ordinary, or compound formatted terminal
         capability, such as "red_on_white", "normal", "red", or
         "bold_on_black", respectively.
     :returns: a string class instance which emits the terminal sequence

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -120,7 +120,7 @@ def _alternative_left_right(term):
     r"""
     Determine and return mapping of left and right arrow keys sequences.
 
-    :param blessed.Terminal term: :class:`~.Terminal` instance.
+    :arg blessed.Terminal term: :class:`~.Terminal` instance.
     :rtype: dict
 
     This function supports :func:`get_terminal_sequences` to discover
@@ -144,7 +144,7 @@ def get_keyboard_sequences(term):
     r"""
     Return mapping of keyboard sequences paired by keycodes.
 
-    :param blessed.Terminal term: :class:`~.Terminal` instance.
+    :arg blessed.Terminal term: :class:`~.Terminal` instance.
     :returns: mapping of keyboard unicode sequences paired by keycodes
         as integer.  This is used as the argument ``mapper`` to
         the supporting function :func:`resolve_sequence`.
@@ -194,7 +194,7 @@ def get_leading_prefixes(sequences):
     """
     Return a set of proper prefixes for given sequence of strings.
 
-    :param iterable sequences
+    :arg iterable sequences
     :rtype: set
 
     Given an iterable of strings, all textparts leading up to the final
@@ -217,10 +217,10 @@ def resolve_sequence(text, mapper, codes):
     :attr:`Keystroke.sequence` valued only ``u\x1b[D``.  It is up to
     determine that ``xxx`` remains unresolved.
 
-    :param text: string of characters received from terminal input stream.
-    :param OrderedDict mapper: an OrderedDict of unicode multibyte sequences,
+    :arg text: string of characters received from terminal input stream.
+    :arg OrderedDict mapper: an OrderedDict of unicode multibyte sequences,
         such as u'\x1b[D' paired by their integer value (260)
-    :param dict codes: a :type:`dict` of integer values (such as 260) paired
+    :arg dict codes: a :type:`dict` of integer values (such as 260) paired
         by their mnemonic name, such as ``'KEY_LEFT'``.
     :rtype: Keystroke
     """

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -22,7 +22,7 @@ def _sort_sequences(regex_seqlist):
     """
     Sort, filter, and return ``regex_seqlist`` in ascending order of length.
 
-    :param list regex_seqlist: list of strings.
+    :arg list regex_seqlist: list of strings.
     :rtype: list
     :returns: given list filtered and sorted.
 
@@ -54,10 +54,10 @@ def _build_numeric_capability(term, cap, optional=False,
     by regular expression pattern ``\d``.  Any other digits found are
     *not* replaced.
 
-    :param blessed.Terminal term: :class:`~.Terminal` instance.
-    :param str cap: terminal capability name.
-    :param int num: the numeric to use for parameterized capability.
-    :param int nparams: the number of parameters to use for capability.
+    :arg blessed.Terminal term: :class:`~.Terminal` instance.
+    :arg str cap: terminal capability name.
+    :arg int num: the numeric to use for parameterized capability.
+    :arg int nparams: the number of parameters to use for capability.
     :rtype: str
     :returns: regular expression for the given capability.
     """
@@ -80,10 +80,10 @@ def _build_any_numeric_capability(term, cap, num=99, nparams=1):
     r"""
     Return regular expression for capabilities containing any numerics.
 
-    :param blessed.Terminal term: :class:`~.Terminal` instance.
-    :param str cap: terminal capability name.
-    :param int num: the numeric to use for parameterized capability.
-    :param int nparams: the number of parameters to use for capability.
+    :arg blessed.Terminal term: :class:`~.Terminal` instance.
+    :arg str cap: terminal capability name.
+    :arg int num: the numeric to use for parameterized capability.
+    :arg int nparams: the number of parameters to use for capability.
     :rtype: str
     :returns: regular expression for the given capability.
 
@@ -104,7 +104,7 @@ def get_movement_sequence_patterns(term):
     """
     Get list of regular expressions for sequences that cause movement.
 
-    :param blessed.Terminal term: :class:`~.Terminal` instance.
+    :arg blessed.Terminal term: :class:`~.Terminal` instance.
     :rtype: list
     """
     bnc = functools.partial(_build_numeric_capability, term)
@@ -148,7 +148,7 @@ def get_wontmove_sequence_patterns(term):
     """
     Get list of regular expressions for sequences not causing movement.
 
-    :param blessed.Terminal term: :class:`~.Terminal` instance.
+    :arg blessed.Terminal term: :class:`~.Terminal` instance.
     :rtype: list
     """
     bnc = functools.partial(_build_numeric_capability, term)
@@ -278,7 +278,7 @@ def init_sequence_patterns(term):
     returns a dictionary database of regular expressions, which is
     re-attached to the terminal by attributes of the same key-name.
 
-    :param blessed.Terminal term: :class:`~.Terminal` instance.
+    :arg blessed.Terminal term: :class:`~.Terminal` instance.
     :rtype: dict
     :returns: dictionary containing mappings of sequence "groups",
         containing a compiled regular expression which it matches:
@@ -499,8 +499,8 @@ class Sequence(six.text_type):
         """
         Class constructor.
 
-        :param sequence_text: A string that may contain sequences.
-        :param blessed.Terminal term: :class:`~.Terminal` instance.
+        :arg sequence_text: A string that may contain sequences.
+        :arg blessed.Terminal term: :class:`~.Terminal` instance.
         """
         new = six.text_type.__new__(cls, sequence_text)
         new._term = term
@@ -510,9 +510,9 @@ class Sequence(six.text_type):
         """
         Return string containing sequences, left-adjusted.
 
-        :param int width: Total width given to right-adjust ``text``.  If
+        :arg int width: Total width given to right-adjust ``text``.  If
             unspecified, the width of the attached terminal is used (default).
-        :param str fillchar: String for padding right-of ``text``.
+        :arg str fillchar: String for padding right-of ``text``.
         :returns: String of ``text``, right-aligned by ``width``.
         :rtype: str
         """
@@ -524,9 +524,9 @@ class Sequence(six.text_type):
         """
         Return string containing sequences, right-adjusted.
 
-        :param int width: Total width given to right-adjust ``text``.  If
+        :arg int width: Total width given to right-adjust ``text``.  If
             unspecified, the width of the attached terminal is used (default).
-        :param str fillchar: String for padding left-of ``text``.
+        :arg str fillchar: String for padding left-of ``text``.
         :returns: String of ``text``, right-aligned by ``width``.
         :rtype: str
         """
@@ -538,9 +538,9 @@ class Sequence(six.text_type):
         """
         Return string containing sequences, centered.
 
-        :param int width: Total width given to center ``text``.  If
+        :arg int width: Total width given to center ``text``.  If
             unspecified, the width of the attached terminal is used (default).
-        :param str fillchar: String for padding left and right-of ``text``.
+        :arg str fillchar: String for padding left and right-of ``text``.
         :returns: String of ``text``, centered by ``width``.
         :rtype: str
         """
@@ -589,7 +589,7 @@ class Sequence(six.text_type):
         """
         Return string of sequences, leading, and trailing whitespace removed.
 
-        :param str chars: Remove characters in chars instead of whitespace.
+        :arg str chars: Remove characters in chars instead of whitespace.
         :rtype: str
         """
         return self.strip_seqs().strip(chars)
@@ -598,7 +598,7 @@ class Sequence(six.text_type):
         """
         Return string of all sequences and leading whitespace removed.
 
-        :param str chars: Remove characters in chars instead of whitespace.
+        :arg str chars: Remove characters in chars instead of whitespace.
         :rtype: str
         """
         return self.strip_seqs().lstrip(chars)
@@ -607,7 +607,7 @@ class Sequence(six.text_type):
         """
         Return string of all sequences and trailing whitespace removed.
 
-        :param str chars: Remove characters in chars instead of whitespace.
+        :arg str chars: Remove characters in chars instead of whitespace.
         :rtype: str
         """
         return self.strip_seqs().rstrip(chars)
@@ -689,8 +689,8 @@ def measure_length(ucs, term):
     r"""
     Return non-zero for string ``ucs`` that begins with a terminal sequence.
 
-    :param str ucs: String that may begin with a terminal sequence.
-    :param blessed.Terminal term: :class:`~.Terminal` instance.
+    :arg str ucs: String that may begin with a terminal sequence.
+    :arg blessed.Terminal term: :class:`~.Terminal` instance.
     :rtype: int
     :returns: length of the sequence beginning at ``ucs``, if any.
         Otherwise 0 if ``ucs`` does not begin with a terminal
@@ -737,11 +737,11 @@ def termcap_distance(ucs, cap, unit, term):
     r"""
     Return distance of capabilities ``cub``, ``cub1``, ``cuf``, and ``cuf1``.
 
-    :param str ucs: Terminal sequence created using any of ``cub(n)``,
-        ``cub1``, ``cuf(n)``, or ``cuf1``.
-    :param str cap: ``cub`` or ``cuf`` only.
-    :param int unit: Unit multiplier, should always be ``1`` or ``-1``.
-    :param blessed.Terminal term: :class:`~.Terminal` instance.
+    :arg str ucs: Terminal sequence created using any of ``cub(n)``, ``cub1``,
+        ``cuf(n)``, or ``cuf1``.
+    :arg str cap: ``cub`` or ``cuf`` only.
+    :arg int unit: Unit multiplier, should always be ``1`` or ``-1``.
+    :arg blessed.Terminal term: :class:`~.Terminal` instance.
     :rtype: int
     :returns: the printable distance determined by the given sequence.  If
         the given sequence does not match any of the ``cub`` or ``cuf``
@@ -780,14 +780,14 @@ def horizontal_distance(ucs, term):
     r"""
     Determine the horizontal distance of single terminal sequence, ``ucs``.
 
-    :param ucs: terminal sequence, which may be any of the following:
+    :arg ucs: terminal sequence, which may be any of the following:
 
         - move_right (fe. ``<ESC>[<n>C``): returns value ``(n)``.
         - move left (fe. ``<ESC>[<n>D``): returns value ``-(n)``.
         - backspace (``\b``) returns value -1.
         - tab (``\t``) returns value 8.
 
-    :param blessed.Terminal term: :class:`~.Terminal` instance.
+    :arg blessed.Terminal term: :class:`~.Terminal` instance.
     :rtype: int
 
     .. note:: Tabstop (``\t``) cannot be correctly calculated, as the relative

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -109,25 +109,24 @@ class Terminal(object):
         """
         Initialize the terminal.
 
-        :param str kind: A terminal string as taken by
-            :func:`curses.setupterm`. Defaults to the value of the ``TERM``
-            environment variable.
+        :arg str kind: A terminal string as taken by :func:`curses.setupterm`.
+            Defaults to the value of the ``TERM`` environment variable.
 
             .. note:: Terminals withing a single process must share a common
                 ``kind``. See :obj:`_CUR_TERM`.
 
-        :param file stream: A file-like object representing the Terminal
-            output. Defaults to the original value of :obj:`sys.__stdout__`,
-            like :func:`curses.initscr` does.
+        :arg file stream: A file-like object representing the Terminal output.
+            Defaults to the original value of :obj:`sys.__stdout__`, like
+            :func:`curses.initscr` does.
 
             If ``stream`` is not a tty, empty Unicode strings are returned for
             all capability values, so things like piping your program output to
             a pipe or file does not emit terminal sequences.
 
-        :param bool force_styling: Whether to force the emission of
-            capabilities even if :obj:`sys.__stdout__` does not seem to be
-            connected to a terminal. If you want to force styling to not
-            happen, use ``force_styling=None``.
+        :arg bool force_styling: Whether to force the emission of capabilities
+            even if :obj:`sys.__stdout__` does not seem to be connected to a
+            terminal. If you want to force styling to not happen, use
+            ``force_styling=None``.
 
             This comes in handy if users are trying to pipe your output through
             something like ``less -r`` or build systems which support decoding
@@ -253,7 +252,8 @@ class Terminal(object):
         if not self.does_styling:
             return NullCallableString()
         val = resolve_attribute(self, attr)
-        # Cache capability codes.
+        # Cache capability resolution: note this will prevent this
+        # __getattr__ method for being called again.  That's the idea!
         setattr(self, attr, val)
         return val
 
@@ -311,7 +311,7 @@ class Terminal(object):
         :mod:`fcntl`, or :mod:`tty`, window size of 80 columns by 25
         rows is always returned.
 
-        :param int fd: file descriptor queries for its window size.
+        :arg int fd: file descriptor queries for its window size.
         :raises IOError: the file descriptor ``fd`` is not a terminal.
         :rtype: WINSZ
 

--- a/blessed/tests/test_formatters.py
+++ b/blessed/tests/test_formatters.py
@@ -22,18 +22,18 @@ def test_parameterizing_string_args_unspecified(monkeypatch):
     # given,
     pstr = ParameterizingString(u'')
 
-    # excersize __new__
+    # exercise __new__
     assert str(pstr) == u''
     assert pstr._normal == u''
     assert pstr._name == u'<not specified>'
 
-    # excersize __call__
+    # exercise __call__
     zero = pstr(0)
     assert type(zero) is FormattingString
     assert zero == u'~0'
     assert zero('text') == u'~0text'
 
-    # excersize __call__ with multiple args
+    # exercise __call__ with multiple args
     onetwo = pstr(1, 2)
     assert type(onetwo) is FormattingString
     assert onetwo == u'~1~2'
@@ -55,18 +55,18 @@ def test_parameterizing_string_args(monkeypatch):
     # given,
     pstr = ParameterizingString(u'cap', u'norm', u'seq-name')
 
-    # excersize __new__
+    # exercise __new__
     assert str(pstr) == u'cap'
     assert pstr._normal == u'norm'
     assert pstr._name == u'seq-name'
 
-    # excersize __call__
+    # exercise __call__
     zero = pstr(0)
     assert type(zero) is FormattingString
     assert zero == u'cap~0'
     assert zero('text') == u'cap~0textnorm'
 
-    # excersize __call__ with multiple args
+    # exercise __call__ with multiple args
     onetwo = pstr(1, 2)
     assert type(onetwo) is FormattingString
     assert onetwo == u'cap~1~2'
@@ -116,7 +116,7 @@ def test_formattingstring(monkeypatch):
     # given, with arg
     pstr = FormattingString(u'attr', u'norm')
 
-    # excersize __call__,
+    # exercise __call__,
     assert pstr._normal == u'norm'
     assert str(pstr) == u'attr'
     assert pstr('text') == u'attrtextnorm'
@@ -193,7 +193,7 @@ def test_resolve_capability(monkeypatch):
     term = mock.Mock()
     term._sugar = dict(mnemonic='xyz')
 
-    # excersize
+    # exercise
     assert resolve_capability(term, 'mnemonic') == u'seq-xyz'
     assert resolve_capability(term, 'natural') == u'seq-natural'
 
@@ -201,7 +201,7 @@ def test_resolve_capability(monkeypatch):
     tigetstr_none = lambda attr: None
     monkeypatch.setattr(curses, 'tigetstr', tigetstr_none)
 
-    # excersize,
+    # exercise,
     assert resolve_capability(term, 'natural') == u''
 
     # given, where does_styling is False
@@ -210,7 +210,7 @@ def test_resolve_capability(monkeypatch):
     term.does_styling = False
     monkeypatch.setattr(curses, 'tigetstr', raises_exception)
 
-    # excersize,
+    # exercise,
     assert resolve_capability(term, 'natural') == u''
 
 
@@ -230,13 +230,13 @@ def test_resolve_color(monkeypatch):
     term.number_of_colors = -1
     term.normal = 'seq-normal'
 
-    # excersize,
+    # exercise,
     red = resolve_color(term, 'red')
     assert type(red) == FormattingString
     assert red == u'seq-1984'
     assert red('text') == u'seq-1984textseq-normal'
 
-    # excersize bold, +8
+    # exercise bold, +8
     bright_red = resolve_color(term, 'bright_red')
     assert type(bright_red) == FormattingString
     assert bright_red == u'seq-1992'
@@ -245,13 +245,13 @@ def test_resolve_color(monkeypatch):
     # given, terminal without color
     term.number_of_colors = 0
 
-    # excersize,
+    # exercise,
     red = resolve_color(term, 'red')
     assert type(red) == NullCallableString
     assert red == u''
     assert red('text') == u'text'
 
-    # excesize bold,
+    # exercise bold,
     bright_red = resolve_color(term, 'bright_red')
     assert type(bright_red) == NullCallableString
     assert bright_red == u''
@@ -349,7 +349,7 @@ def test_resolve_attribute_recursive_compoundables(monkeypatch):
     # given,
     pstr = resolve_attribute(term, 'bright_blue_on_red')
 
-    # excersize,
+    # exercise,
     assert type(pstr) == FormattingString
     assert str(pstr) == 'seq-6808seq-6502'
     assert pstr('text') == 'seq-6808seq-6502textseq-normal'
@@ -378,13 +378,13 @@ def test_pickled_parameterizing_string(monkeypatch):
     # multiprocessing Pipe implicitly pickles.
     r, w = Pipe()
 
-    # excersize picklability of ParameterizingString
+    # exercise picklability of ParameterizingString
     for proto_num in range(pickle.HIGHEST_PROTOCOL):
         assert pstr == pickle.loads(pickle.dumps(pstr, protocol=proto_num))
     w.send(pstr)
     r.recv() == pstr
 
-    # excersize picklability of FormattingString
+    # exercise picklability of FormattingString
     # -- the return value of calling ParameterizingString
     zero = pstr(0)
     for proto_num in range(pickle.HIGHEST_PROTOCOL):

--- a/blessed/tests/test_sequences.py
+++ b/blessed/tests/test_sequences.py
@@ -115,10 +115,13 @@ def test_emit_warnings_about_binpacked():
     # that cause false negatives, because their underlying curses library emits
     # some kind of "warning" to stderr, which our @as_subprocess decorator
     # determines to be noteworthy enough to fail the test:
+    #
     #     https://gist.github.com/jquast/7b90af251fe4000baa09
     #
-    # so we chose only one of beautiful lineage:
+    # so we chose only one, known good value, of beautiful lineage:
+    #
     #    http://terminals.classiccmp.org/wiki/index.php/Tektronix_4207
+
     child(kind='tek4207-s')
 
 
@@ -560,7 +563,7 @@ def test_bnc_parameter_emits_warning():
     fake_cap = lambda *args: u'NO-DIGIT'
     term.fake_cap = fake_cap
 
-    # excersize,
+    # exercise,
     try:
         _build_numeric_capability(term, 'fake_cap', base_num=1984)
     except UserWarning:
@@ -582,7 +585,7 @@ def test_bna_parameter_emits_warning():
     fake_cap = lambda *args: 'NO-DIGIT'
     term.fake_cap = fake_cap
 
-    # excersize,
+    # exercise,
     try:
         _build_any_numeric_capability(term, 'fake_cap')
     except UserWarning:


### PR DESCRIPTION
- sphinx nit: prefer ':arg' over ':param', creates briefer phrases and joins a few phrases
reducing LOC
- spellfix comment excersize -> exercise