### PR TITLE
Fix sphinx build error on readthedocs.org

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 Pillow
-Sphinx
+Sphinx>3
 jinxed
 sphinx-paramlinks
 sphinx_rtd_theme


### PR DESCRIPTION
Problem
-------

RTD does "pip install --upgrade sphinx<2" (...), before "pip install -r docs/requirements.txt", which says "already satisfied" in regards to "Sphinx". But `sphinx_paramlinks` since 0.4.0, is only compatible with `Sphinx>3`,

this line, https://github.com/sqlalchemyorg/sphinx-paramlinks/commit/3fab7d0964722ccc60b13073d019cf73df16ae83#diff-abe84b8e411ab7bd367ad033685b2b5dR31

raises `KeyError` for Sphinx less than version 3.

Solution
--------
freeze dependencies, to ensure successful RTD builds again. Also, add myself for notifications from RTD so that I get e-mail notified next time!