### PR TITLE
Fix shift+arrow keys for tmux

### DIFF
--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -374,6 +374,10 @@ DEFAULT_SEQUENCE_MIXIN = (
     (u"\x1b[B", curses.KEY_DOWN),
     (u"\x1b[C", curses.KEY_RIGHT),
     (u"\x1b[D", curses.KEY_LEFT),
+    (u"\x1b[1;2A", curses.KEY_SR),
+    (u"\x1b[1;2B", curses.KEY_SF),
+    (u"\x1b[1;2C", curses.KEY_SRIGHT),
+    (u"\x1b[1;2D", curses.KEY_SLEFT),
     (u"\x1b[F", curses.KEY_END),
     (u"\x1b[H", curses.KEY_HOME),
     # not sure where these are from .. please report


### PR DESCRIPTION
Dear Maintainer
First off, I am new to github, so please forgive any mistakes on my part

This fixes a bug where blessed does not detect KEY_SUP, KEY_SDOWN, KEY_SLEFT and KEY_SRIGHT when it is running inside tmux.

It appears that this can alternatively be fixed by [reconfiguring tmux](https://unix.stackexchange.com/questions/24414/shift-arrow-not-working-in-emacs-within-tmux), but I believe it is better to implement this fix rather than leaving the user to figure out that they need to change their configuration.

Thank you for your work