### PR TITLE
Minor tweaks for Windows implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ htmlcov
 .coveralls.yml
 .DS_Store
 .*.sw?
+.vscode

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -294,7 +294,7 @@ class Terminal(object):
         if self._keyboard_fd is not None:
             # set input encoding and initialize incremental decoder
             if platform.system() == 'Windows' and sys.version_info[0] < 3:
-                # Default for setlocale() has side effects for Python 2 on Windows
+                # Default for setlocale() has side effects for PY2 on Windows
                 pass
             else:
                 locale.setlocale(locale.LC_ALL, '')

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -293,7 +293,11 @@ class Terminal(object):
 
         if self._keyboard_fd is not None:
             # set input encoding and initialize incremental decoder
-            locale.setlocale(locale.LC_ALL, '')
+            if platform.system() == 'Windows' and sys.version_info[0] < 3:
+                # Default for setlocale() has side effects for Python 2 on Windows
+                pass
+            else:
+                locale.setlocale(locale.LC_ALL, '')
             self._encoding = locale.getpreferredencoding() or 'ascii'
 
             try:

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -437,7 +437,7 @@ class Terminal(object):
             try:
                 if fd is not None:
                     return self._winsize(fd)
-            except (IOError, OSError, ValueError):
+            except (IOError, OSError, ValueError, TypeError):
                 pass
 
         return WINSZ(ws_row=int(os.getenv('LINES', '25')),

--- a/docs/further.rst
+++ b/docs/further.rst
@@ -76,9 +76,9 @@ Here are some recommended readings to help you along:
 
   The TTY driver is a great introduction to Kernel and Systems programming,
   because familiar components may be discovered and experimented with.  It is
-  available on all operating systems, and because of its critical nature, examples of
-  efficient file I/O, character buffers (often implemented as "ring buffers") and even
-  fine-grained kernel locking can be found.
+  available on all operating systems, and because of its critical nature,
+  examples of efficient file I/O, character buffers (often implemented as
+  "ring buffers") and even fine-grained kernel locking can be found.
 
 - `Thomas E. Dickey <http://invisible-island.net/>`_ has been maintaining
   `xterm <http://invisible-island.net/xterm/xterm.html>`_, as well as a


### PR DESCRIPTION
Just a few stray things:
 - Corner case: Added `TypeError` as a caught exception for `_height_and_width()`. For Python 3, Jinxed uses `os.get_terminal_size()` to get the terminal size, and if it's not passed something like a file descriptor, as is the case with the PyCharm Python console, it will raise a TypeError.
- Corner case: locale.setlocale() has strange side effects with Python 2 on Windows. For example, printing `u'█'` works when the C locale is used, but, when the user default locale is used, it's printed as `'U'`. I couldn't find an good information on it and it seems to work fine in Python 3. The few code examples I could find skip setting locale on Windows.
- Tooling: Add .vscode to .gitignore. Purely for my benefit.
- Linting: Fixed some line lengths in the docs you updated the other day