### PR TITLE
Correct "bottom of the screen" example

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -169,7 +169,7 @@ The same program with *Blessed* is simply:
 
     term = Terminal()
     with term.location(0, term.height - 1):
-        print('This is ' + term.underline('underlined') + '!')
+        print('This is ' + term.underline('underlined') + '!', end='')
 
 .. _curses: https://docs.python.org/3/library/curses.html
 .. _tigetstr: http://man.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man3/tigetstr.3


### PR DESCRIPTION
Due to the line break emitted by the print statement the text doesn't appear at the bottom of the screen but one line above. Using end='' ensures the text appears at the bottom of the terminal window.

This took me a rather long time to figure out. :laughing: 