### PR TITLE
Prefer 'dumb' over 'unknown' terminal type in lightweight environments

### DIFF
--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -196,7 +196,7 @@ class Terminal(object):
         if platform.system() == 'Windows':
             self._kind = kind or curses.get_term(self._init_descriptor)
         else:
-            self._kind = kind or os.environ.get('TERM', 'unknown')
+            self._kind = kind or os.environ.get('TERM', 'dumb') or 'dumb'
 
         if self.does_styling:
             # Initialize curses (call setupterm), so things like tigetstr() work.

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: User Interfaces',
         'Topic :: Terminals'


### PR DESCRIPTION
For very lightweight environments, prefer terminal type 'dumb', and in case `TERM=`, that is, an empty string, also use phrase `dumb`, instead of `` or `unknown` as used previously, backporting  4e515462ba86483f6e8671bf42241fd39fd27c4e from https://github.com/erikrose/blessings/issues/39