### PR TITLE
Fixes for Pylint 2.14 and minor tweaks

### DIFF
--- a/bin/cnn.py
+++ b/bin/cnn.py
@@ -42,7 +42,7 @@ def main():
         'subsequent_indent': (' ' * (term.width // 6)) + ' ' * 2,
     }
     for a_href in find_articles(soup):
-        url_id = int(random.randrange(0, 1 << 24))
+        url_id = random.randrange(0, 1 << 24)
         for line in term.wrap(make_bold(term, a_href.text), **textwrap_kwargs):
             print(whitespace_only(term, line), end='')
             print(term.link(cnn_url + a_href.get('href'), line.lstrip(), url_id))

--- a/bin/detect-multibyte.py
+++ b/bin/detect-multibyte.py
@@ -77,7 +77,7 @@ def main():
 
         # determine distance
         horizontal_distance = pos1.column - pos0.column
-        multibyte_capable = bool(horizontal_distance == 1)
+        multibyte_capable = horizontal_distance == 1
 
         # rubout character(s)
         print('\b \b' * horizontal_distance, end='')

--- a/bin/editor.py
+++ b/bin/editor.py
@@ -117,11 +117,11 @@ def redraw(term, screen, start=None, end=None):
     """Redraw the screen."""
     if start is None and end is None:
         echo(term.clear)
-        start, end = (Cursor(y=min([y for (y, x) in screen or [(0, 0)]]),
-                             x=min([x for (y, x) in screen or [(0, 0)]]),
+        start, end = (Cursor(y=min(y for (y, x) in screen or [(0, 0)]),
+                             x=min(x for (y, x) in screen or [(0, 0)]),
                              term=term),
-                      Cursor(y=max([y for (y, x) in screen or [(0, 0)]]),
-                             x=max([x for (y, x) in screen or [(0, 0)]]),
+                      Cursor(y=max(y for (y, x) in screen or [(0, 0)]),
+                             x=max(x for (y, x) in screen or [(0, 0)]),
                              term=term))
     lastcol, lastrow = -1, -1
     for row, col in sorted(screen):

--- a/bin/plasma.py
+++ b/bin/plasma.py
@@ -106,7 +106,7 @@ def main(term):
             if pause:
                 show_paused(term)
 
-            inp = term.inkey(timeout=0.01 if not pause else None)
+            inp = term.inkey(timeout=None if pause else 0.01)
             if inp == '?':
                 assert False, "don't panic"
             elif inp == '\x0c':

--- a/bin/worms.py
+++ b/bin/worms.py
@@ -141,16 +141,12 @@ def next_wormlength(nibble, head, worm_length):
 
 def next_speed(nibble, head, speed, modifier):
     """Return new speed if current nibble is hit."""
-    if hit(head, nibble.location):
-        return speed * modifier
-    return speed
+    return speed * modifier if hit(head, nibble.location) else speed
 
 
 def head_glyph(direction):
     """Return character for worm head depending on horiz/vert orientation."""
-    if direction in (left_of, right_of):
-        return u':'
-    return u'"'
+    return u':' if direction in (left_of, right_of) else u'"'
 
 
 def next_nibble(term, nibble, head, worm):

--- a/blessed/colorspace.py
+++ b/blessed/colorspace.py
@@ -11,6 +11,7 @@ References,
 - https://devblogs.microsoft.com/commandline/24-bit-color-in-the-windows-console/
 - http://jdebp.uk/Softwares/nosh/guide/TerminalCapabilities.html
 """
+
 # std imports
 import collections
 
@@ -21,8 +22,7 @@ __all__ = (
     'X11_COLORNAMES_TO_RGB',
 )
 
-CGA_COLORS = set(
-    ('black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'))
+CGA_COLORS = {'black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'}
 
 
 class RGBColor(collections.namedtuple("RGBColor", ["red", "green", "blue"])):

--- a/blessed/formatters.py
+++ b/blessed/formatters.py
@@ -270,9 +270,7 @@ class FormattingOtherString(six.text_type):
 
     def __call__(self, *args):
         """Return ``text`` by ``target``."""
-        if args:
-            return self._callable(*args)
-        return self
+        return self._callable(*args) if args else self
 
 
 class NullCallableString(six.text_type):

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -71,14 +71,14 @@ class Termcap(object):
             'cursor_right': 1,
             'tab': 8,
             'ascii_tab': 8,
-        }.get(self.name, None)
+        }.get(self.name)
         if value is not None:
             return value
 
         unit = {
             'parm_left_cursor': -1,
             'parm_right_cursor': 1
-        }.get(self.name, None)
+        }.get(self.name)
         if unit is not None:
             value = int(self.re_compiled.match(text).group(1))
             return unit * value

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -273,7 +273,7 @@ class Sequence(six.text_type):
         :rtype: str
         """
         rightside = fillchar * int(
-            (max(0.0, float(width.__index__() - self.length()))) / float(len(fillchar)))
+            (max(0.0, float(int(width) - self.length()))) / float(len(fillchar)))
         return u''.join((self, rightside))
 
     def rjust(self, width, fillchar=u' '):
@@ -287,7 +287,7 @@ class Sequence(six.text_type):
         :rtype: str
         """
         leftside = fillchar * int(
-            (max(0.0, float(width.__index__() - self.length()))) / float(len(fillchar)))
+            (max(0.0, float(int(width) - self.length()))) / float(len(fillchar)))
         return u''.join((leftside, self))
 
     def center(self, width, fillchar=u' '):
@@ -300,7 +300,7 @@ class Sequence(six.text_type):
         :returns: String of ``text``, centered by ``width``.
         :rtype: str
         """
-        split = max(0.0, float(width.__index__()) - self.length()) / 2
+        split = max(0.0, float(int(width)) - self.length()) / 2
         leftside = fillchar * int(
             (max(0.0, math.floor(split))) / float(len(fillchar)))
         rightside = fillchar * int(
@@ -321,7 +321,7 @@ class Sequence(six.text_type):
         """
         output = ""
         current_width = 0
-        target_width = width.__index__()
+        target_width = int(width)
         parsed_seq = iter_parse(self._term, self.padd())
 
         # Retain all text until non-cap width reaches desired width

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -585,7 +585,6 @@ class Terminal(object):
             ...
             >>> assert given_x == result_x, (given_x, result_x)
             >>> assert given_y == result_y, (given_y, result_y)
-
         """
         # Local lines attached by termios and remote login protocols such as
         # ssh and telnet both provide a means to determine the window

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -766,10 +766,10 @@ class Terminal(object):
         This should not be used directly, but rather a specific color by name or
         :meth:`~.Terminal.color_rgb` value.
         """
-        if not self.does_styling:
-            return NullCallableString()
-        return ParameterizingString(self._foreground_color,
-                                    self.normal, 'color')
+        if self.does_styling:
+            return ParameterizingString(self._foreground_color, self.normal, 'color')
+
+        return NullCallableString()
 
     def color_rgb(self, red, green, blue):
         """
@@ -800,10 +800,10 @@ class Terminal(object):
 
         :rtype: ParameterizingString
         """
-        if not self.does_styling:
-            return NullCallableString()
-        return ParameterizingString(self._background_color,
-                                    self.normal, 'on_color')
+        if self.does_styling:
+            return ParameterizingString(self._background_color, self.normal, 'on_color')
+
+        return NullCallableString()
 
     def on_color_rgb(self, red, green, blue):
         """

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -25,7 +25,7 @@ else:
 def fn_tparm(*args):
     """Mock tparm function"""
     return u'~'.join(
-        '%s' % (arg,) if num else arg.decode('latin1') for num, arg in enumerate(args)
+        str(arg) if num else arg.decode('latin1') for num, arg in enumerate(args)
     ).encode('latin1')
 
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -25,8 +25,7 @@ else:
 def fn_tparm(*args):
     """Mock tparm function"""
     return u'~'.join(
-        arg.decode('latin1') if not num else '%s' % (arg,)
-        for num, arg in enumerate(args)
+        '%s' % (arg,) if num else arg.decode('latin1') for num, arg in enumerate(args)
     ).encode('latin1')
 
 

--- a/tests/test_full_keyboard.py
+++ b/tests/test_full_keyboard.py
@@ -23,7 +23,7 @@ from .accessories import (SEMAPHORE,
                           read_until_eof,
                           read_until_semaphore,
                           init_subproc_coverage)
-from.conftest import IS_WINDOWS, TEST_KEYBOARD, TEST_QUICK, TEST_RAW
+from .conftest import IS_WINDOWS, TEST_KEYBOARD, TEST_QUICK, TEST_RAW
 
 try:
     from unittest import mock

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -93,8 +93,8 @@ def test_keystroke_default_args():
     assert ks.code == ks._code
     assert u'x' + ks == u'x'
     assert not ks.is_sequence
-    assert repr(ks) in ("u''",  # py26, 27
-                        "''",)  # py33
+    assert repr(ks) in {"u''",  # py26, 27
+                        "''",}  # py33
 
 
 def test_a_keystroke():
@@ -244,43 +244,43 @@ def test_resolve_sequence():
     assert ks.name is None
     assert ks.code is None
     assert not ks.is_sequence
-    assert repr(ks) in ("u''",  # py26, 27
-                        "''",)  # py33
+    assert repr(ks) in {"u''",  # py26, 27
+                        "''",}  # py33
 
     ks = resolve_sequence(u'notfound', mapper=mapper, codes=codes)
     assert ks == u'n'
     assert ks.name is None
     assert ks.code is None
     assert not ks.is_sequence
-    assert repr(ks) in (u"u'n'", "'n'",)
+    assert repr(ks) in {u"u'n'", "'n'",}
 
     ks = resolve_sequence(u'SEQ1', mapper, codes)
     assert ks == u'SEQ1'
     assert ks.name == u'KEY_SEQ1'
     assert ks.code == 1
     assert ks.is_sequence
-    assert repr(ks) in (u"KEY_SEQ1", "KEY_SEQ1")
+    assert repr(ks) in {u"KEY_SEQ1", "KEY_SEQ1"}
 
     ks = resolve_sequence(u'LONGSEQ_longer', mapper, codes)
     assert ks == u'LONGSEQ'
     assert ks.name == u'KEY_LONGSEQ'
     assert ks.code == 4
     assert ks.is_sequence
-    assert repr(ks) in (u"KEY_LONGSEQ", "KEY_LONGSEQ")
+    assert repr(ks) in {u"KEY_LONGSEQ", "KEY_LONGSEQ"}
 
     ks = resolve_sequence(u'LONGSEQ', mapper, codes)
     assert ks == u'LONGSEQ'
     assert ks.name == u'KEY_LONGSEQ'
     assert ks.code == 4
     assert ks.is_sequence
-    assert repr(ks) in (u"KEY_LONGSEQ", "KEY_LONGSEQ")
+    assert repr(ks) in {u"KEY_LONGSEQ", "KEY_LONGSEQ"}
 
     ks = resolve_sequence(u'Lxxxxx', mapper, codes)
     assert ks == u'L'
     assert ks.name == u'KEY_L'
     assert ks.code == 6
     assert ks.is_sequence
-    assert repr(ks) in (u"KEY_L", "KEY_L")
+    assert repr(ks) in {u"KEY_L", "KEY_L"}
 
 
 def test_keyboard_prefixes():

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -288,7 +288,7 @@ def test_keyboard_prefixes():
     from blessed.keyboard import get_leading_prefixes
     keys = ['abc', 'abdf', 'e', 'jkl']
     pfs = get_leading_prefixes(keys)
-    assert pfs == set([u'a', u'ab', u'abd', u'j', u'jk'])
+    assert pfs == {u'a', u'ab', u'abd', u'j', u'jk'}
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="no multiprocess")

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -94,7 +94,7 @@ def test_keystroke_default_args():
     assert u'x' + ks == u'x'
     assert not ks.is_sequence
     assert repr(ks) in {"u''",  # py26, 27
-                        "''",}  # py33
+                        "''"}  # py33
 
 
 def test_a_keystroke():
@@ -245,42 +245,42 @@ def test_resolve_sequence():
     assert ks.code is None
     assert not ks.is_sequence
     assert repr(ks) in {"u''",  # py26, 27
-                        "''",}  # py33
+                        "''"}  # py33
 
     ks = resolve_sequence(u'notfound', mapper=mapper, codes=codes)
     assert ks == u'n'
     assert ks.name is None
     assert ks.code is None
     assert not ks.is_sequence
-    assert repr(ks) in {u"u'n'", "'n'",}
+    assert repr(ks) in {u"u'n'", "'n'"}
 
     ks = resolve_sequence(u'SEQ1', mapper, codes)
     assert ks == u'SEQ1'
     assert ks.name == u'KEY_SEQ1'
     assert ks.code == 1
     assert ks.is_sequence
-    assert repr(ks) in {u"KEY_SEQ1", "KEY_SEQ1"}
+    assert repr(ks) == u"KEY_SEQ1"
 
     ks = resolve_sequence(u'LONGSEQ_longer', mapper, codes)
     assert ks == u'LONGSEQ'
     assert ks.name == u'KEY_LONGSEQ'
     assert ks.code == 4
     assert ks.is_sequence
-    assert repr(ks) in {u"KEY_LONGSEQ", "KEY_LONGSEQ"}
+    assert repr(ks) == u"KEY_LONGSEQ"
 
     ks = resolve_sequence(u'LONGSEQ', mapper, codes)
     assert ks == u'LONGSEQ'
     assert ks.name == u'KEY_LONGSEQ'
     assert ks.code == 4
     assert ks.is_sequence
-    assert repr(ks) in {u"KEY_LONGSEQ", "KEY_LONGSEQ"}
+    assert repr(ks) == u"KEY_LONGSEQ"
 
     ks = resolve_sequence(u'Lxxxxx', mapper, codes)
     assert ks == u'L'
     assert ks.name == u'KEY_L'
     assert ks.code == 6
     assert ks.is_sequence
-    assert repr(ks) in {u"KEY_L", "KEY_L"}
+    assert repr(ks) == u"KEY_L"
 
 
 def test_keyboard_prefixes():

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -506,7 +506,7 @@ def test_null_callable_string(all_terms):
     def child(kind):
         t = TestTerminal(stream=six.StringIO(), kind=kind)
         assert (t.clear == '')
-        assert (t.move(1 == 2) == '')
+        assert (t.move(False) == '')
         assert (t.move_x(1) == '')
         assert (t.bold() == '')
         assert (t.bold('', 'x', 'huh?') == 'xhuh?')
@@ -730,6 +730,7 @@ def test_truncate_default(all_terms):
     child(all_terms)
 
 
+@pytest.mark.skipif(sys.version_info[:2] < (3, 8), reason="Only supported on Python >= 3.8")
 def test_supports_index(all_terms):
     """Ensure sequence formatting methods support objects with __index__()"""
 

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -8,7 +8,7 @@ import pytest
 
 # local
 from .accessories import TestTerminal, as_subprocess
-from.conftest import TEST_QUICK
+from .conftest import TEST_QUICK
 
 TEXTWRAP_KEYWORD_COMBINATIONS = [
     dict(break_long_words=False,


### PR DESCRIPTION
**Pylint 2.14**
The main thing here is changing `width.__index__()` to `int(width)`. Pylint complained about the use of a dunder method and as I dug into it, using `int()` is more correct since it will support all the magic methods for coercion to an integer (`__int__()`, `__trunc__()`, etc). The test is explicitly for `__index__()` which exists in older Python versions, but is not invoked by `int()` until 3.8, so I limited the test to newer versions.

**Code Tweaks**
Pretty much all of these are getting rid of redundant syntax
- `{...}` instead of `set([...])` 
- `if cond` instead of `if not cond`
- `dict.get(item)` instead of `dict.get(item, None)`
