### PR TITLE
Include the whole doc folder in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include docs/*.rst
+graft docs
 include LICENSE
 include version.json
 include *.txt


### PR DESCRIPTION
Hi,
The current configuration is incomplete because a lot of doc files are
missing from PyPI, including conf.py.

It's weird because this had been fixed in blessings after https://github.com/erikrose/blessings/commit/af6b7b8773c2ff098bce112229913dee90928bfa

I am adding this package to Gentoo and we prefer relying on PyPI to fetch packages. Because of this issue, we will have to use GitHub's tarballs until this is fixed.