### PR TITLE
Fix metadata formatting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.9',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: User Interfaces',
-        'Topic :: Terminals'
+        'Topic :: Terminals',
         'Typing :: Typed',
     ],
     keywords=['terminal', 'sequences', 'tty', 'curses', 'ncurses',


### PR DESCRIPTION
Blocker for releasing 1.19.0
PyPI rejected upload because of unknown classifiers.
Should have caught this in 1.18.1, but I think I messed that one up by building from the wrong branch
