### PR TITLE
Add a small sleep to prevent high CPU usage in kbhit

### DIFF
--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -1363,6 +1363,8 @@ class Terminal(object):
 
         Generally, this should be used inside the :meth:`raw` context manager.
 
+        On windows, a delay of 0.01 seconds is applied between detection of key presses.
+
         :arg float timeout: Number of seconds to wait for a keystroke before
             returning.  When ``None`` (default), this method may block
             indefinitely.

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -1363,8 +1363,6 @@ class Terminal(object):
 
         Generally, this should be used inside the :meth:`raw` context manager.
 
-        On windows, a delay of 0.01 seconds is applied between detection of key presses.
-
         :arg float timeout: Number of seconds to wait for a keystroke before
             returning.  When ``None`` (default), this method may block
             indefinitely.

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -1381,6 +1381,13 @@ class Terminal(object):
         .. note:: When used without the context manager :meth:`cbreak`, or
             :meth:`raw`, :obj:`sys.__stdin__` remains line-buffered, and this
             function will block until the return key is pressed!
+
+        .. note:: On Windows, a 10 ms sleep is added to the key press detection loop to reduce CPU
+            load. Due to the behavior of :py:func:`time.sleep` on Windows, this will actually
+            result in a 15.6 ms delay when using the default `time resolution
+            <https://docs.microsoft.com/en-us/windows/win32/api/timeapi/nf-timeapi-timebeginperiod>`_.
+            Decreasing the time resolution will reduce this to 10 ms, while increasing it, which
+            is rarely done, will have a perceptable impact on the behavior.
         """
         resolve = functools.partial(resolve_sequence,
                                     mapper=self._keymap,

--- a/blessed/win_terminal.py
+++ b/blessed/win_terminal.py
@@ -69,6 +69,7 @@ class Terminal(_Terminal):
             if timeout is not None and end < time.time():
                 break
 
+            # sleep for a bit to prevent the busy waiting consuming all CPU time
             time.sleep(0.01)
         return False
 

--- a/blessed/win_terminal.py
+++ b/blessed/win_terminal.py
@@ -69,6 +69,7 @@ class Terminal(_Terminal):
             if timeout is not None and end < time.time():
                 break
 
+            time.sleep(0.01)
         return False
 
     @staticmethod

--- a/blessed/win_terminal.py
+++ b/blessed/win_terminal.py
@@ -69,8 +69,7 @@ class Terminal(_Terminal):
             if timeout is not None and end < time.time():
                 break
 
-            # sleep for a bit to prevent the busy waiting consuming all CPU time
-            time.sleep(0.01)
+            time.sleep(0.01)  # Sleep to reduce CPU load
         return False
 
     @staticmethod


### PR DESCRIPTION
Closes: #208 

Adds a `0.01` sec sleepto the windows version of the kbhit method as discussed in the linked issue.

I don't know if this could be an issue with other terminal emulators, but on cmd, Windows Terminal and conemu, increasing the sleep to `0.015` started making the following test script choppy, where it needed a bit of time until the buffer was fully printed out after the key was released and had inconsistent delays between each key being available. However, with the current `0.01` sec sleep the script functions as expected. 
I'm wary of relying on small differences like these making the desired impact and I'm wondering if it is some sort of sweet spot, but it seemed to work fine with the mentioned terminals I had at hand.
```py
import blessed

term = blessed.Terminal()
fl = True
while True:
    with term.cbreak():
        k = term.inkey()
        print(repr(k) + "#" * 20 if fl else repr(k))
        fl = not fl
```