### PR TITLE
Optimize length

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ matrix:
          - python -m pip install tox
       env: PATH=/c/Python38:/c/Python38/Scripts:$PATH TOXENV=py38,codecov COVERAGE_ID=travis-ci TEST_KEYBOARD=no
 
-jobs:
   allow_failures:
     - python: 2.6
     - python: 3.9-dev

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -526,6 +526,7 @@ def test_padd():
         assert Sequence('xyz\b-', term).padd() == u'xy-'
         assert Sequence('xxxx\x1b[3Dzz', term).padd() == u'xzz'
         assert Sequence('\x1b[3D', term).padd() == u''  # "Trim left"
+        assert Sequence(term.red('xxxx\x1b[3Dzz'), term).padd() == term.red(u'xzz')
 
     kind = 'xterm-256color'
     if platform.system() == 'Windows':


### PR DESCRIPTION
Some minor optimizations for Sequence.length(). Should result in ~40% performance gain.

    >>> from timeit import timeit
    >>> 
    >>> setup = """\
    ... from blessed import Terminal
    ... from blessed.sequences import Sequence
    ... term = Terminal()
    ... msg = term.clear + term.red(u'コンニチハ')
    ... """
    >>> 
    >>> timeit('Sequence(msg, term).length()', setup=setup, number=100000)

Before optimizations:
    9.816482461988926

After optimizations:
    5.693301688996144

There are some smaller optimizations, but the main one is using `padd()` instead of `strip_seqs()`. `strip_seqs()` was essentially calling `padd()` and then dropping any caps, so now `padd()` can take a boolean to drop caps as it's iterating. That saves a layer of function calls and half the calls to `iter_parse()`.
