### PR TITLE
Add 'linkcheck' tox target, fix a few, disable test broken on osx

### DIFF
--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -368,7 +368,7 @@ class Terminal(object):
             >>> term.move(line, column)
 
         See the manual page `terminfo(5)
-        <http://invisible-island.net/ncurses/man/terminfo.5.html>`_ for a
+        <https://invisible-island.net/ncurses/man/terminfo.5.html>`_ for a
         complete list of capabilities and their arguments.
         """
         if not self.does_styling:
@@ -566,7 +566,7 @@ class Terminal(object):
         # dimensions of a connected client, but **no means to determine the
         # location of the cursor**.
         #
-        # from http://invisible-island.net/ncurses/terminfo.src.html,
+        # from https://invisible-island.net/ncurses/terminfo.src.html,
         #
         # > The System V Release 4 and XPG4 terminfo format defines ten string
         # > capabilities for use by applications, <u0>...<u9>.   In this file,

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -41,12 +41,12 @@ Version History
     though such value is always True since 1.9.
 
 1.16
-  * introduced: Windows support?! :ghissue:`110` by :ghuser:`avylove`.
+  * introduced: Windows support?! :ghpull:`110` by :ghuser:`avylove`.
 
 1.15
   * enhancement: disable timing integration tests for keyboard routines.
-  * enhancement: Support python 3.7. :ghissue:`102`.
-  * enhancement: Various fixes to test automation :ghissue:`108`
+  * enhancement: Support python 3.7. :ghpull:`102`.
+  * enhancement: Various fixes to test automation :ghpull:`108`
 
 1.14
   * bugfix: :meth:`~.Terminal.wrap` misbehaved for text containing newlines,
@@ -203,9 +203,9 @@ Version History
   * Make ``python setup.py test`` work without spurious errors on 2.6.
   * Work around a tox parsing bug in its config file.
   * Make context managers clean up after themselves even if there's an
-    exception (Vitja Makarov :ghpull:`29`).
+    exception (`Vitja Makarov #29 <https://github.com/erikrose/blessings/pull/29>`).
   * Parameterizing a capability no longer crashes when there is no tty
-    (Vitja Makarov :ghpull:`31`)
+    (`<Vitja Makarov #31 <https://github.com/erikrose/blessings/pull/31>`)
 
 1.5
   * Add syntactic sugar and documentation for ``enter_fullscreen``
@@ -244,7 +244,7 @@ Version History
 1.2
   * Added support for Python 3! We need 3.2.3 or greater, because the curses
     library couldn't decide whether to accept strs or bytes before that
-    (http://bugs.python.org/issue10570).
+    (https://bugs.python.org/issue10570).
   * Everything that comes out of the library is now unicode. This lets us
     support Python 3 without making a mess of the code, and Python 2 should
     continue to work unless you were testing types (and badly). Please file a
@@ -266,13 +266,13 @@ Version History
 1.0
   * Extracted Blessed from `nose-progressive`_.
 
-.. _`nose-progressive`: http://pypi.python.org/pypi/nose-progressive/
+.. _`nose-progressive`: https://pypi.org/project/nose-progressive/
 .. _`erikrose/blessings`: https://github.com/erikrose/blessings
 .. _`jquast/blessed`: https://github.com/jquast/blessed
 .. _`issue tracker`: https://github.com/jquast/blessed/issues/
 .. _curses: https://docs.python.org/library/curses.html
 .. _colorama: https://pypi.python.org/pypi/colorama
-.. _wcwidth: https://pypi.python.org/pypi/wcwidth
+.. _wcwidth: https://pypi.org/project/wcwidth/
 .. _`cbreak(3)`: http://www.openbsd.org/cgi-bin/man.cgi?query=cbreak&apropos=0&sektion=3
 .. _`curs_getch(3)`: http://www.openbsd.org/cgi-bin/man.cgi?query=curs_getch&apropos=0&sektion=3
 .. _`termios(4)`: http://www.openbsd.org/cgi-bin/man.cgi?query=termios&apropos=0&sektion=4
@@ -280,5 +280,5 @@ Version History
 .. _tigetstr: http://www.openbsd.org/cgi-bin/man.cgi?query=tigetstr&sektion=3
 .. _tparm: http://www.openbsd.org/cgi-bin/man.cgi?query=tparm&sektion=3
 .. _`API Documentation`: http://blessed.rtfd.org
-.. _`PDCurses`: http://www.lfd.uci.edu/~gohlke/pythonlibs/#curses
+.. _`PDCurses`: https://www.lfd.uci.edu/~gohlke/pythonlibs/#curses
 .. _`ansi`: https://github.com/tehmaze/ansi

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -32,7 +32,7 @@ Whether you want to improve CLI apps with colors, or making fullscreen applicati
 *blessed* should help get you started quickly. Your users will love it because it works on Windows,
 Mac, and Linux, and you will love it because it has plenty of documentation and examples!
 
-Full documentation at http://blessed.readthedocs.org/en/latest/
+Full documentation at https://blessed.readthedocs.io/en/latest/
 
 Examples
 --------
@@ -172,9 +172,9 @@ The same program with *Blessed* is simply:
         print('This is ' + term.underline('underlined') + '!')
 
 .. _curses: https://docs.python.org/3/library/curses.html
-.. _tigetstr: http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man3/tigetstr.3
-.. _tparm: http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man3/tparm.3
-.. _`terminfo(5)`: http://invisible-island.net/ncurses/man/terminfo.5.html
+.. _tigetstr: http://man.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man3/tigetstr.3
+.. _tparm: http://man.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man3/tparm.3
+.. _`terminfo(5)`: https://invisible-island.net/ncurses/man/terminfo.5.html
 .. _str.center(): https://docs.python.org/3/library/stdtypes.html#str.center
 .. _textwrap.wrap(): https://docs.python.org/3/library/textwrap.html#textwrap.wrap
 .. _Terminal: https://blessed.readthedocs.io/en/stable/terminal.html
@@ -195,7 +195,7 @@ The same program with *Blessed* is simply:
 .. _`Terminal.raw()`: https://blessed.readthedocs.io/en/stable/api/terminal.html#blessed.terminal.Terminal.raw
 .. _`Terminal.inkey()`: https://blessed.readthedocs.io/en/stable/api/terminal.html#blessed.terminal.Terminal.inkey
 .. _Colors: https://blessed.readthedocs.io/en/stable/colors.html
-.. _Styles: https://blessed.readthedocs.io/en/stable/colors.html#style
+.. _Styles: https://blessed.readthedocs.io/en/stable/terminal.html#styles
 .. _Location: https://blessed.readthedocs.io/en/stable/location.html
 .. _Keyboard: https://blessed.readthedocs.io/en/stable/keyboard.html
 .. _Examples: https://blessed.readthedocs.io/en/stable/examples.html
@@ -212,10 +212,10 @@ The same program with *Blessed* is simply:
 .. _f-strings: https://docs.python.org/3/reference/lexical_analysis.html#f-strings
 .. |pypi_downloads| image:: https://img.shields.io/pypi/dm/blessed.svg?logo=pypi
     :alt: Downloads
-    :target: https://pypi.python.org/pypi/blessed
+    :target: https://pypi.org/project/blessed/
 .. |codecov| image:: https://codecov.io/gh/jquast/blessed/branch/master/graph/badge.svg
     :alt: codecov.io Code Coverage
-    :target: https://codecov.io/gh/jquast/blessed
+    :target: https://codecov.io/gh/jquast/blessed/
 .. |linux| image:: https://img.shields.io/badge/Linux-yes-success?logo=linux
     :alt: Linux supported
 .. |windows| image:: https://img.shields.io/badge/Windows-NEW-success?logo=windows

--- a/docs/keyboard.rst
+++ b/docs/keyboard.rst
@@ -94,7 +94,7 @@ Alt/meta
 
 Programs with GNU readline, like bash, have *Alt* combinators, such as *ALT+u* to uppercase the word
 after cursor.  This is achieved by the configuration option altSendsEscape or `metaSendsEscape
-<http://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Alt-and-Meta-Keys>`_ in xterm.
+<https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Alt-and-Meta-Keys>`_ in xterm.
 
 The default for most terminals, however, is for this key to be bound by the operating system, or,
 used for inserting international keys, (where the combination *ALT+u, a* is used to insert the

--- a/docs/project.rst
+++ b/docs/project.rst
@@ -36,7 +36,7 @@ Install and run tox::
 
 Py.test is used as the test runner, and with the tox target supporting positional arguments, you may
 for example use `looponfailing
-<https://pytest.org/latest/xdist.html#running-tests-in-looponfailing-mode>`_ with python 3.7,
+<https://docs.pytest.org/en/3.0.1/xdist.html#running-tests-in-looponfailing-mode>`_ with python 3.7,
 stopping at the first failing test case, and looping (retrying) after a filesystem save is
 detected::
 
@@ -61,7 +61,7 @@ help you along:
   capabilities available as attributes of :class:`~.Terminal` are directly mapped to those listed in
   the column **Cap-name**.
 
-- The :linuxman:`termios(4)` of your preferred posix-like operating system.
+- The :linuxman:`termios(3)` of your preferred posix-like operating system.
 
 - `The TTY demystified <http://www.linusakesson.net/programming/tty/index.php>`_ by Linus Åkesson.
 
@@ -69,7 +69,7 @@ help you along:
   <https://blog.nelhage.com/2009/12/a-brief-introduction-to-termios/>`_ by Nelson Elhage.
 
 - Richard Steven's `Advance Unix Programming
-  <http://www.amazon.com/exec/obidos/ISBN=0201563177/wrichardstevensA/>`_ ("AUP") provides two very
+  <https://www.amazon.com/exec/obidos/ISBN=0201563177/wrichardstevensA/>`_ ("AUP") provides two very
   good chapters, "Terminal I/O" and "Pseudo Terminals".
 
 - GNU's `The Termcap Manual
@@ -81,7 +81,7 @@ help you along:
   CUNY's course material for *Introduction to System Programming*, by `Stewart Weiss
   <http://compsci.hunter.cuny.edu/~sweiss/>`_
 
-- `Chapter 11 <http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap11.html>`_ of the
+- `Chapter 11 <https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap11.html>`_ of the
   IEEE Open Group Base Specifications Issue 7, "General Terminal Interface"
 
 - The GNU C Library documentation, section `Low-Level Terminal Interface
@@ -91,7 +91,7 @@ help you along:
   of a terminal capability", or whether or not your preferred terminal emulator actually handles
   them, read the source! Many modern terminal emulators are now based on `libvte <https://github.com/GNOME/vte>`_.
 
-- The source code of the :linuxman:`tty(4)`, :linuxman:`pty(4)`, and the given "console driver" for
+- The source code of the :linuxman:`tty(4)`, :linuxman:`pty(7)`, and the given "console driver" for
   any posix-like operating system.  If you search thoroughly enough, you will eventually discover a
   terminal sequence decoder, usually a ``case`` switch that translates ``\x1b[0m`` into a "reset
   color" action towards the video driver.  Though ``tty.c`` linked here is probably not the most
@@ -100,23 +100,23 @@ help you along:
      - `FreeBSD <https://github.com/freebsd/freebsd/blob/master/sys/kern/tty.c>`_
      - `OpenBSD <http://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/src/sys/kern/tty.c?content-type=text/plain>`_
      - `Illumos (Solaris) <https://github.com/illumos/illumos-gate/blob/master/usr/src/uts/common/io/tty_common.c>`_
-     - `Minix <https://github.com/minix3/minix/blob/master/minix/drivers/tty/tty/tty.c>`_
+     - `Minix <https://github.com/Stichting-MINIX-Research-Foundation/minix/blob/master/minix/drivers/tty/tty/tty.c>`_
      - `Linux <https://github.com/torvalds/linux/blob/master/drivers/tty/n_tty.c>`_
 
-- `Thomas E. Dickey <http://invisible-island.net/>`_ has been maintaining `xterm
-  <http://invisible-island.net/xterm/xterm.html>`_, as well as a primary maintainer of many related
-  packages such as `ncurses <http://invisible-island.net/ncurses/ncurses.html>`_ for quite a long
+- `Thomas E. Dickey <https://invisible-island.net/>`_ has been maintaining `xterm
+  <https://invisible-island.net/xterm/xterm.html>`_, as well as a primary maintainer of many related
+  packages such as `ncurses <https://invisible-island.net/ncurses/ncurses.html>`_ for quite a long
   while. His consistent, well-documented, long-term dedication to xterm, curses, and the many
   related projects is world-renown.
 
 - `termcap & terminfo (O'Reilly Nutshell)
-  <http://www.amazon.com/termcap-terminfo-OReilly-Nutshell-Linda/dp/0937175226>`_ by Linda Mui, Tim
+  <https://www.amazon.com/termcap-terminfo-OReilly-Nutshell-Linda/dp/0937175226>`_ by Linda Mui, Tim
   O'Reilly, and John Strang.
 
 - Note that System-V systems, also known as `Unix98
   <https://en.wikipedia.org/wiki/Single_UNIX_Specification>`_ (SunOS, HP-UX, AIX and others) use a
   `Streams <https://en.wikipedia.org/wiki/STREAMS>`_ interface.  On these systems, the `ioctl(2)
-  <http://pubs.opengroup.org/onlinepubs/009695399/functions/ioctl.html>`_ interface provides the
+  <https://pubs.opengroup.org/onlinepubs/009695399/functions/ioctl.html>`_ interface provides the
   ``PUSH`` and ``POP`` parameters to communicate with a Streams device driver, which differs
   significantly from Linux and BSD.
 
@@ -130,8 +130,8 @@ When people say 'ANSI', they are discussing:
 
 - Standard `ECMA-48`_: Control Functions for Coded Character Sets
 
-- `ANSI X3.64 <http://sydney.edu.au/engineering/it/~tapted/ansi.html>`_ from 1981, when the
-  `American National Standards Institute <http://www.ansi.org/>`_ adopted the `ECMA-48`_ as
+- `ANSI X3.64 <https://en.wikipedia.org/wiki/ANSI_escape_code#History>`_ from 1981, when the
+  `American National Standards Institute <https://www.ansi.org/>`_ adopted the `ECMA-48`_ as
   standard, which was later withdrawn in 1997 (so in this sense it is *not* an ANSI standard).
 
 - The `ANSI.SYS`_ driver provided in MS-DOS and clones.  The popularity of the IBM Personal Computer
@@ -140,14 +140,14 @@ When people say 'ANSI', they are discussing:
 
 - The various code pages used in MS-DOS Personal Computers, providing "block art" characters in the
   8th bit (int 127-255), paired with `ECMA-48`_ sequences supported by the MS-DOS `ANSI.SYS`_ driver
-  to create artwork, known as `ANSI art <http://pc.textmod.es/>`_.
+  to create artwork, known as `ANSI art <https://16colo.rs/>`_.
 
 - The ANSI terminal database entry and its many descendants in the `terminfo database
-  <http://invisible-island.net/ncurses/terminfo.src.html>`_.  This is mostly due to terminals
+  <https://invisible-island.net/ncurses/terminfo.src.html>`_.  This is mostly due to terminals
   compatible with SCO UNIX, which was the successor of Microsoft's Xenix, which brought some
   semblance of the Microsoft DOS `ANSI.SYS`_ driver capabilities.
 
-- `Select Graphics Rendition (SGR) <http://vt100.net/docs/vt510-rm/SGR>`_
+- `Select Graphics Rendition (SGR) <https://vt100.net/docs/vt510-rm/SGR>`_
   on vt100 clones, which include many of the common sequences in `ECMA-48`_.
 
 - Any sequence started by the `Control-Sequence-Inducer`_ is often mistakenly termed as an "ANSI
@@ -156,9 +156,9 @@ When people say 'ANSI', they are discussing:
   escape key (ESC, ``\x1b``).
 
 .. _`issue tracker`: https://github.com/jquast/blessed/issues/
-.. _`stackoverflow`: http://stackoverflow.com/
+.. _`stackoverflow`: https://stackoverflow.com/
 .. _code page: https://en.wikipedia.org/wiki/Code_page
 .. _IBM CP437: https://en.wikipedia.org/wiki/Code_page_437
-.. _Control-Sequence-Inducer: http://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Controls-beginning-with-ESC
+.. _Control-Sequence-Inducer: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Controls-beginning-with-ESC
 .. _ANSI.SYS: http://www.kegel.com/nansi/
 .. _ECMA-48: http://www.ecma-international.org/publications/standards/Ecma-048.htm

--- a/tests/test_full_keyboard.py
+++ b/tests/test_full_keyboard.py
@@ -305,6 +305,8 @@ def test_keystroke_0s_cbreak_multibyte_utf8():
 # Avylove: Added delay which should account for race contition. Re-add skip if randomly fail
 # @pytest.mark.skipif(os.environ.get('TRAVIS', None) is not None,
 #                     reason="travis-ci does not handle ^C very well.")
+@pytest.mark.skipif(platform.system() == 'Darwin',
+                    reason='os.write() raises OSError: [Errno 5] Input/output error')
 def test_keystroke_0s_raw_input_ctrl_c():
     """0-second keystroke with raw allows receiving ^C."""
     import pty

--- a/tox.ini
+++ b/tox.ini
@@ -206,6 +206,10 @@ commands = {envbindir}/pydocstyle --source --explain {toxinidir}/blessed
 deps = -r {toxinidir}/docs/requirements.txt
 commands = {envbindir}/sphinx-build {posargs:-v -W -d {toxinidir}/docs/_build/doctrees -b html docs {toxinidir}/docs/_build/html}
 
+[testenv:linkcheck]
+deps = -r {toxinidir}/docs/requirements.txt
+commands = {envbindir}/sphinx-build -v -W -d {toxinidir}/docs/_build/doctrees -b linkcheck docs docs/_build/linkcheck
+
 [testenv:codecov]
 basepython = python{env:TOXPYTHON:{env:TRAVIS_PYTHON_VERSION:3.8}}
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*


### PR DESCRIPTION
- `tox -e linkcheck`
- fix a few
- disable test on osx, fails.

```
    def test_keystroke_0s_raw_input_ctrl_c():
        """0-second keystroke with raw allows receiving ^C."""
        import pty
        pid, master_fd = pty.fork()
        if pid == 0:  # child
            cov = init_subproc_coverage('test_keystroke_0s_raw_input_ctrl_c')
            term = TestTerminal()
            read_until_semaphore(sys.__stdin__.fileno(), semaphore=SEMAPHORE)
            with term.raw():
                os.write(sys.__stdout__.fileno(), RECV_SEMAPHORE)
                inp = term.inkey(timeout=0)
                os.write(sys.__stdout__.fileno(), inp.encode('latin1'))
            if cov is not None:
                cov.stop()
                cov.save()
            os._exit(0)

        with echo_off(master_fd):
            os.write(master_fd, SEND_SEMAPHORE)
            # ensure child is in raw mode before sending ^C,
            read_until_semaphore(master_fd)
            time.sleep(0.05)
>           os.write(master_fd, u'\x03'.encode('latin1'))
E           OSError: [Errno 5] Input/output error

tests/test_full_keyboard.py:332: OSError
```