### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -45,7 +45,10 @@ pep257:
         - 'D203'
         # 1 blank line required after class docstring
         - 'D204'
-
+        # Multi-line docstring summary should start at the first line
+        - 'D212'
+        # First line should be in imperative mood
+        - 'D401'
 
 pep8:
     # style checking

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,11 @@ matrix:
     - python: 3.4
       env: TOXENV=py34 TEST_QUICK=1 COVERAGE_ID=travis-ci
     - python: 3.5
-      env: TOXENV=py35 COVERAGE_ID=travis-ci
+      env: TOXENV=py35 TEST_QUICK=1 COVERAGE_ID=travis-ci
+    - python: 3.6
+      env: TOXENV=py36 COVERAGE_ID=travis-ci
+    - python: 3.7-dev
+      env: TOXENV=py37 COVERAGE_ID=travis-ci
 install:
   - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
       env: TOXENV=py36 COVERAGE_ID=travis-ci
     - python: 3.7-dev
       env: TOXENV=py37 COVERAGE_ID=travis-ci
+before_install:
+    # work around https://github.com/travis-ci/travis-ci/issues/8363
+    - pyenv global system 3.6
 install:
   - pip install tox
 script:

--- a/bin/display-maxcanon.py
+++ b/bin/display-maxcanon.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-This tool uses pexpect to test expected Canonical mode length.
+A tool which uses pexpect to test expected Canonical mode length.
 
 All systems use the value of MAX_CANON which can be found using
 fpathconf(3) value PC_MAX_CANON -- with the exception of Linux

--- a/bin/editor.py
+++ b/bin/editor.py
@@ -81,9 +81,9 @@ def readline(term, width=20):
             text = text[:-1]
             # https://utcc.utoronto.ca/~cks/space/blog/unix/HowUnixBackspaces
             #
-            # "When you hit backspace, the kernel tty line discipline rubs out your previous
-            #  character by printing (in the simple case) Ctrl-H, a space, and then another
-            #  Ctrl-H."
+            # "When you hit backspace, the kernel tty line discipline rubs out
+            # your previous character by printing (in the simple case)
+            # Ctrl-H, a space, and then another Ctrl-H."
             echo(u'\b \b')
     return text
 

--- a/bin/on_resize.py
+++ b/bin/on_resize.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-This is an example application for the 'blessed' Terminal library for python.
+Example application for the 'blessed' Terminal library for python.
 
 Window size changes are caught by the 'on_resize' function using a traditional
 signal handler.  Meanwhile, blocking keyboard input is displayed to stdout.

--- a/bin/progress_bar.py
+++ b/bin/progress_bar.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-This is an example application for the 'blessed' Terminal library for python.
+Example application for the 'blessed' Terminal library for python.
 
 This isn't a real progress bar, just a sample "animated prompt" of sorts
 that demonstrates the separate move_x() and move_y() functions, made

--- a/bin/worms.py
+++ b/bin/worms.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-This is an example application for the 'blessed' Terminal library for python.
+Example application for the 'blessed' Terminal library for python.
 
 It is also an experiment in functional programming.
 """
@@ -25,7 +25,7 @@ except TypeError:
     import sys
 
     def echo(text):
-        """python 2 version of print(end='', flush=True)."""
+        """Python 2 version of print(end='', flush=True)."""
         sys.stdout.write(u'{0}'.format(text))
         sys.stdout.flush()
 

--- a/blessed/formatters.py
+++ b/blessed/formatters.py
@@ -1,4 +1,4 @@
-"""This sub-module provides sequence-formatting functions."""
+"""Sub-module providing sequence-formatting functions."""
 # standard imports
 import curses
 
@@ -59,10 +59,10 @@ class ParameterizingString(six.text_type):
         :arg normal: terminating sequence for this capability (optional).
         :arg name: name of this terminal capability (optional).
         """
-        assert len(args) and len(args) < 4, args
+        assert args and len(args) < 4, args
         new = six.text_type.__new__(cls, args[0])
-        new._normal = len(args) > 1 and args[1] or u''
-        new._name = len(args) > 2 and args[2] or u'<not specified>'
+        new._normal = args[1] if len(args) > 1 else u''
+        new._name = args[2] if len(args) > 2 else u'<not specified>'
         return new
 
     def __call__(self, *args):
@@ -84,7 +84,7 @@ class ParameterizingString(six.text_type):
         except TypeError as err:
             # If the first non-int (i.e. incorrect) arg was a string, suggest
             # something intelligent:
-            if len(args) and isinstance(args[0], six.string_types):
+            if args and isinstance(args[0], six.string_types):
                 raise TypeError(
                     "A native or nonexistent capability template, %r received"
                     " invalid argument %r: %s. You probably misspelled a"
@@ -135,13 +135,13 @@ class ParameterizingProxyString(six.text_type):
         :arg normal: terminating sequence for this capability (optional).
         :arg name: name of this terminal capability (optional).
         """
-        assert len(args) and len(args) < 4, args
+        assert args and len(args) < 4, args
         assert isinstance(args[0], tuple), args[0]
         assert callable(args[0][1]), args[0][1]
         new = six.text_type.__new__(cls, args[0][0])
         new._fmt_args = args[0][1]
-        new._normal = len(args) > 1 and args[1] or u''
-        new._name = len(args) > 2 and args[2] or u'<not specified>'
+        new._normal = args[1] if len(args) > 1 else u''
+        new._name = args[2] if len(args) > 2 else u'<not specified>'
         return new
 
     def __call__(self, *args):
@@ -226,7 +226,7 @@ class FormattingString(six.text_type):
         """
         assert 1 <= len(args) <= 2, args
         new = six.text_type.__new__(cls, args[0])
-        new._normal = len(args) > 1 and args[1] or u''
+        new._normal = args[1] if len(args) > 1 else u''
         return new
 
     def __call__(self, *args):
@@ -246,7 +246,7 @@ class FormattingString(six.text_type):
                                     expected_types=six.string_types,
                                 ))
         postfix = u''
-        if len(self) and self._normal:
+        if self and self._normal:
             postfix = self._normal
             _refresh = self._normal + self
             args = [_refresh.join(ucs_part.split(self._normal))
@@ -281,7 +281,7 @@ class NullCallableString(six.text_type):
         the first arg, acting in place of :class:`FormattingString` without
         any attributes.
         """
-        if len(args) == 0 or isinstance(args[0], int):
+        if not args or isinstance(args[0], int):
             # As a NullCallableString, even when provided with a parameter,
             # such as t.color(5), we must also still be callable, fe:
             #

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -1,4 +1,4 @@
-"""This sub-module provides 'keyboard awareness'."""
+"""Sub-module providing 'keyboard awareness'."""
 
 # std imports
 import curses.has_key
@@ -52,8 +52,7 @@ class Keystroke(six.text_type):
 
     def __repr__(self):
         """Docstring overwritten."""
-        return (self._name is None and
-                six.text_type.__repr__(self) or
+        return (six.text_type.__repr__(self) if self._name is None else
                 self._name)
     __repr__.__doc__ = six.text_type.__doc__
 
@@ -246,10 +245,7 @@ def _time_left(stime, timeout):
     :returns: time remaining as float. If no time is remaining,
        then the integer ``0`` is returned.
     """
-    if timeout is not None:
-        if timeout == 0:
-            return 0
-        return max(0, timeout - (time.time() - stime))
+    return max(0, timeout - (time.time() - stime)) if timeout else timeout
 
 
 def _read_until(term, pattern, timeout):

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-"""This module provides 'sequence awareness'."""
+"""Module providing 'sequence awareness'."""
 # std imports
 import functools
 import textwrap
@@ -136,7 +136,7 @@ class Termcap(object):
 
 
 class SequenceTextWrapper(textwrap.TextWrapper):
-    """This docstring overridden."""
+    """Docstring overridden."""
 
     def __init__(self, width, term, **kwargs):
         """
@@ -195,7 +195,8 @@ class SequenceTextWrapper(textwrap.TextWrapper):
         return lines
 
     def _handle_long_word(self, reversed_chunks, cur_line, cur_len, width):
-        """Sequence-aware :meth:`textwrap.TextWrapper._handle_long_word`.
+        """
+        Sequence-aware :meth:`textwrap.TextWrapper._handle_long_word`.
 
         This simply ensures that word boundaries are not broken mid-sequence,
         as standard python textwrap would incorrectly determine the length

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -129,9 +129,9 @@ class Termcap(object):
                     return cls(name, pattern, attribute)
 
         if match_grouped:
-            pattern = re.sub(r'(\d+)', _numeric_regex, _outp)
+            pattern = re.sub(r'(\d+)', lambda x: _numeric_regex, _outp)
         else:
-            pattern = re.sub(r'\d+', _numeric_regex, _outp)
+            pattern = re.sub(r'\d+', lambda x: _numeric_regex, _outp)
         return cls(name, pattern, attribute)
 
 

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-"""This module contains :class:`Terminal`, the primary API entry point."""
+"""Module containing :class:`Terminal`, the primary API entry point."""
 # pylint: disable=too-many-lines
 #         Too many lines in module (1027/1000)
 import codecs
@@ -73,6 +73,9 @@ from .keyboard import (get_keyboard_sequences,
                        _read_until,
                        _time_left,
                        )
+
+
+_CUR_TERM = None  # See comments at end of file
 
 
 class Terminal(object):
@@ -191,9 +194,8 @@ class Terminal(object):
         self._normal = None  # cache normal attr, preventing recursive lookups
 
         # The descriptor to direct terminal initialization sequences to.
-        self._init_descriptor = (stream_fd is None and
-                                 sys.__stdout__.fileno() or
-                                 stream_fd)
+        self._init_descriptor = (sys.__stdout__.fileno() if stream_fd is None
+                                 else stream_fd)
         self._kind = kind or os.environ.get('TERM', 'unknown')
 
         if self.does_styling:
@@ -1009,8 +1011,8 @@ class Terminal(object):
         A context manager for :func:`tty.setraw`.
 
         Although both :meth:`break` and :meth:`raw` modes allow each keystroke
-        to be read immediately after it is pressed, Raw mode disables processing
-        of input and output.
+        to be read immediately after it is pressed, Raw mode disables
+        processing of input and output.
 
         In cbreak mode, special input characters such as ``^C`` or ``^S`` are
         interpreted by the terminal driver and excluded from the stdin stream.
@@ -1177,6 +1179,7 @@ class WINSZ(collections.namedtuple('WINSZ', (
     _BUF = '\x00' * struct.calcsize(_FMT)
 
 
+#: _CUR_TERM = None
 #: From libcurses/doc/ncurses-intro.html (ESR, Thomas Dickey, et. al)::
 #:
 #:   "After the call to setupterm(), the global variable cur_term is set to
@@ -1196,4 +1199,3 @@ class WINSZ(collections.namedtuple('WINSZ', (
 #: Therefore, the :attr:`Terminal.kind` of each :class:`Terminal` is
 #: essentially a singleton. This global variable reflects that, and a warning
 #: is emitted if somebody expects otherwise.
-_CUR_TERM = None

--- a/blessed/tests/test_core.py
+++ b/blessed/tests/test_core.py
@@ -479,7 +479,8 @@ def test_termcap_repr():
 
     given_ttype='vt220'
     given_capname = 'cursor_up'
-    expected = [r"<Termcap cursor_up:'\\\x1b\\[A'>",
+    expected = [r"<Termcap cursor_up:'\x1b\\[A'>",
+                r"<Termcap cursor_up:'\\\x1b\\[A'>",
                 r"<Termcap cursor_up:u'\\\x1b\\[A'>"]
 
     @as_subprocess

--- a/requirements-analysis.txt
+++ b/requirements-analysis.txt
@@ -1,3 +1,4 @@
 prospector[with_pyroma]
 restructuredtext_lint
 doc8
+Pygments

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,9 @@ setuptools.setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: User Interfaces',
         'Topic :: Terminals'

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters = true
 [testenv]
 whitelist_externals = cp
 setenv = PYTHONIOENCODING=UTF8
-passenv = TEST_QUICK TEST_FULL
+passenv = TEST_QUICK TEST_FULL TRAVIS
 deps = -rrequirements-tests.txt
 commands = {envbindir}/py.test {posargs:\
                --strict --verbose --verbose --color=yes \

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = about, sa, sphinx, py{26,27,34,35}
+envlist = about, sa, sphinx, py{26,27,34,35,36,37}
 skip_missing_interpreters = true
 
 [testenv]
@@ -30,14 +30,14 @@ commands = coveralls
 
 [testenv:about]
 deps = -rrequirements-about.txt
-basepython = python3.5
+basepython = python3.6
 commands = python {toxinidir}/bin/display-sighandlers.py
            python {toxinidir}/bin/display-terminalinfo.py
            python {toxinidir}/bin/display-fpathconf.py
            python {toxinidir}/bin/display-maxcanon.py
 
 [testenv:sa]
-basepython = python3.5
+basepython = python3.6
 deps = -rrequirements-analysis.txt
        -rrequirements-about.txt
 commands = python -m compileall -fq {toxinidir}/blessed
@@ -49,13 +49,19 @@ commands = python -m compileall -fq {toxinidir}/blessed
 
 [testenv:sphinx]
 whitelist_externals = echo
-basepython = python3.5
+basepython = python3.6
 deps = -rrequirements-docs.txt
 commands = {envbindir}/sphinx-build -v -W \
                -d {toxinidir}/docs/_build/doctrees \
                {posargs:-b html} docs \
                {toxinidir}/docs/_build/html
            echo "--> open docs/_build/html/index.html for review."
+
+[testenv:py35]
+# there is not much difference of py34 vs. 35 in blessed
+# library; prefer testing integration against py35, and
+# just do a 'quick' on py34, if exists.
+setenv = TEST_QUICK=1
 
 [testenv:py34]
 # there is not much difference of py34 vs. 35 in blessed

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ deps = -rrequirements-analysis.txt
 commands = python -m compileall -fq {toxinidir}/blessed
            {envbindir}/prospector \
                --die-on-tool-error \
+               --no-external-config \
                {toxinidir}
            {envbindir}/rst-lint README.rst
            {envbindir}/doc8 --ignore-path docs/_build --ignore D000 docs

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,8 @@ basepython = python3.6
 commands = python {toxinidir}/bin/display-sighandlers.py
            python {toxinidir}/bin/display-terminalinfo.py
            python {toxinidir}/bin/display-fpathconf.py
-           python {toxinidir}/bin/display-maxcanon.py
+           # Temporarily disable until limits are added to MAX_CANON logic
+           # python {toxinidir}/bin/display-maxcanon.py
 
 [testenv:sa]
 basepython = python3.6


### PR DESCRIPTION
[Python 3.7](https://www.python.org/dev/peps/pep-0537/) is scheduled for release on June 15th so I've started testing some of my projects for compatibility. I ran into some issues running blessed due to changes in the the [re](https://docs.python.org/3.7/library/re.html) module. I also added 3.6 and 3.7 to tox and travis and included changes needed to ensure all the tests pass. Summary of the changes is below.

**Python 3.7 compatibility**
- [re.sub](https://docs.python.org/3.7/library/re.html#re.sub): Unknown escapes in repl consisting of '\' and an ASCII letter now are errors.
    - blessed/sequences.py
    - Workaround by making repl a function
      `pattern = re.sub(r'\d+', _numeric_regex, _outp)`
     becomes
       `pattern = re.sub(r'\d+', lambda x: _numeric_regex, _outp)`

- [re.escape](https://docs.python.org/3.7/library/re.html#re.escape): Only characters that can have special meaning in a regular expression are escaped.
    - blessed/sequences.py (affects behavior)
    - blessed/tests/test_core.py (changes)
    - Only test that failed was `test_termcap_repr()`
        - Returned
            `r"<Termcap cursor_up:'\x1b\\[A'>"`
          instead of
            `r"<Termcap cursor_up:'\\\x1b\\[A'>"`
        - Assuming new output is valid since primary purpose is to feed regex and all other tests pass
        - Updated test to expect new output (along with existing)

**Fixes for Travis**
- Not related to Python 3.7
- Ctrl-C test was inconsistent and configured to be skipped on Travis, but the TRAVIS environment variable was not being passed to tox
    - Added TRAVIS variable to tox environment
- There were some issues in the Travis environment due to the default Python
    - Changed global python to 3.6 before install
    - The Travis environment should be updated soon and we won't need this anymore

**Fix issues with static analysis**
- Not related to Python 3.7
- Forced prospector not to use external config files
    - This prevents it from using any pylintrc and similar files it finds in it's environment
- Disabled two docstring checks:
    - D212: Multi-line docstring summary should start at the first line
    - D401: First line should be in imperative mood
- Code cleanup to resolve other errors and warnings

**Temporarily disabled display-maxcanon.py**
- Not related to Python 3.7
- On my system and in Travis, this seems to run forever.
    - Unsure if this is due to a change in pexpect or Linux
    - Considered adding limits, but you're the expert in this, so figured you would know better
