### PR TITLE
bugfix: ValueError: underlying buffer has been detached

### DIFF
--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -175,7 +175,9 @@ class Terminal(object):
         try:
             stream_fd = (stream.fileno() if hasattr(stream, 'fileno') and
                          callable(stream.fileno) else None)
-        except io.UnsupportedOperation:
+        except (io.UnsupportedOperation, ValueError):
+            # The stream is not a file, such as the case of StringIO, or, when it has been
+            # "detached", such as might be the case of stdout in some test scenarios.
             stream_fd = None
 
         self._stream = stream

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,8 @@ Version History
   * introduced: 24-bit color support, detected by ``term.number_of_colors == 1 << 24``,
     and 24-bit color foreground method :meth:`~Terminal.color_rgb` and background method
     :meth:`~Terminal.on_color_rgb`.
+  * bugfix: prevent error condition, ``ValueError: underlying buffer has been detached`` in rare
+    conditions where sys.__stdout__ has been detached in test frameworks. :ghissue:`126`.
   * bugfix: off-by-one error in :meth:`~.Terminal.get_location`, now accounts for
     ``%i`` in cursor_report, :ghissue:`94`.
   * bugfix :meth:`~Terminal.split_seqs` and related functions failed to match when the

--- a/tests/test_length_sequence.py
+++ b/tests/test_length_sequence.py
@@ -55,13 +55,11 @@ def test_length_ansiart():
     child(kind)
 
 
-@pytest.mark.skipif(platform.system() == 'Windows',
-                    reason='https://github.com/jquast/blessed/issues/122')
 def test_sequence_length(all_terms):
     """Ensure T.length(string containing sequence) is correcterm."""
     @as_subprocess
     def child(kind):
-        term = TestTerminal(kind=kind)
+        term = TestTerminal(kind=kind, force_styling=True)
         # Create a list of ascii characters, to be separated
         # by word, to be zipped up with a cycling list of
         # terminal sequences. Then, compare the length of
@@ -401,14 +399,12 @@ def test_sequence_is_movement_true(all_terms):
     child(all_terms)
 
 
-@pytest.mark.skipif(platform.system() == 'Windows',
-                    reason='https://github.com/jquast/blessed/issues/122')
 def test_termcap_will_move_true(all_terms):
     """Test parser about sequences that move the cursor."""
     @as_subprocess
     def child(kind):
         from blessed.sequences import iter_parse
-        term = TestTerminal(kind=kind)
+        term = TestTerminal(kind=kind, force_styling=True)
         assert next(iter_parse(term, term.move(98, 76)))[1].will_move
         assert next(iter_parse(term, term.move(54)))[1].will_move
         assert next(iter_parse(term, term.cud1))[1].will_move

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -47,13 +47,12 @@ def test_capability_with_forced_tty():
     child()
 
 
-@pytest.mark.skipif(platform.system() == 'Windows',
-                    reason='https://github.com/jquast/blessed/issues/122')
 def test_parametrization():
     """Test parameterizing a capability."""
     @as_subprocess
     def child():
-        assert TestTerminal().cup(3, 4) == unicode_parm('cup', 3, 4)
+        term = TestTerminal(force_styling=True)
+        assert term.cup(3, 4) == unicode_parm('cup', 3, 4)
 
     child()
 


### PR DESCRIPTION
Prevent error condition, `ValueError: underlying buffer has been detached` from raising, Closes #126 