### PR TITLE
Run terminal tests on Windows 10 using Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,14 @@ matrix:
       env: TOXENV=py39,coveralls TEST_QUICK=1 COVERAGE_ID=travis-ci
     - python: 3.8
       env: TOXENV=about,pylint,flake8,flake8_tests,sphinx COVERAGE_ID=travis-ci
+    - python: 3.8
+      os: windows
+      language: shell
+      before_install:
+         - choco install python --version 3.8.0
+         - python -m pip install --upgrade pip
+         - python -m pip install tox
+      env: PATH=/c/Python38:/c/Python38/Scripts:$PATH TOXENV=py38,coveralls COVERAGE_ID=travis-ci
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
 jobs:
   allow_failures:
     - env: TOXENV=py39,coveralls TEST_QUICK=1 COVERAGE_ID=travis-ci
-    - env: TOXENV=about,pylint,flake8,sphinx COVERAGE_ID=travis-ci
+    - env: TOXENV=about,pylint,flake8,flake8_tests,sphinx COVERAGE_ID=travis-ci
 
 install:
   - pip install tox

--- a/bin/display-terminalinfo.py
+++ b/bin/display-terminalinfo.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 import os
 import sys
 import locale
-import termios
+import platform
 
 BITMAP_IFLAG = {
     'IGNBRK': 'ignore BREAK condition',
@@ -99,6 +99,7 @@ CTLCHAR_INDEX = {
 
 def display_bitmask(kind, bitmap, value):
     """Display all matching bitmask values for ``value`` given ``bitmap``."""
+    import termios
     col1_width = max(map(len, list(bitmap.keys()) + [kind]))
     col2_width = 7
     fmt = '{name:>{col1_width}} {value:>{col2_width}}   {description}'
@@ -126,6 +127,7 @@ def display_bitmask(kind, bitmap, value):
 
 def display_ctl_chars(index, ctlc):
     """Display all control character indicies, names, and values."""
+    import termios
     title = 'Special Character'
     col1_width = len(title)
     col2_width = max(map(len, index.values()))
@@ -175,6 +177,11 @@ def display_pathconf(names, getter):
 
 def main():
     """Program entry point."""
+    if platform.system() == 'Windows':
+        print('No terminal on windows systems!')
+        exit(0)
+
+    import termios
     fd = sys.stdin.fileno()
     locale.setlocale(locale.LC_ALL, '')
     encoding = locale.getpreferredencoding()

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -202,7 +202,7 @@ class Terminal(object):
         if self.does_styling:
             # Initialize curses (call setupterm), so things like tigetstr() work.
             try:
-                curses.setupterm(kind, open(os.devnull).fileno())
+                curses.setupterm(self._kind, open(os.devnull).fileno())
             except curses.error as err:
                 warnings.warn('Failed to setupterm(kind={0!r}): {1}'
                               .format(self._kind, err))

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -68,7 +68,7 @@ else:
             "are not found on your platform '{platform}'. "
             "The following methods of Terminal are dummy/no-op "
             "unless a deriving class overrides them: {tty_methods}."
-            .format(paltform=sys.platform.lower(),
+            .format(platform=platform.system(),
                     tty_methods=', '.join(_TTY_METHODS)))
         warnings.warn(_MSG_NOSUPPORT)
         HAS_TTY = False

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -51,9 +51,9 @@ except ImportError:
     from ordereddict import OrderedDict
 
 
+HAS_TTY = True
 if platform.system() == 'Windows':
     import jinxed as curses  # pylint: disable=import-error
-    HAS_TTY = True
 else:
     import curses
 
@@ -61,14 +61,15 @@ else:
         import termios
         import fcntl
         import tty
-        HAS_TTY = True
     except ImportError:
         _TTY_METHODS = ('setraw', 'cbreak', 'kbhit', 'height', 'width')
         _MSG_NOSUPPORT = (
             "One or more of the modules: 'termios', 'fcntl', and 'tty' "
-            "are not found on your platform '{0}'. The following methods "
-            "of Terminal are dummy/no-op unless a deriving class overrides "
-            "them: {1}".format(sys.platform.lower(), ', '.join(_TTY_METHODS)))
+            "are not found on your platform '{platform}'. "
+            "The following methods of Terminal are dummy/no-op "
+            "unless a deriving class overrides them: {tty_methods}."
+            .format(paltform=sys.platform.lower(),
+                    tty_methods=', '.join(_TTY_METHODS)))
         warnings.warn(_MSG_NOSUPPORT)
         HAS_TTY = False
 

--- a/blessed/tests/accessories.py
+++ b/blessed/tests/accessories.py
@@ -7,7 +7,6 @@ from __future__ import print_function, with_statement
 import os
 import sys
 import codecs
-import curses
 import platform
 import functools
 import traceback
@@ -22,8 +21,11 @@ import pytest
 from blessed import Terminal
 
 if platform.system() != "Windows":
+    import curses
     import pty
     import termios
+else:
+    import jinxed as curses
 
 TestTerminal = functools.partial(Terminal, kind='xterm-256color')
 SEND_SEMAPHORE = SEMAPHORE = b'SEMAPHORE\n'

--- a/blessed/tests/accessories.py
+++ b/blessed/tests/accessories.py
@@ -51,6 +51,8 @@ if os.environ.get('TEST_FULL'):
             .communicate()[0].splitlines()]
     except OSError:
         pass
+elif platform.system() == 'Windows':
+    all_terms_params = ['xterm', ]
 elif os.environ.get('TEST_QUICK'):
     all_terms_params = 'xterm screen ansi linux'.split()
 

--- a/blessed/tests/accessories.py
+++ b/blessed/tests/accessories.py
@@ -52,7 +52,7 @@ if os.environ.get('TEST_FULL'):
     except OSError:
         pass
 elif platform.system() == 'Windows':
-    all_terms_params = ['xterm', ]
+    all_terms_params = ['vtwin10', ]
 elif os.environ.get('TEST_QUICK'):
     all_terms_params = 'xterm screen ansi linux'.split()
 

--- a/blessed/tests/accessories.py
+++ b/blessed/tests/accessories.py
@@ -27,7 +27,11 @@ if platform.system() != "Windows":
 else:
     import jinxed as curses
 
-TestTerminal = functools.partial(Terminal, kind='xterm-256color')
+
+test_kind = 'xterm-256color'
+if platform.system() == 'Windows':
+    test_kind = 'vtwin10'
+TestTerminal = functools.partial(Terminal, kind=test_kind)
 SEND_SEMAPHORE = SEMAPHORE = b'SEMAPHORE\n'
 RECV_SEMAPHORE = b'SEMAPHORE\r\n'
 many_lines_params = [40, 80]

--- a/blessed/tests/test_core.py
+++ b/blessed/tests/test_core.py
@@ -324,6 +324,7 @@ def test_IOUnsupportedOperation():
     child()
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason="has process-wide side-effects")
 def test_winsize_IOError_returns_environ():
     """When _winsize raises IOError, defaults from os.environ given."""
     @as_subprocess
@@ -478,6 +479,7 @@ def test_time_left_infinite_None():
     assert _time_left(stime=time.time(), timeout=None) is None
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason="cant multiprocess")
 def test_termcap_repr():
     """Ensure ``hidden_cursor()`` writes hide_cursor and normal_cursor."""
 

--- a/blessed/tests/test_core.py
+++ b/blessed/tests/test_core.py
@@ -221,9 +221,12 @@ def test_setupterm_invalid_issue39():
             term = TestTerminal(kind='unknown', force_styling=True)
         except UserWarning:
             err = sys.exc_info()[1]
-            assert err.args[0] == (
+            assert err.args[0] in (
                 "Failed to setupterm(kind='unknown'): "
-                "setupterm: could not find terminal")
+                "setupterm: could not find terminal",
+                "Failed to setupterm(kind='unknown'): "
+                "Could not find terminal unknown",
+            )
         else:
             if platform.system().lower() != 'freebsd':
                 assert not term.is_a_tty and not term.does_styling, (

--- a/blessed/tests/test_core.py
+++ b/blessed/tests/test_core.py
@@ -87,6 +87,7 @@ def test_null_fileno():
     child()
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', "requires more than 1 tty")
 def test_number_of_colors_without_tty():
     """``number_of_colors`` should return 0 when there's no tty."""
     @as_subprocess
@@ -122,6 +123,7 @@ def test_number_of_colors_without_tty():
     child_256_nostyle()
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', "requires more than 1 tty")
 def test_number_of_colors_with_tty():
     """test ``number_of_colors`` 0, 8, and 256."""
     @as_subprocess

--- a/blessed/tests/test_core.py
+++ b/blessed/tests/test_core.py
@@ -87,7 +87,7 @@ def test_null_fileno():
     child()
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', "requires more than 1 tty")
+@pytest.mark.skipif(platform.system() == 'Windows', reason="requires more than 1 tty")
 def test_number_of_colors_without_tty():
     """``number_of_colors`` should return 0 when there's no tty."""
     @as_subprocess
@@ -123,7 +123,7 @@ def test_number_of_colors_without_tty():
     child_256_nostyle()
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', "requires more than 1 tty")
+@pytest.mark.skipif(platform.system() == 'Windows', reason="requires more than 1 tty")
 def test_number_of_colors_with_tty():
     """test ``number_of_colors`` 0, 8, and 256."""
     @as_subprocess
@@ -393,7 +393,7 @@ def test_unknown_preferredencoding_warned_and_fallback_ascii():
     child()
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', "requires fcntl")
+@pytest.mark.skipif(platform.system() == 'Windows', reason="requires fcntl")
 def test_win32_missing_tty_modules(monkeypatch):
     """Ensure dummy exception is used when io is without UnsupportedOperation."""
     @as_subprocess

--- a/blessed/tests/test_core.py
+++ b/blessed/tests/test_core.py
@@ -185,7 +185,7 @@ def test_setupterm_singleton_issue_33():
 
         # instantiate first terminal, of type xterm-256color
         term = TestTerminal(force_styling=True)
-        first_kind = TestTerminal.kind
+        first_kind = term.kind
         next_kind = 'xterm'
 
         try:

--- a/blessed/tests/test_core.py
+++ b/blessed/tests/test_core.py
@@ -185,11 +185,8 @@ def test_setupterm_singleton_issue_33():
 
         # instantiate first terminal, of type xterm-256color
         term = TestTerminal(force_styling=True)
-        next_kind = 'vt220'
         first_kind = 'xterm-256color'
-        if platform.system() == 'Windows':
-            first_kind = 'vtwin10'
-            next_kind = 'xterm'
+        next_kind = 'xterm'
 
         try:
             # a second instantiation raises UserWarning

--- a/blessed/tests/test_core.py
+++ b/blessed/tests/test_core.py
@@ -177,7 +177,7 @@ def test_force_styling_none(all_terms):
     child(all_terms)
 
 
-def test_setupterm_singleton_issue33():
+def test_setupterm_singleton_issue_33():
     """A warning is emitted if a new terminal ``kind`` is used per process."""
     @as_subprocess
     def child():
@@ -185,16 +185,21 @@ def test_setupterm_singleton_issue33():
 
         # instantiate first terminal, of type xterm-256color
         term = TestTerminal(force_styling=True)
+        next_kind = 'vt220'
+        first_kind = 'xterm-256color'
+        if platform.system() == 'Windows':
+            first_kind = 'vtwin10'
+            next_kind = 'xterm'
 
         try:
             # a second instantiation raises UserWarning
-            term = TestTerminal(kind="vt220", force_styling=True)
+            term = TestTerminal(kind=next_kind, force_styling=True)
         except UserWarning:
             err = sys.exc_info()[1]
             assert (err.args[0].startswith(
-                    'A terminal of kind "vt220" has been requested')
+                    'A terminal of kind "' + next_kind + '" has been requested')
                     ), err.args[0]
-            assert ('a terminal of kind "xterm-256color" will '
+            assert ('a terminal of kind "' + first_kind + '" will '
                     'continue to be returned' in err.args[0]), err.args[0]
         else:
             # unless term is not a tty and setupterm() is not called

--- a/blessed/tests/test_core.py
+++ b/blessed/tests/test_core.py
@@ -385,18 +385,18 @@ def test_no_preferredencoding_fallback_ascii():
 
 
 @pytest.mark.skipif(platform.system() == 'Windows', reason="requires fcntl")
+#@pytest.mark.filterwarnings("ignore:LookupError")
 def test_unknown_preferredencoding_warned_and_fallback_ascii():
     """Ensure a locale without a codec emits a warning."""
     @as_subprocess
     def child():
         with mock.patch('locale.getpreferredencoding') as get_enc:
-            with warnings.catch_warnings(record=True) as warned:
-                get_enc.return_value = '---unknown--encoding---'
+            get_enc.return_value = '---unknown--encoding---'
+            with pytest.warns(UserWarning, match=(
+                    'LookupError: unknown encoding: ---unknown--encoding---, '
+                    'fallback to ASCII for keyboard.')):
                 t = TestTerminal()
                 assert t._encoding == 'ascii'
-                assert len(warned) == 1
-                assert issubclass(warned[-1].category, UserWarning)
-                assert "fallback to ASCII" in str(warned[-1].message)
 
     child()
 

--- a/blessed/tests/test_core.py
+++ b/blessed/tests/test_core.py
@@ -370,6 +370,7 @@ def test_yield_hidden_cursor(all_terms):
     child(all_terms)
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason="windows doesn't work like this")
 def test_no_preferredencoding_fallback_ascii():
     """Ensure empty preferredencoding value defaults to ascii."""
     @as_subprocess

--- a/blessed/tests/test_core.py
+++ b/blessed/tests/test_core.py
@@ -14,6 +14,7 @@ import collections
 # 3rd party
 import six
 import mock
+import pytest
 from six.moves import reload_module
 
 # local
@@ -390,6 +391,7 @@ def test_unknown_preferredencoding_warned_and_fallback_ascii():
     child()
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', "requires fcntl")
 def test_win32_missing_tty_modules(monkeypatch):
     """Ensure dummy exception is used when io is without UnsupportedOperation."""
     @as_subprocess

--- a/blessed/tests/test_core.py
+++ b/blessed/tests/test_core.py
@@ -185,7 +185,7 @@ def test_setupterm_singleton_issue_33():
 
         # instantiate first terminal, of type xterm-256color
         term = TestTerminal(force_styling=True)
-        first_kind = 'xterm-256color'
+        first_kind = TestTerminal.kind
         next_kind = 'xterm'
 
         try:

--- a/blessed/tests/test_core.py
+++ b/blessed/tests/test_core.py
@@ -383,6 +383,7 @@ def test_no_preferredencoding_fallback_ascii():
     child()
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason="requires fcntl")
 def test_unknown_preferredencoding_warned_and_fallback_ascii():
     """Ensure a locale without a codec emits a warning."""
     @as_subprocess

--- a/blessed/tests/test_formatters.py
+++ b/blessed/tests/test_formatters.py
@@ -1,11 +1,16 @@
 # -*- coding: utf-8 -*-
 """Tests string formatting functions."""
 # std imports
-import curses
+import platform
 
 # 3rd party
 import mock
 import pytest
+
+if platform.system() != 'Windows':
+    import curses
+else:
+    import jinxed as curses
 
 
 def fn_tparm(*args):

--- a/blessed/tests/test_keyboard.py
+++ b/blessed/tests/test_keyboard.py
@@ -14,9 +14,9 @@ from .accessories import TestTerminal, all_terms, as_subprocess
 
 if platform.system() != 'Windows':
     import curses
+    import tty  # NOQA
 else:
     import jinxed as curses
-    import tty  # NOQA
 
 if sys.version_info[0] == 3:
     unichr = chr

--- a/blessed/tests/test_keyboard.py
+++ b/blessed/tests/test_keyboard.py
@@ -170,7 +170,10 @@ def test_get_keyboard_sequences_sort_order():
                 assert len(sequence) <= maxlen
             assert sequence
             maxlen = len(sequence)
-    child(kind='xterm-256color')
+    kind = 'xterm-256color'
+    if platform.system() == 'Windows':
+        kind = 'vtwin10'
+    child(kind)
 
 
 def test_get_keyboard_sequence(monkeypatch):

--- a/blessed/tests/test_keyboard.py
+++ b/blessed/tests/test_keyboard.py
@@ -21,7 +21,7 @@ else:
 if sys.version_info[0] == 3:
     unichr = chr
 
-
+@pytest.mark.skipif(platform.system() == 'Windows', reason="?")
 def test_break_input_no_kb():
     """cbreak() should not call tty.setcbreak() without keyboard."""
     @as_subprocess
@@ -35,6 +35,7 @@ def test_break_input_no_kb():
     child()
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason="?")
 def test_raw_input_no_kb():
     """raw should not call tty.setraw() without keyboard."""
     @as_subprocess
@@ -48,6 +49,7 @@ def test_raw_input_no_kb():
     child()
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason="?")
 def test_raw_input_with_kb():
     """raw should call tty.setraw() when with keyboard."""
     @as_subprocess
@@ -281,6 +283,7 @@ def test_keyboard_prefixes():
     assert pfs == set([u'a', u'ab', u'abd', u'j', u'jk'])
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason="no multiprocess")
 def test_keypad_mixins_and_aliases():
     """Test PC-Style function key translations when in ``keypad`` mode."""
     # Key     plain   app     modified

--- a/blessed/tests/test_keyboard.py
+++ b/blessed/tests/test_keyboard.py
@@ -2,8 +2,7 @@
 """Tests for keyboard support."""
 # std imports
 import sys
-import tty  # NOQA
-import curses
+import platform
 import tempfile
 import functools
 
@@ -12,6 +11,12 @@ import mock
 
 # local
 from .accessories import TestTerminal, all_terms, as_subprocess
+
+if platform.system() != 'Windows':
+    import curses
+else:
+    import jinxed as curses
+    import tty  # NOQA
 
 if sys.version_info[0] == 3:
     unichr = chr

--- a/blessed/tests/test_keyboard.py
+++ b/blessed/tests/test_keyboard.py
@@ -8,6 +8,7 @@ import functools
 
 # 3rd party
 import mock
+import pytest
 
 # local
 from .accessories import TestTerminal, all_terms, as_subprocess

--- a/blessed/tests/test_length_sequence.py
+++ b/blessed/tests/test_length_sequence.py
@@ -22,7 +22,7 @@ if platform.system() != 'Windows':
 def test_length_cjk():
     @as_subprocess
     def child():
-        term = TestTerminal(kind='xterm-256color')
+        term = TestTerminal()
 
         # given,
         given = term.bold_red(u'コンニチハ, セカイ!')
@@ -36,9 +36,9 @@ def test_length_cjk():
 
 def test_length_ansiart():
     @as_subprocess
-    def child():
+    def child(kind):
         import codecs
-        term = TestTerminal(kind='xterm-256color')
+        term = TestTerminal(kind=kind)
         # this 'ansi' art contributed by xzip!impure for another project,
         # unlike most CP-437 DOS ansi art, this is actually utf-8 encoded.
         fname = os.path.join(os.path.dirname(__file__), 'wall.ans')
@@ -50,7 +50,10 @@ def test_length_ansiart():
         assert term.length(lines[4]) == 78
         assert term.length(lines[5]) == 78
         assert term.length(lines[6]) == 77
-    child()
+    kind = 'xterm-256color'
+    if platform.system() == 'Windows':
+        kind = 'vtwin10'
+    child(kind)
 
 
 def test_sequence_length(all_terms):

--- a/blessed/tests/test_length_sequence.py
+++ b/blessed/tests/test_length_sequence.py
@@ -170,7 +170,14 @@ def test_sequence_length(all_terms):
         # XXX why are some terminals width of 9 here ??
         assert (term.length(u'\t') in (8, 9))
         assert (term.strip(u'\t') == u'')
-        assert (term.length(u'_' + term.move_left) == 0)
+
+        if term.kind != 'vtwin10':
+            assert (term.length(u'_' + term.move_left) == 0)
+        else:
+            # XXX Why, on windows / jinxed, is this value correct,
+            # but, when running the tests on windows, the value
+            # is *incorrect* !?
+            assert (term.length(u'_' + term.move_left) == 1)
 
         if term.cub:
             assert (term.length((u'_' * 10) + term.cub(10)) == 0)

--- a/blessed/tests/test_length_sequence.py
+++ b/blessed/tests/test_length_sequence.py
@@ -173,16 +173,18 @@ def test_sequence_length(all_terms):
 
         if term.kind != 'vtwin10':
             assert (term.length(u'_' + term.move_left) == 0)
+            assert (term.length(term.move_right) == 1)
         else:
             # XXX Why, on windows / jinxed, is this value correct,
             # but, when running the tests on windows, the value
             # is *incorrect* !?
             assert (term.length(u'_' + term.move_left) == 1)
+            # XXX And, 0 here, it is as though RE_MOVE isn't working.
+            assert (term.length(term.move_right) == 0)
 
         if term.cub:
             assert (term.length((u'_' * 10) + term.cub(10)) == 0)
 
-        assert (term.length(term.move_right) == 1)
 
         if term.cuf:
             assert (term.length(term.cuf(10)) == 10)

--- a/blessed/tests/test_length_sequence.py
+++ b/blessed/tests/test_length_sequence.py
@@ -218,7 +218,7 @@ def test_env_winsize():
     child()
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', "requires fcntl")
+@pytest.mark.skipif(platform.system() == 'Windows', reason="requires fcntl")
 def test_winsize(many_lines, many_columns):
     """Test height and width is appropriately queried in a pty."""
     @as_subprocess
@@ -258,7 +258,7 @@ def test_Sequence_alignment_fixed_width():
         assert (term.length(radjusted) == len(pony_msg.rjust(88)))
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', "requires fcntl")
+@pytest.mark.skipif(platform.system() == 'Windows', reason="requires fcntl")
 def test_Sequence_alignment(all_terms):
     """Tests methods related to Sequence class, namely ljust, rjust, center."""
     @as_subprocess

--- a/blessed/tests/test_length_sequence.py
+++ b/blessed/tests/test_length_sequence.py
@@ -2,19 +2,22 @@
 # std imports
 import os
 import sys
-import fcntl
 import struct
-import termios
+import platform
 import itertools
 
 # 3rd party
 import six
+import pytest
 
 # local
 from blessed.tests.accessories import (  # isort:skip
     TestTerminal, as_subprocess, all_terms, many_lines, many_columns
 )
 
+if platform.system() != 'Windows':
+    import fcntl
+    import termios
 
 def test_length_cjk():
     @as_subprocess
@@ -215,6 +218,7 @@ def test_env_winsize():
     child()
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', "requires fcntl")
 def test_winsize(many_lines, many_columns):
     """Test height and width is appropriately queried in a pty."""
     @as_subprocess
@@ -254,6 +258,7 @@ def test_Sequence_alignment_fixed_width():
         assert (term.length(radjusted) == len(pony_msg.rjust(88)))
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', "requires fcntl")
 def test_Sequence_alignment(all_terms):
     """Tests methods related to Sequence class, namely ljust, rjust, center."""
     @as_subprocess

--- a/blessed/tests/test_length_sequence.py
+++ b/blessed/tests/test_length_sequence.py
@@ -56,6 +56,8 @@ def test_length_ansiart():
     child(kind)
 
 
+@pytest.mark.skipif(platform.system() == 'Windows',
+                    reason='https://github.com/jquast/blessed/issues/122')
 def test_sequence_length(all_terms):
     """Ensure T.length(string containing sequence) is correcterm."""
     @as_subprocess
@@ -171,16 +173,8 @@ def test_sequence_length(all_terms):
         assert (term.length(u'\t') in (8, 9))
         assert (term.strip(u'\t') == u'')
 
-        if term.kind != 'vtwin10':
-            assert (term.length(u'_' + term.move_left) == 0)
-            assert (term.length(term.move_right) == 1)
-        else:
-            # XXX Why, on windows / jinxed, is this value correct,
-            # but, when running the tests on windows, the value
-            # is *incorrect* !?
-            assert (term.length(u'_' + term.move_left) == 1)
-            # XXX And, 0 here, it is as though RE_MOVE isn't working.
-            assert (term.length(term.move_right) == 0)
+        assert (term.length(u'_' + term.move_left) == 0)
+        assert (term.length(term.move_right) == 1)
 
         if term.cub:
             assert (term.length((u'_' * 10) + term.cub(10)) == 0)
@@ -409,6 +403,8 @@ def test_sequence_is_movement_true(all_terms):
     child(all_terms)
 
 
+@pytest.mark.skipif(platform.system() == 'Windows',
+                    reason='https://github.com/jquast/blessed/issues/122')
 def test_termcap_will_move_true(all_terms):
     """Test parser about sequences that move the cursor."""
     @as_subprocess

--- a/blessed/tests/test_sequences.py
+++ b/blessed/tests/test_sequences.py
@@ -480,16 +480,19 @@ def test_null_callable_string(all_terms):
 def test_padd():
     """Test Terminal.padd(seq)."""
     @as_subprocess
-    def child():
+    def child(kind):
         from blessed.sequences import Sequence
         from blessed import Terminal
-        term = Terminal('xterm-256color')
+        term = Terminal(kind)
         assert Sequence('xyz\b', term).padd() == u'xy'
         assert Sequence('xyz\b-', term).padd() == u'xy-'
         assert Sequence('xxxx\x1b[3Dzz', term).padd() == u'xzz'
         assert Sequence('\x1b[3D', term).padd() == u''  # "Trim left"
 
-    child()
+    kind = 'xterm-256color'
+    if platform.system() == 'Windows':
+        kind = 'vtwin10'
+    child(kind)
 
 
 def test_split_seqs(all_terms):

--- a/blessed/tests/test_sequences.py
+++ b/blessed/tests/test_sequences.py
@@ -16,7 +16,7 @@ from .accessories import (TestTerminal,
                           as_subprocess)
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', "requires real tty")
+@pytest.mark.skipif(platform.system() == 'Windows', reason="requires real tty")
 def test_capability():
     """Check that capability lookup works."""
     @as_subprocess
@@ -154,7 +154,7 @@ def test_vertical_location(all_terms):
     child(all_terms)
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', "requires multiprocess")
+@pytest.mark.skipif(platform.system() == 'Windows', reason="requires multiprocess")
 def test_inject_move_x():
     """Test injection of hpa attribute for screen/ansi (issue #55)."""
     @as_subprocess
@@ -175,7 +175,7 @@ def test_inject_move_x():
     child('ansi')
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', "requires multiprocess")
+@pytest.mark.skipif(platform.system() == 'Windows', reason="requires multiprocess")
 def test_inject_move_y():
     """Test injection of vpa attribute for screen/ansi (issue #55)."""
     @as_subprocess
@@ -196,7 +196,7 @@ def test_inject_move_y():
     child('ansi')
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', "requires multiprocess")
+@pytest.mark.skipif(platform.system() == 'Windows', reason="requires multiprocess")
 def test_inject_civis_and_cnorm_for_ansi():
     """Test injection of cvis attribute for ansi."""
     @as_subprocess
@@ -210,7 +210,7 @@ def test_inject_civis_and_cnorm_for_ansi():
     child('ansi')
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', "requires multiprocess")
+@pytest.mark.skipif(platform.system() == 'Windows', reason="requires multiprocess")
 def test_inject_sc_and_rc_for_ansi():
     """Test injection of sc and rc (save and restore cursor) for ansi."""
     @as_subprocess

--- a/blessed/tests/test_sequences.py
+++ b/blessed/tests/test_sequences.py
@@ -16,12 +16,12 @@ from .accessories import (TestTerminal,
                           as_subprocess)
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', "requires real tty")
 def test_capability():
     """Check that capability lookup works."""
     @as_subprocess
     def child():
-        # Also test that Terminal grabs a reasonable default stream. This test
-        # assumes it will be run from a tty.
+        # Also test that Terminal grabs a reasonable default stream.
         t = TestTerminal()
         sc = unicode_cap('sc')
         assert t.save == sc
@@ -175,6 +175,7 @@ def test_inject_move_x():
     child('ansi')
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', "requires multiprocess")
 def test_inject_move_y():
     """Test injection of vpa attribute for screen/ansi (issue #55)."""
     @as_subprocess
@@ -195,6 +196,7 @@ def test_inject_move_y():
     child('ansi')
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', "requires multiprocess")
 def test_inject_civis_and_cnorm_for_ansi():
     """Test injection of cvis attribute for ansi."""
     @as_subprocess

--- a/blessed/tests/test_sequences.py
+++ b/blessed/tests/test_sequences.py
@@ -153,6 +153,7 @@ def test_vertical_location(all_terms):
     child(all_terms)
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', "requires multiprocess")
 def test_inject_move_x():
     """Test injection of hpa attribute for screen/ansi (issue #55)."""
     @as_subprocess
@@ -206,6 +207,7 @@ def test_inject_civis_and_cnorm_for_ansi():
     child('ansi')
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', "requires multiprocess")
 def test_inject_sc_and_rc_for_ansi():
     """Test injection of sc and rc (save and restore cursor) for ansi."""
     @as_subprocess

--- a/blessed/tests/test_sequences.py
+++ b/blessed/tests/test_sequences.py
@@ -6,6 +6,7 @@ import platform
 
 # 3rd party
 import six
+import pytest
 
 # local
 from .accessories import (TestTerminal,

--- a/blessed/tests/test_sequences.py
+++ b/blessed/tests/test_sequences.py
@@ -51,6 +51,8 @@ def test_capability_with_forced_tty():
     child()
 
 
+@pytest.skipif(platform.system() == 'Windows',
+               reason='https://github.com/jquast/blessed/issues/122')
 def test_parametrization():
     """Test parameterizing a capability."""
     @as_subprocess

--- a/blessed/tests/test_sequences.py
+++ b/blessed/tests/test_sequences.py
@@ -51,8 +51,8 @@ def test_capability_with_forced_tty():
     child()
 
 
-@pytest.skipif(platform.system() == 'Windows',
-               reason='https://github.com/jquast/blessed/issues/122')
+@pytest.mark.skipif(platform.system() == 'Windows',
+                    reason='https://github.com/jquast/blessed/issues/122')
 def test_parametrization():
     """Test parameterizing a capability."""
     @as_subprocess

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,8 @@ norecursedirs = .git .tox build
 addopts = --cov-append --cov-report=html --color=yes --ignore=setup.py --ignore=.tox
           --log-format='%(levelname)s %(relativeCreated)2.2f %(filename)s:%(lineno)d %(message)s'
           --cov=blessed
+filterwarnings =
+    error
 junit_family = xunit1
 
 [coverage:run]


### PR DESCRIPTION
By manipulating our `@as_subprocess` test framework developed to execute tests in a sub-process to shield from the "cannot change terminal definition at runtime" issue -- for WIndows, no sub-process is used, and the `vtwin10` kind is always used.

We achieve 65% code coverage on Windows, and integrate into Travis-CI, passing below.