### PR TITLE
Pin attrs version for py34

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -96,6 +96,7 @@ deps = pytest==4.6.9
        pytest-cov==2.8.1
        pytest-xdist==1.31.0
        mock==3.0.5
+       attrs==20.3.0
 
 [testenv:py35]
 setenv = TEST_QUICK=1


### PR DESCRIPTION
Pytest requitres attrs. attrs 21.1.0 broke compatibility for Python 3.4, but incompatibility wasn't set in the metadata until 21.2.0. Version 21.1.0 was "yanked" from PyPI, but is still getting pulled. Pinning to the last compatible version, 20.3.0, works around this problem.

This is the easiest fix. pypinfo reports only 265 downloads in the last month, likely mostly dependent package test builds. So, while it's more work to do it now, the next time we hit a blocker, we may want to look at dropping 3.4 or moving testing to allow_failures.


| python_version | download_count |
| -------------- | -------------- |
| 3.7            |        204,776 |
| 3.8            |        141,061 |
| 3.6            |        124,048 |
| 3.9            |         40,574 |
| 2.7            |         30,224 |
| 3.5            |         11,986 |
| 3.4            |            265 |
| 3.10           |            126 |
| 3.3            |             12 |
| Total          |        553,072 |

