### PR TITLE
Prepare for 1.19.0

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,13 +12,11 @@ unsafe-load-any-extension = yes
 
 [MESSAGES CONTROL]
 disable=
-    I,
     fixme,
-    c-extension-no-member,
+    consider-using-f-string,  # Python 2
     raise-missing-from,  # Python 2
     redundant-u-string-prefix,  # Python 2
     super-with-arguments,  # Python 2
-    ungrouped-imports,
     useless-object-inheritance  # Python 2
 
 [FORMAT]

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -261,8 +261,7 @@ class Terminal(object):
         self._color_distance_algorithm = 'cie2000'
         if not self.does_styling:
             self.number_of_colors = 0
-        elif platform.system() == 'Windows' or (
-                os.environ.get('COLORTERM') in ('truecolor', '24bit')):
+        elif IS_WINDOWS or os.environ.get('COLORTERM') in ('truecolor', '24bit'):
             self.number_of_colors = 1 << 24
         else:
             self.number_of_colors = max(0, curses.tigetnum('colors') or -1)

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,8 +1,12 @@
+.. py:currentmodule:: blessed.terminal
+
 Version History
 ===============
 1.19
-  * Added :meth:`~Terminal.truncate` to truncate a string while
+  * introduced :meth:`~Terminal.truncate` to truncate a string while
     retaining the sequences, :ghissue:`211` by :ghuser:`fishermans-friend`
+  * enhancement: Add small sleep in :meth:`~Terminal.kbhit` on Windows
+    to reduce CPU load :ghissue:`209` by :ghuser:`numerlor`
 
 1.18
   * bugfix: :meth:`~Terminal.split_seqs` for some sequences

--- a/tests/accessories.py
+++ b/tests/accessories.py
@@ -16,6 +16,7 @@ import six
 
 # local
 from blessed import Terminal
+from .conftest import IS_WINDOWS
 
 try:
     from typing import Callable
@@ -23,15 +24,15 @@ except ImportError:  # py2
     pass
 
 
-if platform.system() != "Windows":
+if IS_WINDOWS:
+    import jinxed as curses
+else:
     import curses
     import pty
     import termios
-else:
-    import jinxed as curses
 
 
-test_kind = 'vtwin10' if platform.system() == 'Windows' else 'xterm-256color'
+test_kind = 'vtwin10' if IS_WINDOWS else 'xterm-256color'
 TestTerminal = functools.partial(Terminal, kind=test_kind)  # type: Callable[..., Terminal]
 SEND_SEMAPHORE = SEMAPHORE = b'SEMAPHORE\n'
 RECV_SEMAPHORE = b'SEMAPHORE\r\n'
@@ -61,7 +62,7 @@ class as_subprocess(object):  # pylint: disable=too-few-public-methods
         self.func = func
 
     def __call__(self, *args, **kwargs):  # pylint: disable=too-many-locals, too-complex
-        if platform.system() == 'Windows':
+        if IS_WINDOWS:
             self.func(*args, **kwargs)
             return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ import subprocess
 # 3rd party
 import pytest
 
+IS_WINDOWS = platform.system() == 'Windows'
+
 all_terms_params = 'xterm screen ansi vt220 rxvt cons25 linux'.split()
 many_lines_params = [40, 80]
 # we must test a '1' column for conditional in _handle_long_word
@@ -53,7 +55,7 @@ if TEST_FULL:
             .communicate()[0].splitlines()]
     except OSError:
         pass
-elif platform.system() == 'Windows':
+elif IS_WINDOWS:
     all_terms_params = ['vtwin10', ]
 elif TEST_QUICK:
     all_terms_params = 'xterm screen ansi linux'.split()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,6 +17,7 @@ from six.moves import reload_module
 
 # local
 from .accessories import TestTerminal, unicode_cap, as_subprocess
+from .conftest import IS_WINDOWS
 
 try:
     from unittest import mock
@@ -90,7 +91,7 @@ def test_null_fileno():
     child()
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="requires more than 1 tty")
+@pytest.mark.skipif(IS_WINDOWS, reason="requires more than 1 tty")
 def test_number_of_colors_without_tty():
     """``number_of_colors`` should return 0 when there's no tty."""
     @as_subprocess
@@ -123,7 +124,7 @@ def test_number_of_colors_without_tty():
     child_256_nostyle()
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="requires more than 1 tty")
+@pytest.mark.skipif(IS_WINDOWS, reason="requires more than 1 tty")
 def test_number_of_colors_with_tty():
     """test ``number_of_colors`` 0, 8, and 256."""
     @as_subprocess
@@ -294,7 +295,7 @@ def test_IOUnsupportedOperation():
     child()
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="has process-wide side-effects")
+@pytest.mark.skipif(IS_WINDOWS, reason="has process-wide side-effects")
 def test_winsize_IOError_returns_environ():
     """When _winsize raises IOError, defaults from os.environ given."""
     @as_subprocess
@@ -341,7 +342,7 @@ def test_yield_hidden_cursor(all_terms):
     child(all_terms)
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="windows doesn't work like this")
+@pytest.mark.skipif(IS_WINDOWS, reason="windows doesn't work like this")
 def test_no_preferredencoding_fallback():
     """Ensure empty preferredencoding value defaults to ascii."""
     @as_subprocess
@@ -354,7 +355,7 @@ def test_no_preferredencoding_fallback():
     child()
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="requires fcntl")
+@pytest.mark.skipif(IS_WINDOWS, reason="requires fcntl")
 def test_unknown_preferredencoding_warned_and_fallback():
     """Ensure a locale without a codec emits a warning."""
     @as_subprocess
@@ -370,7 +371,7 @@ def test_unknown_preferredencoding_warned_and_fallback():
     child()
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="requires fcntl")
+@pytest.mark.skipif(IS_WINDOWS, reason="requires fcntl")
 def test_win32_missing_tty_modules(monkeypatch):
     """Ensure dummy exception is used when io is without UnsupportedOperation."""
     @as_subprocess
@@ -447,7 +448,7 @@ def test_time_left_infinite_None():
     assert _time_left(stime=time.time(), timeout=None) is None
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="cant multiprocess")
+@pytest.mark.skipif(IS_WINDOWS, reason="cant multiprocess")
 def test_termcap_repr():
     """Ensure ``hidden_cursor()`` writes hide_cursor and normal_cursor."""
 

--- a/tests/test_full_keyboard.py
+++ b/tests/test_full_keyboard.py
@@ -23,7 +23,7 @@ from .accessories import (SEMAPHORE,
                           read_until_eof,
                           read_until_semaphore,
                           init_subproc_coverage)
-from.conftest import TEST_KEYBOARD, TEST_QUICK, TEST_RAW
+from.conftest import IS_WINDOWS, TEST_KEYBOARD, TEST_QUICK, TEST_RAW
 
 try:
     from unittest import mock
@@ -33,7 +33,7 @@ except ImportError:
 got_sigwinch = False
 
 pytestmark = pytest.mark.skipif(
-    not TEST_KEYBOARD or platform.system() == 'Windows',
+    not TEST_KEYBOARD or IS_WINDOWS,
     reason="Timing-sensitive tests please do not run on build farms.")
 
 

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -11,6 +11,7 @@ import pytest
 
 # local
 from .accessories import TestTerminal, as_subprocess
+from .conftest import IS_WINDOWS
 
 try:
     from unittest import mock
@@ -27,7 +28,7 @@ if sys.version_info[0] == 3:
     unichr = chr
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="?")
+@pytest.mark.skipif(IS_WINDOWS, reason="?")
 def test_break_input_no_kb():
     """cbreak() should not call tty.setcbreak() without keyboard."""
     @as_subprocess
@@ -41,7 +42,7 @@ def test_break_input_no_kb():
     child()
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="?")
+@pytest.mark.skipif(IS_WINDOWS, reason="?")
 def test_raw_input_no_kb():
     """raw should not call tty.setraw() without keyboard."""
     @as_subprocess
@@ -55,7 +56,7 @@ def test_raw_input_no_kb():
     child()
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="?")
+@pytest.mark.skipif(IS_WINDOWS, reason="?")
 def test_raw_input_with_kb():
     """raw should call tty.setraw() when with keyboard."""
     @as_subprocess
@@ -175,9 +176,7 @@ def test_get_keyboard_sequences_sort_order():
                 assert len(sequence) <= maxlen
             assert sequence
             maxlen = len(sequence)
-    kind = 'xterm-256color'
-    if platform.system() == 'Windows':
-        kind = 'vtwin10'
+    kind = 'vtwin10' if IS_WINDOWS else 'xterm-256color'
     child(kind)
 
 
@@ -292,7 +291,7 @@ def test_keyboard_prefixes():
     assert pfs == set([u'a', u'ab', u'abd', u'j', u'jk'])
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="no multiprocess")
+@pytest.mark.skipif(IS_WINDOWS, reason="no multiprocess")
 def test_keypad_mixins_and_aliases():  # pylint: disable=too-many-statements
     """Test PC-Style function key translations when in ``keypad`` mode."""
     # Key     plain   app     modified

--- a/tests/test_length_sequence.py
+++ b/tests/test_length_sequence.py
@@ -14,6 +14,7 @@ import pytest
 
 # local
 from .accessories import TestTerminal, as_subprocess
+from .conftest import IS_WINDOWS
 
 if platform.system() != 'Windows':
     import fcntl
@@ -54,9 +55,7 @@ def test_length_ansiart():
         assert term.length(lines[4]) == 78
         assert term.length(lines[5]) == 78
         assert term.length(lines[6]) == 77
-    kind = 'xterm-256color'
-    if platform.system() == 'Windows':
-        kind = 'vtwin10'
+    kind = 'vtwin10' if IS_WINDOWS else 'xterm-256color'
     child(kind)
 
 
@@ -327,7 +326,7 @@ def test_env_winsize():
     child()
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="requires fcntl")
+@pytest.mark.skipif(IS_WINDOWS, reason="requires fcntl")
 def test_winsize(many_lines, many_columns):
     """Test height and width is appropriately queried in a pty."""
     pixel_width, pixel_height = 1024, 768
@@ -373,7 +372,7 @@ def test_Sequence_alignment_fixed_width(all_terms):
     child(kind=all_terms)
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="requires fcntl")
+@pytest.mark.skipif(IS_WINDOWS, reason="requires fcntl")
 def test_Sequence_alignment(all_terms):
     """Tests methods related to Sequence class, namely ljust, rjust, center."""
     @as_subprocess

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -10,6 +10,7 @@ import pytest
 
 # local
 from .accessories import TestTerminal, unicode_cap, unicode_parm, as_subprocess, MockTigetstr
+from .conftest import IS_WINDOWS
 
 try:
     from unittest import mock
@@ -17,7 +18,7 @@ except ImportError:
     import mock
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="requires real tty")
+@pytest.mark.skipif(IS_WINDOWS, reason="requires real tty")
 def test_capability():
     """Check that capability lookup works."""
     @as_subprocess
@@ -197,7 +198,7 @@ def test_vertical_location(all_terms):
     child(all_terms)
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="requires multiprocess")
+@pytest.mark.skipif(IS_WINDOWS, reason="requires multiprocess")
 def test_inject_move_x():
     """Test injection of hpa attribute for screen/ansi (issue #55)."""
     @as_subprocess
@@ -219,7 +220,7 @@ def test_inject_move_x():
     child('ansi')
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="requires multiprocess")
+@pytest.mark.skipif(IS_WINDOWS, reason="requires multiprocess")
 def test_inject_move_y():
     """Test injection of vpa attribute for screen/ansi (issue #55)."""
     @as_subprocess
@@ -241,7 +242,7 @@ def test_inject_move_y():
     child('ansi')
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="requires multiprocess")
+@pytest.mark.skipif(IS_WINDOWS, reason="requires multiprocess")
 def test_inject_civis_and_cnorm_for_ansi():
     """Test injection of civis attribute for ansi."""
     @as_subprocess
@@ -255,7 +256,7 @@ def test_inject_civis_and_cnorm_for_ansi():
     child('ansi')
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="requires multiprocess")
+@pytest.mark.skipif(IS_WINDOWS, reason="requires multiprocess")
 def test_inject_sc_and_rc_for_ansi():
     """Test injection of sc and rc (save and restore cursor) for ansi."""
     @as_subprocess
@@ -526,10 +527,7 @@ def test_padd():
         assert Sequence('xxxx\x1b[3Dzz', term).padd() == u'xzz'
         assert Sequence('\x1b[3D', term).padd() == u''  # "Trim left"
         assert Sequence(term.red('xxxx\x1b[3Dzz'), term).padd() == term.red(u'xzz')
-
-    kind = 'xterm-256color'
-    if platform.system() == 'Windows':
-        kind = 'vtwin10'
+    kind = 'vtwin10' if IS_WINDOWS else 'xterm-256color'
     child(kind)
 
 


### PR DESCRIPTION
- Consolidated number of times we check `platform.system() == 'Windows'`
- Updated history.rst
  - Set current module so `Terminal` refs work
  - Add entry for windows sleep in `kbhit()`

Once done, I think we need to push 1.19.0. There seems to be an issue with 1.18.1, https://github.com/jquast/blessed/issues/202#issuecomment-913857952
