### PR TITLE
Expand coverage analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ matrix:
 
 jobs:
   allow_failures:
-    - python 2.6
-    - python 3.9-dev
+    - python: 2.6
+    - python: 3.9-dev
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 matrix:
   fast_finish: true
   include:
+    - python: 2.6
+      env: TOXENV=py26,codecov TEST_QUICK=1 COVERAGE_ID=travis-ci
+      dist: trusty
     - python: 2.7
       env: TOXENV=py27,codecov TEST_QUICK=1 COVERAGE_ID=travis-ci
     - python: 3.4
@@ -18,6 +21,14 @@ matrix:
       env: TOXENV=py39,codecov TEST_QUICK=1 COVERAGE_ID=travis-ci
     - python: 3.8
       env: TOXENV=about,pylint,flake8,flake8_tests,sphinx COVERAGE_ID=travis-ci
+    - python: 2.7
+      os: windows
+      language: shell
+      before_install:
+         - choco install python2
+         - python -m pip install --upgrade pip
+         - python -m pip install tox
+      env: PATH=/c/Python27:/c/Python27/Scripts:$PATH TOXENV=py27,codecov COVERAGE_ID=travis-ci TEST_KEYBOARD=no
     - python: 3.8
       os: windows
       language: shell

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 matrix:
   fast_finish: true
   include:
+    - python: 3.8
+      env: TOXENV=about,pylint,flake8,flake8_tests,sphinx COVERAGE_ID=travis-ci
     - python: 2.6
       env: TOXENV=py26,codecov TEST_QUICK=1 COVERAGE_ID=travis-ci
       dist: trusty
@@ -18,9 +20,7 @@ matrix:
     - python: 3.8
       env: TOXENV=py38,codecov COVERAGE_ID=travis-ci
     - python: 3.9-dev
-      env: TOXENV=py39,codecov TEST_QUICK=1 COVERAGE_ID=travis-ci
-    - python: 3.8
-      env: TOXENV=about,pylint,flake8,flake8_tests,sphinx COVERAGE_ID=travis-ci
+      env: TRAVIS_PYTHON_VERSION=3.9 TOXENV=py39,codecov TEST_QUICK=1 COVERAGE_ID=travis-ci
     - python: 2.7
       os: windows
       language: shell
@@ -42,7 +42,6 @@ jobs:
   allow_failures:
     - env: TOXENV=py26,codecov TEST_QUICK=1 COVERAGE_ID=travis-ci
     - env: TOXENV=py39,codecov TEST_QUICK=1 COVERAGE_ID=travis-ci
-    - env: TOXENV=about,pylint,flake8,flake8_tests,sphinx COVERAGE_ID=travis-ci
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - python: 3.8
       env: TOXENV=py38,codecov COVERAGE_ID=travis-ci
     - python: 3.9-dev
-      env: TRAVIS_PYTHON_VERSION=3.9 TOXENV=py39,codecov TEST_QUICK=1 COVERAGE_ID=travis-ci
+      env: TOXENV=py39,codecov TEST_QUICK=1 COVERAGE_ID=travis-ci TOXPYTHON=3.9
     - python: 2.7
       os: windows
       language: shell
@@ -28,7 +28,7 @@ matrix:
          - choco install python2
          - python -m pip install --upgrade pip
          - python -m pip install tox
-      env: PATH=/c/Python27:/c/Python27/Scripts:$PATH TRAVIS_PYTHON_VERSION=2.7 TOXENV=py27,codecov COVERAGE_ID=travis-ci TEST_KEYBOARD=no
+      env: PATH=/c/Python27:/c/Python27/Scripts:$PATH TOXPYTHON=2.7 TOXENV=py27,codecov COVERAGE_ID=travis-ci TEST_KEYBOARD=no
     - python: 3.8
       os: windows
       language: shell
@@ -40,8 +40,8 @@ matrix:
 
 jobs:
   allow_failures:
-    - env: TOXENV=py26,codecov TEST_QUICK=1 COVERAGE_ID=travis-ci
-    - env: TOXENV=py39,codecov TEST_QUICK=1 COVERAGE_ID=travis-ci
+    - python 2.6
+    - python 3.9-dev
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
          - choco install python2
          - python -m pip install --upgrade pip
          - python -m pip install tox
-      env: PATH=/c/Python27:/c/Python27/Scripts:$PATH TOXENV=py27,codecov COVERAGE_ID=travis-ci TEST_KEYBOARD=no
+      env: PATH=/c/Python27:/c/Python27/Scripts:$PATH TRAVIS_PYTHON_VERSION=2.7 TOXENV=py27,codecov COVERAGE_ID=travis-ci TEST_KEYBOARD=no
     - python: 3.8
       os: windows
       language: shell

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ matrix:
 
 jobs:
   allow_failures:
+    - env: TOXENV=py26,codecov TEST_QUICK=1 COVERAGE_ID=travis-ci
     - env: TOXENV=py39,codecov TEST_QUICK=1 COVERAGE_ID=travis-ci
     - env: TOXENV=about,pylint,flake8,flake8_tests,sphinx COVERAGE_ID=travis-ci
 

--- a/blessed/_capabilities.py
+++ b/blessed/_capabilities.py
@@ -6,10 +6,7 @@ try:
     from collections import OrderedDict
 except ImportError:
     # python 2.6 requires 3rd party library (backport)
-    #
-    # pylint: disable=import-error
-    #         Unable to import 'ordereddict'
-    from ordereddict import OrderedDict
+    from ordereddict import OrderedDict  # pylint: disable=import-error
 
 __all__ = (
     'CAPABILITY_DATABASE',

--- a/blessed/color.py
+++ b/blessed/color.py
@@ -14,6 +14,7 @@ from math import cos, exp, sin, sqrt, atan2
 try:
     from functools import lru_cache
 except ImportError:
+    # lru_cache was added in Python 3.2
     from backports.functools_lru_cache import lru_cache
 
 

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -119,11 +119,7 @@ def get_keyboard_codes():
     keycodes = OrderedDict(get_curses_keycodes())
     keycodes.update(CURSES_KEYCODE_OVERRIDE_MIXIN)
     # merge _CURSES_KEYCODE_ADDINS added to our module space
-    keycodes.update({
-        name: value
-        for name, value in globals().items()
-        if name.startswith('KEY_')
-    })
+    keycodes.update((name, value) for name, value in globals().items() if name.startswith('KEY_'))
 
     # invert dictionary (key, values) => (values, key), preferring the
     # last-most inserted value ('KEY_DELETE' over 'KEY_DC').

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -12,10 +12,7 @@ try:
     from collections import OrderedDict
 except ImportError:
     # python 2.6 requires 3rd party library (backport)
-    #
-    # pylint: disable=import-error
-    #         Unable to import 'ordereddict'
-    from ordereddict import OrderedDict
+    from ordereddict import OrderedDict # pylint: disable=import-error
 
 # curses
 if platform.system() == 'Windows':

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -12,7 +12,7 @@ try:
     from collections import OrderedDict
 except ImportError:
     # python 2.6 requires 3rd party library (backport)
-    from ordereddict import OrderedDict # pylint: disable=import-error
+    from ordereddict import OrderedDict  # pylint: disable=import-error
 
 # curses
 if platform.system() == 'Windows':

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -46,10 +46,7 @@ try:
     from collections import OrderedDict
 except ImportError:
     # python 2.6 requires 3rd party library (backport)
-    #
-    # pylint: disable=import-error
-    #         Unable to import 'ordereddict'
-    from ordereddict import OrderedDict
+    from ordereddict import OrderedDict  # pylint: disable=import-error
 
 
 HAS_TTY = True

--- a/run_codecov.py
+++ b/run_codecov.py
@@ -1,0 +1,34 @@
+# Workaround for https://github.com/codecov/codecov-python/issues/158
+
+import sys
+
+import codecov
+
+
+RETRIES = 5
+
+
+def main():
+
+    # Make a copy of argv and make sure --required is in it
+    args = sys.argv[1:]
+    if '--required' not in args:
+        args.append('--required')
+
+    for num in range(1, RETRIES + 1):
+
+        print('Running codecov attempt %d: ' % num)
+        # On the last, let codecov handle the exit
+        if num == RETRIES:
+            codecov.main()
+
+        try:
+            codecov.main(*args)
+        except SystemExit as err:
+            # If there's no exit code, it was successful
+            if not err.code:
+                sys.exit(err.code)
+
+
+if __name__ == '__main__':
+    main()

--- a/run_codecov.py
+++ b/run_codecov.py
@@ -1,14 +1,22 @@
-# Workaround for https://github.com/codecov/codecov-python/issues/158
+"""
+Workaround for https://github.com/codecov/codecov-python/issues/158
+"""
 
 import sys
+import time
 
 import codecov
 
 
 RETRIES = 5
+TIMEOUT = 2
 
 
 def main():
+    """
+    Run codecov up to RETRIES times
+    On the final attempt, let it exit normally
+    """
 
     # Make a copy of argv and make sure --required is in it
     args = sys.argv[1:]
@@ -26,8 +34,12 @@ def main():
             codecov.main(*args)
         except SystemExit as err:
             # If there's no exit code, it was successful
-            if not err.code:
+            if err.code:
+                time.sleep(TIMEOUT)
+            else:
                 sys.exit(err.code)
+        else:
+            break
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -205,7 +205,7 @@ commands = {envbindir}/sphinx-build \
            {posargs:-v -W -d {toxinidir}/docs/_build/doctrees -b html docs {toxinidir}/docs/_build/html}
 
 [testenv:codecov]
-basepython = python{env:TRAVIS_PYTHON_VERSION:3.8}
+basepython = python{env:TOXPYTHON:{env:TRAVIS_PYTHON_VERSION:3.8}}
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 deps = codecov>=1.4.0
 commands = codecov -e TOXENV

--- a/tox.ini
+++ b/tox.ini
@@ -81,6 +81,8 @@ max-line-length = 100
 [testenv:py26]
 setenv = TEST_QUICK=1
 basepython = python2.6
+deps = {[testenv]deps}
+       pytest==3.2.5
 
 [testenv:py27]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -133,6 +133,10 @@ commands = {envbindir}/py.test --cov-config={toxinidir}/tox.ini \
              } \
           tests
 
+[testenv:py39]
+setenv = TEST_QUICK=1
+basepython = python3.9
+
 [testenv:develop]
 commands = {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -209,4 +209,4 @@ basepython = python{env:TOXPYTHON:{env:TRAVIS_PYTHON_VERSION:3.8}}
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 deps = codecov>=1.4.0
 # Codecov upload can be flakey, so try up to 3 times
-commands = codecov -e TOXENV --required || codecov -e TOXENV --required || codecov -e TOXENV
+commands = codecov -e TOXENV --required || (codecov -e TOXENV --required) || (codecov -e TOXENV)

--- a/tox.ini
+++ b/tox.ini
@@ -201,6 +201,7 @@ commands = {envbindir}/sphinx-build \
            {posargs:-v -W -d {toxinidir}/docs/_build/doctrees -b html docs {toxinidir}/docs/_build/html}
 
 [testenv:codecov]
+basepython = python{env:TRAVIS_PYTHON_VERSION:3.8}
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 deps = codecov>=1.4.0
 commands = codecov -e TOXENV

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps = pytest==5.3.2
        pytest-cov==2.8.1
        pytest-xdist==1.31.0
        mock==3.0.5
-commands = {envbindir}/py.test --cov-config={toxinidir}/tox.ini {posargs:\
+commands = {envpython} -m pytest --cov-config={toxinidir}/tox.ini {posargs:\
              --strict --verbose \
              --junit-xml=.tox/results.{envname}.xml \
              --durations=3 \

--- a/tox.ini
+++ b/tox.ini
@@ -208,4 +208,5 @@ commands = {envbindir}/sphinx-build \
 basepython = python{env:TOXPYTHON:{env:TRAVIS_PYTHON_VERSION:3.8}}
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 deps = codecov>=1.4.0
-commands = codecov -e TOXENV
+# Codecov upload can be flakey, so try up to 3 times
+commands = codecov -e TOXENV --required || codecov -e TOXENV --required || codecov -e TOXENV

--- a/tox.ini
+++ b/tox.ini
@@ -82,9 +82,9 @@ max-line-length = 100
 setenv = TEST_QUICK=1
 basepython = python2.6
 deps = pytest==3.2.5
-       pytest-cov
-       pytest-xdist
-       mock==3.0.5
+       pytest-cov==2.5.1
+       pytest-xdist==1.20.1
+       mock==2.0.0
 
 [testenv:py27]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -81,8 +81,10 @@ max-line-length = 100
 [testenv:py26]
 setenv = TEST_QUICK=1
 basepython = python2.6
-deps = {[testenv]deps}
-       pytest==3.2.5
+deps = pytest==3.2.5
+       pytest-cov
+       pytest-xdist
+       mock==3.0.5
 
 [testenv:py27]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -209,4 +209,4 @@ basepython = python{env:TOXPYTHON:{env:TRAVIS_PYTHON_VERSION:3.8}}
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 deps = codecov>=1.4.0
 # Codecov upload can be flakey, so try up to 3 times
-commands = codecov -e TOXENV --required || (codecov -e TOXENV --required) || (codecov -e TOXENV)
+commands = (codecov -e TOXENV --required) || (codecov -e TOXENV --required) || (codecov -e TOXENV)

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ commands = {envpython} -m pytest --cov-config={toxinidir}/tox.ini {posargs:\
              --junit-xml=.tox/results.{envname}.xml \
              --durations=3 \
              } \
+          --log-format='%(levelname)s %(relativeCreated)2.2f %(filename)s:%(lineno)d %(message)s' \
           tests
 
 [pytest]
@@ -29,7 +30,6 @@ looponfailroots = blessed
 norecursedirs = .git .tox build
 addopts = --disable-pytest-warnings
           --cov-append --cov-report=html --color=yes --ignore=setup.py --ignore=.tox
-          --log-format='%(levelname)s %(relativeCreated)2.2f %(filename)s:%(lineno)d %(message)s'
           --cov=blessed
 filterwarnings =
     error
@@ -85,6 +85,12 @@ deps = pytest==3.2.5
        pytest-cov==2.5.1
        pytest-xdist==1.20.1
        mock==2.0.0
+commands = {envpython} -m pytest --cov-config={toxinidir}/tox.ini {posargs:\
+             --strict --verbose \
+             --junit-xml=.tox/results.{envname}.xml \
+             --durations=3 \
+             } \
+          tests
 
 [testenv:py27]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -208,5 +208,6 @@ commands = {envbindir}/sphinx-build \
 basepython = python{env:TOXPYTHON:{env:TRAVIS_PYTHON_VERSION:3.8}}
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 deps = codecov>=1.4.0
-# Codecov upload can be flakey, so try up to 3 times
-commands = (codecov -e TOXENV --required) || (codecov -e TOXENV --required) || (codecov -e TOXENV)
+# commands = codecov -e TOXENV
+# Workaround for https://github.com/codecov/codecov-python/issues/158
+commands = {envpython} run_codecov.py -e TOXENV


### PR DESCRIPTION
Update tests to fix a few issues:
- 3.9-dev was failing
- Only 3.8 tests were getting uploaded to codecov
- 2.6 workarounds were not being covered
- codecov can timeout on upload and doesn't include a retry option