### PR TITLE
Fix global variable declarations in formatters.pyi

### DIFF
--- a/blessed/formatters.pyi
+++ b/blessed/formatters.pyi
@@ -14,8 +14,8 @@ from typing import (Any,
 # local
 from .terminal import Terminal
 
-COLORS = Set[str]
-COMPOUNDABLES = Set[str]
+COLORS: Set[str]
+COMPOUNDABLES: Set[str]
 
 _T = TypeVar("_T")
 


### PR DESCRIPTION
Convert aliases into type annotations, as was intended.

This needs some work to prove it out, since apparently mypy isn't cross-checking the py and pyi files, or it would have caught this?