### PR TITLE
change docstring param name to name used in code

### DIFF
--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -56,7 +56,7 @@ def _build_numeric_capability(term, cap, optional=False,
 
     :arg blessed.Terminal term: :class:`~.Terminal` instance.
     :arg str cap: terminal capability name.
-    :arg int num: the numeric to use for parameterized capability.
+    :arg int base_num: the numeric to use for parameterized capability.
     :arg int nparams: the number of parameters to use for capability.
     :rtype: str
     :returns: regular expression for the given capability.


### PR DESCRIPTION
Wasn't sure which way to change it, I made the docs match the code.