### PR TITLE
Pin apipkg for 3.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,7 @@ deps =
     pytest-cov==2.8.1
     pytest-xdist==1.31.0
     attrs==20.3.0
+    apipkg==2.0.1
 
 
 ####### Linting and Formatting Environments #######


### PR DESCRIPTION
apipkg 2.1.0 breaks on Python 3.4, so pinning to 2.0.1. I put in a [bug](https://github.com/pytest-dev/apipkg/issues/29) for it since 3.4 is specifically called out in their readme. Not sure if they will fix or change the readme, so pinning makes the most sense for now.