### PR TITLE
Add support for Windows

### DIFF
--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -7,7 +7,10 @@ http://pypi.python.org/pypi/blessed
 import platform as _platform
 
 # local
-from blessed.terminal import Terminal
+if _platform.system() == 'Windows':
+    from blessed.win_terminal import Terminal
+else:
+    from blessed.terminal import Terminal
 
 if ('3', '0', '0') <= _platform.python_version_tuple() < ('3', '2', '2+'):
     # Good till 3.2.10

--- a/blessed/formatters.py
+++ b/blessed/formatters.py
@@ -1,9 +1,15 @@
 """Sub-module providing sequence-formatting functions."""
 # standard imports
-import curses
+import platform
 
 # 3rd-party
 import six
+
+# curses
+if platform.system() == 'Windows':
+    import jinxed as curses   # pylint: disable=import-error
+else:
+    import curses
 
 
 def _make_colors():

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -1,8 +1,7 @@
 """Sub-module providing 'keyboard awareness'."""
 
 # std imports
-import curses.has_key
-import curses
+import platform
 import time
 import re
 
@@ -17,6 +16,15 @@ except ImportError:
     # pylint: disable=import-error
     #         Unable to import 'ordereddict'
     from ordereddict import OrderedDict
+
+# curses
+if platform.system() == 'Windows':
+    # pylint: disable=import-error
+    import jinxed as curses
+    from jinxed.has_key import _capability_names as capability_names
+else:
+    import curses
+    from curses.has_key import _capability_names as capability_names
 
 
 class Keystroke(six.text_type):
@@ -170,7 +178,6 @@ def get_keyboard_sequences(term):
     # of a kermit or avatar terminal, for example, remains unchanged
     # in its byte sequence values even when represented by unicode.
     #
-    capability_names = curses.has_key._capability_names
     sequence_map = dict((
         (seq.decode('latin1'), val)
         for (seq, val) in (

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -437,7 +437,7 @@ class Terminal(object):
             try:
                 if fd is not None:
                     return self._winsize(fd)
-            except IOError:
+            except (IOError, OSError, ValueError):
                 pass
 
         return WINSZ(ws_row=int(os.getenv('LINES', '25')),

--- a/blessed/tests/test_keyboard.py
+++ b/blessed/tests/test_keyboard.py
@@ -748,7 +748,6 @@ def test_get_keyboard_sequences_sort_order():
 
 def test_get_keyboard_sequence(monkeypatch):
     "Test keyboard.get_keyboard_sequence. "
-    import curses.has_key
     import blessed.keyboard
 
     (KEY_SMALL, KEY_LARGE, KEY_MIXIN) = range(3)
@@ -765,7 +764,7 @@ def test_get_keyboard_sequence(monkeypatch):
                         lambda cap: {CAP_SMALL: SEQ_SMALL,
                                      CAP_LARGE: SEQ_LARGE}[cap])
 
-    monkeypatch.setattr(curses.has_key, '_capability_names',
+    monkeypatch.setattr(blessed.keyboard, 'capability_names',
                         dict(((KEY_SMALL, CAP_SMALL,),
                               (KEY_LARGE, CAP_LARGE,))))
 

--- a/blessed/win_terminal.py
+++ b/blessed/win_terminal.py
@@ -1,0 +1,157 @@
+# encoding: utf-8
+"""Module containing Windows version of :class:`Terminal`."""
+
+from __future__ import absolute_import
+
+import contextlib
+import msvcrt  # pylint: disable=import-error
+import time
+
+import jinxed.win32 as win32  # pylint: disable=import-error
+
+from .terminal import WINSZ, Terminal as _Terminal
+
+
+class Terminal(_Terminal):
+    """Windows subclass of :class:`Terminal`."""
+
+    def getch(self):
+        r"""
+        Read, decode, and return the next byte from the keyboard stream.
+
+        :rtype: unicode
+        :returns: a single unicode character, or ``u''`` if a multi-byte
+            sequence has not yet been fully received.
+
+        For versions of Windows 10.0.10586 and later, the console is expected
+        to be in ENABLE_VIRTUAL_TERMINAL_INPUT mode and the default method is
+        called.
+
+        For older versions of Windows, msvcrt.getwch() is used. If the received
+        character is ``\x00`` or ``\xe0``, the next character is
+        automatically retrieved.
+        """
+        if win32.VTMODE_SUPPORTED:
+            return super(Terminal, self).getch()
+
+        rtn = msvcrt.getwch()
+        if rtn in ('\x00', '\xe0'):
+            rtn += msvcrt.getwch()
+        return rtn
+
+    def kbhit(self, timeout=None, **_kwargs):
+        """
+        Return whether a keypress has been detected on the keyboard.
+
+        This method is used by :meth:`inkey` to determine if a byte may
+        be read using :meth:`getch` without blocking.  This is implemented
+        by wrapping msvcrt.kbhit() in a timeout.
+
+        :arg float timeout: When ``timeout`` is 0, this call is
+            non-blocking, otherwise blocking indefinitely until keypress
+            is detected when None (default). When ``timeout`` is a
+            positive number, returns after ``timeout`` seconds have
+            elapsed (float).
+        :rtype: bool
+        :returns: True if a keypress is awaiting to be read on the keyboard
+            attached to this terminal.
+        """
+        end = time.time() + (timeout or 0)
+        while True:
+
+            if msvcrt.kbhit():
+                return True
+
+            if timeout is not None and end < time.time():
+                break
+
+        return False
+
+    @staticmethod
+    def _winsize(fd):
+        """
+        Return named tuple describing size of the terminal by ``fd``.
+
+        :arg int fd: file descriptor queries for its window size.
+        :rtype: WINSZ
+
+        WINSZ is a :class:`collections.namedtuple` instance, whose structure
+        directly maps to the return value of the :const:`termios.TIOCGWINSZ`
+        ioctl return value. The return parameters are:
+
+            - ``ws_row``: width of terminal by its number of character cells.
+            - ``ws_col``: height of terminal by its number of character cells.
+            - ``ws_xpixel``: width of terminal by pixels (not accurate).
+            - ``ws_ypixel``: height of terminal by pixels (not accurate).
+        """
+        window = win32.get_terminal_size(fd)
+        return WINSZ(ws_row=window.lines, ws_col=window.columns,
+                     ws_xpixel=0, ws_ypixel=0)
+
+    @contextlib.contextmanager
+    def cbreak(self):
+        """
+        Allow each keystroke to be read immediately after it is pressed.
+
+        This is a context manager for ``jinxed.w32.setcbreak()``.
+
+        .. note:: You must explicitly print any user input you would like
+            displayed.  If you provide any kind of editing, you must handle
+            backspace and other line-editing control functions in this mode
+            as well!
+
+        **Normally**, characters received from the keyboard cannot be read
+        by Python until the *Return* key is pressed. Also known as *cooked* or
+        *canonical input* mode, it allows the tty driver to provide
+        line-editing before shuttling the input to your program and is the
+        (implicit) default terminal mode set by most unix shells before
+        executing programs.
+        """
+        if self._keyboard_fd is not None:
+
+            filehandle = msvcrt.get_osfhandle(self._keyboard_fd)
+
+            # Save current terminal mode:
+            save_mode = win32.get_console_mode(filehandle)
+            save_line_buffered = self._line_buffered
+            win32.setcbreak(filehandle)
+            try:
+                self._line_buffered = False
+                yield
+            finally:
+                win32.set_console_mode(filehandle, save_mode)
+                self._line_buffered = save_line_buffered
+
+        else:
+            yield
+
+    @contextlib.contextmanager
+    def raw(self):
+        """
+        A context manager for ``jinxed.w32.setcbreak()``.
+
+        Although both :meth:`break` and :meth:`raw` modes allow each keystroke
+        to be read immediately after it is pressed, Raw mode disables
+        processing of input and output.
+
+        In cbreak mode, special input characters such as ``^C`` are
+        interpreted by the terminal driver and excluded from the stdin stream.
+        In raw mode these values are receive by the :meth:`inkey` method.
+        """
+        if self._keyboard_fd is not None:
+
+            filehandle = msvcrt.get_osfhandle(self._keyboard_fd)
+
+            # Save current terminal mode:
+            save_mode = win32.get_console_mode(filehandle)
+            save_line_buffered = self._line_buffered
+            win32.setraw(filehandle)
+            try:
+                self._line_buffered = False
+                yield
+            finally:
+                win32.set_console_mode(filehandle, save_mode)
+                self._line_buffered = save_line_buffered
+
+        else:
+            yield

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 wcwidth>=0.1.4
 six>=1.9.0
+# support python2.6 by using backport of 'orderedict'
+ordereddict==1.1; python_version < "2.7"
+# Windows requires jinxed
+jinxed>=0.5.4; platform_system == "Windows"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Distutils setup script."""
 import os
+import platform
 import setuptools
 
 
@@ -12,6 +13,10 @@ def _get_install_requires(fname):
     # support python2.6 by using backport of 'orderedict'
     if sys.version_info < (2, 7):
         result.append('ordereddict==1.1')
+
+    # Windows requires jinxed
+    if platform.system() == 'Windows':
+        result.append('jinxed>=0.5.4')
 
     return result
 
@@ -53,6 +58,7 @@ setuptools.setup(
         'Environment :: Console :: Curses',
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX',
+        'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,12 @@
 #!/usr/bin/env python
 """Distutils setup script."""
 import os
-import platform
 import setuptools
 
 
 def _get_install_requires(fname):
-    import sys
     result = [req_line.strip() for req_line in open(fname)
               if req_line.strip() and not req_line.startswith('#')]
-
-    # support python2.6 by using backport of 'orderedict'
-    if sys.version_info < (2, 7):
-        result.append('ordereddict==1.1')
-
-    # Windows requires jinxed
-    if platform.system() == 'Windows':
-        result.append('jinxed>=0.5.4')
 
     return result
 


### PR DESCRIPTION
This should address #18 and #90. (and maybe #73?)

This mostly came out of my efforts to support [Enlighten](https://pypi.org/project/enlighten) on Windows. I just needed a subset of Blessed for Enlighten, so that's what I originally implemented, but I kept looking at it and eventually it seemed like I had enough pieces to add Windows support to Blessed itself.

I decided to move the bulk of the logic to its own library, [Jinxed](https://pypi.org/project/jinxed). It provides a pure Python (with some ctypes calls) implementation for the parts of curses needed by Blessed. The terminfo is implemented through inherited dictionaries rather than by parsing the upstream terminfo. While that's a little more work upfront, it's more efficient and should make it easier for people to add new terminals. For new versions of Windows 10, it enables the build-in terminal processing and, for older versions of Windows, it relies on ANSICON which will be automatically loaded. ANSICON is missing a few things. For example, there's no `smcup` equivalent and some key combinations are not recognized, but it provides enough capabilities for most projects. If another library provides better support, it's relatively easy to add.

The tests currently don't run on Windows, but this is primarily due to the way the tests are constructed. Mostly, it's replacing some of the termios calls like `echo_off()` with a Windows equivalent and making a dummy version of `as_subprocess()` since [Jinxed](https://pypi.org/project/jinxed) will allow you to rerun `setupterm()` multiple times. That can be done if you think it's necessary. The actual implementation for Windows is pretty thin and contained in `blessed/win_terminal.py`.

Let me know what you think.