### PR TITLE
term.move_up/down/left/right are now also callables

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -9,6 +9,10 @@ Version History
     positional arguments, ``(x, y)`` match the return value of :meth:`~.Terminal.get_location`,
     and all other common graphics library calls, :ghissue:`65`.
     values over the b``term.move``.
+  * introduced: :meth:`~.Terminal.move_up`, :meth:`~Terminal.move_down`, :meth:`Terminal.move_left`,
+    :meth:`~Terminal.move_right` which are strings that move the cursor one cell in the respective
+    direction, are now also callables for moving *n* cells to the given direction, such as
+    ``term.move_right(9)``.
   * bugfix: prevent error condition, ``ValueError: underlying buffer has been detached`` in rare
     conditions where sys.__stdout__ has been detached in test frameworks. :ghissue:`126`.
   * bugfix: off-by-one error in :meth:`~.Terminal.get_location`, now accounts for ``%i`` in

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -192,7 +192,7 @@ this::
     term = Terminal()
     print(term.move_xy(10, 1) + 'Hi, mom!')
 
-There are three basic movement capabilities:
+There are three basic direct movement capabilities:
 
 ``move_xy(x, y)``
   Position cursor at given **x**, **y**.
@@ -202,6 +202,17 @@ There are three basic movement capabilities:
   Position cursor at row **y**.
 ``home``
   Position cursor at (0, 0).
+
+And your basic set of relative capabilities:
+
+``move_up`` or ``move_up(y)``
+  Position cursor 1 or **y** cells above the current position.
+``move_down`` or ``move_down(y)``
+  Position cursor 1 or **y** cells below the current position.
+``move_left`` or ``move_left(x)``
+  Position cursor 1 or **x** cells left of the current position.
+``move_right`` or ``move_right(x)``
+  Position cursor 1 or **x** cells right of the current position.
 
 A context manager, :meth:`~.Terminal.location` is provided to move the cursor
 to an *(x, y)* screen position and *restore the previous position* on exit::
@@ -215,13 +226,10 @@ to an *(x, y)* screen position and *restore the previous position* on exit::
 
     print('This is back where I came from.')
 
-Parameters to :meth:`~.Terminal.location` are the **optional** *x* and/or *y*
-keyword arguments::
-
-    with term.location(y=10):
-        print('We changed just the row.')
-
-When omitted, it saves the current cursor position, and restore it on exit::
+Parameters to :meth:`~.Terminal.location` are the **optional** *x* and/or *y* keyword arguments.
+When only one argument is used, only the row or column is positioned. When both arguments are
+omitted, it saves the current cursor position, without performing any movement, but restore that
+position on exit::
 
     with term.location():
         print(term.move_xy(1, 1) + 'Hi')


### PR DESCRIPTION
Introduce this new kind of FormattingOtherString class, which allows us to make a capability that prints as a sequence, but is also callable as a capability to print another sequence, for the move_up/down/left/right() family of functions. A rather obscure convenience, Closes #47 