### PR TITLE
Drop python2 support

### DIFF
--- a/blessed/formatters.py
+++ b/blessed/formatters.py
@@ -2,9 +2,6 @@
 # std imports
 import platform
 
-# 3rd party
-import six
-
 # local
 from blessed.colorspace import CGA_COLORS, X11_COLORNAMES_TO_RGB
 
@@ -48,7 +45,7 @@ COLORS = _make_colors()
 COMPOUNDABLES = set('bold underline reverse blink italic standout'.split())
 
 
-class ParameterizingString(six.text_type):
+class ParameterizingString(str):
     r"""
     A Unicode string which can be called as a parameterizing termcap.
 
@@ -70,7 +67,7 @@ class ParameterizingString(six.text_type):
         :arg str normal: terminating sequence for this capability (optional).
         :arg str name: name of this terminal capability (optional).
         """
-        new = six.text_type.__new__(cls, cap)
+        new = str.__new__(cls, cap)
         new._normal = normal
         new._name = name
         return new
@@ -97,7 +94,7 @@ class ParameterizingString(six.text_type):
         except TypeError as err:
             # If the first non-int (i.e. incorrect) arg was a string, suggest
             # something intelligent:
-            if args and isinstance(args[0], six.string_types):
+            if args and isinstance(args[0], str):
                 raise TypeError(
                     "Unknown terminal capability, %r, or, TypeError "
                     "for arguments %r: %s" % (self._name, args, err))
@@ -108,12 +105,12 @@ class ParameterizingString(six.text_type):
             # ignore 'tparm() returned NULL', you won't get any styling,
             # even if does_styling is True. This happens on win32 platforms
             # with http://www.lfd.uci.edu/~gohlke/pythonlibs/#curses installed
-            if "tparm() returned NULL" not in six.text_type(err):
+            if "tparm() returned NULL" not in str(err):
                 raise
             return NullCallableString()
 
 
-class ParameterizingProxyString(six.text_type):
+class ParameterizingProxyString(str):
     r"""
     A Unicode string which can be called to proxy missing termcap entries.
 
@@ -150,7 +147,7 @@ class ParameterizingProxyString(six.text_type):
         """
         assert isinstance(fmt_pair, tuple), fmt_pair
         assert callable(fmt_pair[1]), fmt_pair[1]
-        new = six.text_type.__new__(cls, fmt_pair[0])
+        new = str.__new__(cls, fmt_pair[0])
         new._fmt_args = fmt_pair[1]
         new._normal = normal
         new._name = name
@@ -172,7 +169,7 @@ class ParameterizingProxyString(six.text_type):
                                 self._normal)
 
 
-class FormattingString(six.text_type):
+class FormattingString(str):
     r"""
     A Unicode string which doubles as a callable.
 
@@ -199,7 +196,7 @@ class FormattingString(six.text_type):
         :arg str sequence: terminal attribute sequence.
         :arg str normal: terminating sequence for this attribute (optional).
         """
-        new = six.text_type.__new__(cls, sequence)
+        new = str.__new__(cls, sequence)
         new._normal = normal
         return new
 
@@ -217,8 +214,8 @@ class FormattingString(six.text_type):
         #
         # >>> t.red('This is ', t.bold('extremely'), ' dangerous!')
         for idx, ucs_part in enumerate(args):
-            if not isinstance(ucs_part, six.string_types):
-                expected_types = ', '.join(_type.__name__ for _type in six.string_types)
+            if not isinstance(ucs_part, str):
+                expected_types = str.__name__
                 raise TypeError(
                     "TypeError for FormattingString argument, "
                     "%r, at position %s: expected type %s, "
@@ -234,7 +231,7 @@ class FormattingString(six.text_type):
         return self + u''.join(args) + postfix
 
 
-class FormattingOtherString(six.text_type):
+class FormattingOtherString(str):
     r"""
     A Unicode string which doubles as a callable for another sequence when called.
 
@@ -260,20 +257,20 @@ class FormattingOtherString(six.text_type):
         :arg str direct: capability name for direct formatting, eg ``('x' + term.right)``.
         :arg str target: capability name for callable, eg ``('x' + term.right(99))``.
         """
-        new = six.text_type.__new__(cls, direct)
+        new = str.__new__(cls, direct)
         new._callable = target
         return new
 
     def __getnewargs__(self):
         # return arguments used for the __new__ method upon unpickling.
-        return six.text_type.__new__(six.text_type, self), self._callable
+        return str.__new__(str, self), self._callable
 
     def __call__(self, *args):
         """Return ``text`` by ``target``."""
         return self._callable(*args) if args else self
 
 
-class NullCallableString(six.text_type):
+class NullCallableString(str):
     """
     A dummy callable Unicode alternative to :class:`FormattingString`.
 
@@ -283,7 +280,7 @@ class NullCallableString(six.text_type):
 
     def __new__(cls):
         """Class constructor."""
-        return six.text_type.__new__(cls, u'')
+        return str.__new__(cls, u'')
 
     def __call__(self, *args):
         """

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -6,9 +6,6 @@ import time
 import platform
 from collections import OrderedDict
 
-# 3rd party
-import six
-
 # isort: off
 # curses
 if platform.system() == 'Windows':
@@ -20,7 +17,7 @@ else:
     from curses.has_key import _capability_names as capability_names
 
 
-class Keystroke(six.text_type):
+class Keystroke(str):
     """
     A unicode-derived class for describing a single keystroke.
 
@@ -41,7 +38,7 @@ class Keystroke(six.text_type):
 
     def __new__(cls, ucs='', code=None, name=None):
         """Class constructor."""
-        new = six.text_type.__new__(cls, ucs)
+        new = str.__new__(cls, ucs)
         new._name = name
         new._code = code
         return new
@@ -53,9 +50,9 @@ class Keystroke(six.text_type):
 
     def __repr__(self):
         """Docstring overwritten."""
-        return (six.text_type.__repr__(self) if self._name is None else
+        return (str.__repr__(self) if self._name is None else
                 self._name)
-    __repr__.__doc__ = six.text_type.__doc__
+    __repr__.__doc__ = str.__doc__
 
     @property
     def name(self):
@@ -358,12 +355,12 @@ for keycode_name in _CURSES_KEYCODE_ADDINS:
 DEFAULT_SEQUENCE_MIXIN = (
     # these common control characters (and 127, ctrl+'?') mapped to
     # an application key definition.
-    (six.unichr(10), curses.KEY_ENTER),
-    (six.unichr(13), curses.KEY_ENTER),
-    (six.unichr(8), curses.KEY_BACKSPACE),
-    (six.unichr(9), KEY_TAB),  # noqa  # pylint: disable=undefined-variable
-    (six.unichr(27), curses.KEY_EXIT),
-    (six.unichr(127), curses.KEY_BACKSPACE),
+    (chr(10), curses.KEY_ENTER),
+    (chr(13), curses.KEY_ENTER),
+    (chr(8), curses.KEY_BACKSPACE),
+    (chr(9), KEY_TAB),  # noqa  # pylint: disable=undefined-variable
+    (chr(27), curses.KEY_EXIT),
+    (chr(127), curses.KEY_BACKSPACE),
 
     (u"\x1b[A", curses.KEY_UP),
     (u"\x1b[B", curses.KEY_DOWN),

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -6,7 +6,6 @@ import math
 import textwrap
 
 # 3rd party
-import six
 from wcwidth import wcwidth
 
 # local
@@ -241,7 +240,7 @@ class SequenceTextWrapper(textwrap.TextWrapper):
 SequenceTextWrapper.__doc__ = textwrap.TextWrapper.__doc__
 
 
-class Sequence(six.text_type):
+class Sequence(str):
     """
     A "sequence-aware" version of the base :class:`str` class.
 
@@ -258,7 +257,7 @@ class Sequence(six.text_type):
         :arg str sequence_text: A string that may contain sequences.
         :arg blessed.Terminal term: :class:`~.Terminal` instance.
         """
-        new = six.text_type.__new__(cls, sequence_text)
+        new = str.__new__(cls, sequence_text)
         new._term = term
         return new
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 wcwidth>=0.1.4
-six>=1.9.0
 # support python2.6 by using backport of 'orderedict'
 ordereddict==1.1; python_version < "2.7"
 # support python2.7 by using backport of 'functools.lru_cache'

--- a/setup.py
+++ b/setup.py
@@ -66,8 +66,6 @@ setuptools.setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX',
         'Operating System :: Microsoft :: Windows',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tests/accessories.py
+++ b/tests/accessories.py
@@ -11,9 +11,6 @@ import functools
 import traceback
 import contextlib
 
-# 3rd party
-import six
-
 # local
 from blessed import Terminal
 from .conftest import IS_WINDOWS
@@ -106,7 +103,7 @@ class as_subprocess(object):  # pylint: disable=too-few-public-methods
                   .format(pid_testrunner, os.getpid()), file=sys.stderr)
             os._exit(1)
 
-        exc_output = six.text_type()
+        exc_output = str()
         decoder = codecs.getincrementaldecoder(self.encoding)()
         while True:
             try:
@@ -146,7 +143,7 @@ def read_until_semaphore(fd, semaphore=RECV_SEMAPHORE, encoding='utf8'):
     # process will read xyz\\r\\n -- this is how pseudo terminals
     # behave; a virtual terminal requires both carriage return and
     # line feed, it is only for convenience that \\n does both.
-    outp = six.text_type()
+    outp = str()
     decoder = codecs.getincrementaldecoder(encoding)()
     semaphore = semaphore.decode('ascii')
     while not outp.startswith(semaphore):
@@ -170,7 +167,7 @@ def read_until_eof(fd, encoding='utf8'):
     Return decoded string.
     """
     decoder = codecs.getincrementaldecoder(encoding)()
-    outp = six.text_type()
+    outp = str()
     while True:
         try:
             _exc = os.read(fd, 100)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@
 """Core blessed Terminal() tests."""
 
 # std imports
+from importlib import reload as reload_module
 import io
 import os
 import sys
@@ -11,9 +12,7 @@ import platform
 import warnings
 
 # 3rd party
-import six
 import pytest
-from six.moves import reload_module
 
 # local
 from .accessories import TestTerminal, unicode_cap, as_subprocess
@@ -35,7 +34,7 @@ def test_null_location(all_terms):
     """Make sure ``location()`` with no args just does position restoration."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(stream=io.StringIO(), force_styling=True)
         with t.location():
             pass
         expected_output = u''.join(
@@ -49,7 +48,7 @@ def test_location_to_move_xy(all_terms):
     """``location()`` and ``move_xy()`` receive complimentary arguments."""
     @as_subprocess
     def child(kind):
-        buf = six.StringIO()
+        buf = io.StringIO()
         t = TestTerminal(stream=buf, force_styling=True)
         x, y = 12, 34
         with t.location(y, x):
@@ -65,7 +64,7 @@ def test_yield_keypad():
     @as_subprocess
     def child(kind):
         # given,
-        t = TestTerminal(stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(stream=io.StringIO(), force_styling=True)
         expected_output = u''.join((t.smkx, t.rmkx))
 
         # exercise,
@@ -83,7 +82,7 @@ def test_null_fileno():
     @as_subprocess
     def child():
         # This simulates piping output to another program.
-        out = six.StringIO()
+        out = io.StringIO()
         out.fileno = None
         t = TestTerminal(stream=out)
         assert (t.save == u'')
@@ -96,25 +95,25 @@ def test_number_of_colors_without_tty():
     """``number_of_colors`` should return 0 when there's no tty."""
     @as_subprocess
     def child_256_nostyle():
-        t = TestTerminal(stream=six.StringIO())
+        t = TestTerminal(stream=io.StringIO())
         assert (t.number_of_colors == 0)
 
     @as_subprocess
     def child_256_forcestyle():
-        t = TestTerminal(stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(stream=io.StringIO(), force_styling=True)
         assert (t.number_of_colors == 256)
 
     @as_subprocess
     def child_8_forcestyle():
         # 'ansi' on freebsd returns 0 colors. We use 'cons25', compatible with its kernel tty.c
         kind = 'cons25' if platform.system().lower() == 'freebsd' else 'ansi'
-        t = TestTerminal(kind=kind, stream=six.StringIO(),
+        t = TestTerminal(kind=kind, stream=io.StringIO(),
                          force_styling=True)
         assert (t.number_of_colors == 8)
 
     @as_subprocess
     def child_0_forcestyle():
-        t = TestTerminal(kind='vt220', stream=six.StringIO(),
+        t = TestTerminal(kind='vt220', stream=io.StringIO(),
                          force_styling=True)
         assert (t.number_of_colors == 0)
 
@@ -153,7 +152,7 @@ def test_init_descriptor_always_initted(all_terms):
     """Test height and width with non-tty Terminals."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO())
+        t = TestTerminal(kind=kind, stream=io.StringIO())
         assert t._init_descriptor == sys.__stdout__.fileno()
         assert (isinstance(t.height, int))
         assert (isinstance(t.width, int))
@@ -316,7 +315,7 @@ def test_yield_fullscreen(all_terms):
     """Ensure ``fullscreen()`` writes enter_fullscreen and exit_fullscreen."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(stream=io.StringIO(), force_styling=True)
         t.enter_fullscreen = u'BEGIN'
         t.exit_fullscreen = u'END'
         with t.fullscreen():
@@ -331,7 +330,7 @@ def test_yield_hidden_cursor(all_terms):
     """Ensure ``hidden_cursor()`` writes hide_cursor and normal_cursor."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(stream=io.StringIO(), force_styling=True)
         t.hide_cursor = u'BEGIN'
         t.normal_cursor = u'END'
         with t.hidden_cursor():

--- a/tests/test_full_keyboard.py
+++ b/tests/test_full_keyboard.py
@@ -2,6 +2,7 @@
 """Tests for capturing keyboard input"""
 
 # std imports
+import io
 import os
 import sys
 import math
@@ -10,7 +11,6 @@ import signal
 import platform
 
 # 3rd party
-import six
 import pytest
 
 # local
@@ -136,7 +136,7 @@ def test_kbhit_no_kb():
     """kbhit() always immediately returns False without a keyboard."""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=io.StringIO())
         stime = time.time()
         assert term._keyboard_fd is None
         assert not term.kbhit(timeout=1.1)
@@ -149,7 +149,7 @@ def test_kbhit_no_tty():
     @as_subprocess
     def child():
         with mock.patch('blessed.terminal.HAS_TTY', False):
-            term = TestTerminal(stream=six.StringIO())
+            term = TestTerminal(stream=io.StringIO())
             stime = time.time()
             assert term.kbhit(timeout=1.1) is False
             assert math.floor(time.time() - stime) == 0
@@ -173,7 +173,7 @@ def test_keystroke_0s_cbreak_noinput_nokb():
     """0-second keystroke without data in input stream and no keyboard/tty."""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=io.StringIO())
         with term.cbreak():
             stime = time.time()
             inp = term.inkey(timeout=0)
@@ -201,7 +201,7 @@ def test_keystroke_1s_cbreak_noinput_nokb():
     """1-second keystroke without input or keyboard."""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=io.StringIO())
         with term.cbreak():
             stime = time.time()
             inp = term.inkey(timeout=1)
@@ -582,7 +582,7 @@ def test_get_location_0s():
     """0-second get_location call without response."""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=io.StringIO())
         stime = time.time()
         y, x = term.get_location(timeout=0)
         assert (math.floor(time.time() - stime) == 0.0)
@@ -650,7 +650,7 @@ def test_get_location_0s_reply_via_ungetch():
     """0-second get_location call with response."""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=io.StringIO())
         stime = time.time()
         # monkey patch in an invalid response !
         term.ungetch(u'\x1b[10;10R')
@@ -667,7 +667,7 @@ def test_get_location_0s_nonstandard_u6():
 
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=io.StringIO())
 
         stime = time.time()
         # monkey patch in an invalid response !
@@ -685,12 +685,12 @@ def test_get_location_styling_indifferent():
     """Ensure get_location() behavior is the same regardless of styling"""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO(), force_styling=True)
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term.ungetch(u'\x1b[10;10R')
         y, x = term.get_location(timeout=0.01)
         assert (y, x) == (9, 9)
 
-        term = TestTerminal(stream=six.StringIO(), force_styling=False)
+        term = TestTerminal(stream=io.StringIO(), force_styling=False)
         term.ungetch(u'\x1b[10;10R')
         y, x = term.get_location(timeout=0.01)
         assert (y, x) == (9, 9)
@@ -701,7 +701,7 @@ def test_get_location_timeout():
     """0-second get_location call with response."""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=io.StringIO())
         stime = time.time()
         # monkey patch in an invalid response !
         term.ungetch(u'\x1b[0n')
@@ -712,7 +712,6 @@ def test_get_location_timeout():
     child()
 
 
-@pytest.mark.skipif(six.PY2, reason="Python 3 only")
 def test_detached_stdout():
     """Ensure detached __stdout__ does not raise an exception"""
     import pty

--- a/tests/test_length_sequence.py
+++ b/tests/test_length_sequence.py
@@ -2,6 +2,7 @@
 """Tests for Terminal methods that account for sequences in strings"""
 
 # std imports
+import io
 import os
 import sys
 import struct
@@ -9,7 +10,6 @@ import platform
 import itertools
 
 # 3rd party
-import six
 import pytest
 
 # local
@@ -308,7 +308,7 @@ def test_env_winsize():
         # set the pty's virtual window size
         os.environ['COLUMNS'] = '99'
         os.environ['LINES'] = '11'
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=io.StringIO())
         save_init = term._init_descriptor
         save_stdout = sys.__stdout__
         try:

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -1,11 +1,11 @@
 """Tests for Terminal() sequences and sequence-awareness."""
 # -*- coding: utf-8 -*-
 # std imports
+import io
 import sys
 import platform
 
 # 3rd party
-import six
 import pytest
 
 # local
@@ -36,7 +36,7 @@ def test_capability_without_tty():
     """Assert capability templates are '' when stream is not a tty."""
     @as_subprocess
     def child():
-        t = TestTerminal(stream=six.StringIO())
+        t = TestTerminal(stream=io.StringIO())
         assert t.save == u''
         assert t.red == u''
 
@@ -47,7 +47,7 @@ def test_capability_with_forced_tty():
     """force styling should return sequences even for non-ttys."""
     @as_subprocess
     def child():
-        t = TestTerminal(stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(stream=io.StringIO(), force_styling=True)
         assert t.save == unicode_cap('sc')
 
     child()
@@ -58,7 +58,7 @@ def test_basic_url():
     @as_subprocess
     def child():
         # given
-        t = TestTerminal(stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(stream=io.StringIO(), force_styling=True)
         given_url = 'https://blessed.readthedocs.org'
         given_text = 'documentation'
         expected_output = ('\x1b]8;;{0}\x1b\\{1}\x1b]8;;\x1b\\'
@@ -78,7 +78,7 @@ def test_url_with_id():
     @as_subprocess
     def child():
         # given
-        t = TestTerminal(stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(stream=io.StringIO(), force_styling=True)
         given_url = 'https://blessed.readthedocs.org'
         given_text = 'documentation'
         given_url_id = '123'
@@ -128,7 +128,7 @@ def test_location_with_styling(all_terms):
     """Make sure ``location()`` works on all terminals."""
     @as_subprocess
     def child_with_styling(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(kind=kind, stream=io.StringIO(), force_styling=True)
         with t.location(3, 4):
             t.stream.write(u'hi')
         expected_output = u''.join(
@@ -146,7 +146,7 @@ def test_location_without_styling():
     @as_subprocess
     def child_without_styling():
         """No side effect for location as a context manager without styling."""
-        t = TestTerminal(stream=six.StringIO(), force_styling=None)
+        t = TestTerminal(stream=io.StringIO(), force_styling=None)
 
         with t.location(3, 4):
             t.stream.write(u'hi')
@@ -160,7 +160,7 @@ def test_horizontal_location(all_terms):
     """Make sure we can move the cursor horizontally without changing rows."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(kind=kind, stream=io.StringIO(), force_styling=True)
         with t.location(x=5):
             pass
         _hpa = unicode_parm('hpa', 5)
@@ -181,7 +181,7 @@ def test_vertical_location(all_terms):
     """Make sure we can move the cursor horizontally without changing rows."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(kind=kind, stream=io.StringIO(), force_styling=True)
         with t.location(y=5):
             pass
         _vpa = unicode_parm('vpa', 5)
@@ -203,7 +203,7 @@ def test_inject_move_x():
     """Test injection of hpa attribute for screen/ansi (issue #55)."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(kind=kind, stream=io.StringIO(), force_styling=True)
         COL = 5
         with mock.patch('curses.tigetstr', side_effect=MockTigetstr(hpa=None)):
             with t.location(x=COL):
@@ -225,7 +225,7 @@ def test_inject_move_y():
     """Test injection of vpa attribute for screen/ansi (issue #55)."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(kind=kind, stream=io.StringIO(), force_styling=True)
         ROW = 5
         with mock.patch('curses.tigetstr', side_effect=MockTigetstr(vpa=None)):
             with t.location(y=ROW):
@@ -247,7 +247,7 @@ def test_inject_civis_and_cnorm_for_ansi():
     """Test injection of civis attribute for ansi."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(kind=kind, stream=io.StringIO(), force_styling=True)
         with t.hidden_cursor():
             pass
         expected_output = u'\x1b[?25l\x1b[?25h'
@@ -261,7 +261,7 @@ def test_inject_sc_and_rc_for_ansi():
     """Test injection of sc and rc (save and restore cursor) for ansi."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(kind=kind, stream=io.StringIO(), force_styling=True)
         with t.location():
             pass
         expected_output = u'\x1b[s\x1b[u'
@@ -274,7 +274,7 @@ def test_zero_location(all_terms):
     """Make sure ``location()`` pays attention to 0-valued args."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(kind=kind, stream=io.StringIO(), force_styling=True)
         with t.location(0, 0):
             pass
         expected_output = u''.join(
@@ -350,7 +350,7 @@ def test_null_callable_numeric_colors(all_terms):
     """``color(n)`` should be a no-op on null terminals."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(stream=six.StringIO(), kind=kind)
+        t = TestTerminal(stream=io.StringIO(), kind=kind)
         assert (t.color(5)('smoo') == 'smoo')
         assert (t.on_color(6)('smoo') == 'smoo')
 
@@ -442,7 +442,7 @@ def test_formatting_functions_without_tty(all_terms):
     """Test crazy-ass formatting wrappers when there's no tty."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO(), force_styling=False)
+        t = TestTerminal(kind=kind, stream=io.StringIO(), force_styling=False)
         assert (t.bold(u'hi') == u'hi')
         assert (t.green('hi') == u'hi')
         # Test non-ASCII chars, no longer really necessary:
@@ -504,7 +504,7 @@ def test_null_callable_string(all_terms):
     """Make sure NullCallableString tolerates all kinds of args."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(stream=six.StringIO(), kind=kind)
+        t = TestTerminal(stream=io.StringIO(), kind=kind)
         assert (t.clear == '')
         assert (t.move(False) == '')
         assert (t.move_x(1) == '')
@@ -605,7 +605,7 @@ def test_formatting_other_string(all_terms):
     """FormattingOtherString output depends on how it's called"""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(stream=six.StringIO(), kind=kind, force_styling=True)
+        t = TestTerminal(stream=io.StringIO(), kind=kind, force_styling=True)
 
         assert (t.move_left == t.cub1)
         assert (t.move_left() == t.cub1)

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist =
     pydocstyle
     mypy
     sphinx
-    py{27,34,35,36,37,38,39}
+    py{34,35,36,37,38,39}
 
 
 ####### Python Test Environments #######
@@ -43,16 +43,6 @@ deps =
     pytest-rerunfailures
 commands =
     {envpython} -m pytest {posargs: --reruns 5 --strict-markers --verbose --durations=3} tests
-
-[testenv:py27]
-setenv =
-    TEST_QUICK = {env:TEST_QUICK:0}
-    TEST_KEYBOARD = {env:TEST_KEYBOARD:1}
-deps =
-    mock
-    pytest <= 4.7
-    pytest-cov  # 2.7 still supported as of 2.12.1
-    pytest-xdist==1.34.0
 
 [testenv:py34]
 deps =
@@ -288,5 +278,4 @@ addopts =
 filterwarnings = error
 junit_family = xunit1
 log_format=%(levelname)s %(relativeCreated)2.2f %(filename)s:%(lineno)d %(message)s
-looponfailroots = blessed
 norecursedirs = .git .tox build


### PR DESCRIPTION
Python 2 went EOL on 1/1/2020 and we receive no more support from the Python Core Team after Python 2.7.18 even for known security issues.