### PR TITLE
Use get_console_input_encoding for input encoding on Windows

### DIFF
--- a/blessed/_capabilities.py
+++ b/blessed/_capabilities.py
@@ -3,7 +3,6 @@
 import re
 from collections import OrderedDict
 
-
 __all__ = (
     'CAPABILITY_DATABASE',
     'CAPABILITIES_RAW_MIXIN',

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ ordereddict==1.1; python_version < "2.7"
 # support python2.7 by using backport of 'functools.lru_cache'
 backports.functools-lru-cache>=1.2.1; python_version < "3.2"
 # Windows requires jinxed
-jinxed>=0.5.4; platform_system == "Windows"
+jinxed>=1.1.0; platform_system == "Windows"

--- a/tox.ini
+++ b/tox.ini
@@ -95,6 +95,7 @@ deps = pytest==4.6.9
        pytest-cov==2.8.1
        pytest-xdist==1.31.0
        mock==3.0.5
+       attrs==20.3.0
 
 [testenv:py35]
 setenv = TEST_QUICK=1


### PR DESCRIPTION
This is to fix #202. Windows code pages are hard to detect in Python, so this will rely on the Windows API instead.

flake8_tests is failing, but it's unrelated and I think that's fixed in another pull request.
