### PR TITLE
Drop 3.4 Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,16 +110,8 @@ jobs:
       - name: Upload to Codecov
         if: ${{ matrix.label != 'linting' }}
 
-        # CodeCov Python Uploader
-        env:
-          CODECOV_ENV: TEST_QUICK,TEST_KEYBOARD,TEST_RAW
-          CODECOV_NAME: ${{ matrix.label || matrix.python-version }} ${{ startsWith(matrix.os, 'windows') && '(Windows)' || '' }}
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: tox -e codecov
-
-        # CodeCov GitHub Actions Uploader
-        # uses: codecov/codecov-action@v2
-        # with:
-        #   verbose: true
-        #   name: ${{ matrix.label || matrix.python-version }} ${{ startsWith(matrix.os, 'windows') && '(Windows)' || '' }}
-        #   env_vars: TOXENV,TEST_QUICK,TEST_KEYBOARD,TEST_RAW
+        uses: codecov/codecov-action@v3
+        with:
+          verbose: true
+          name: ${{ matrix.label || matrix.python-version }} ${{ startsWith(matrix.os, 'windows') && '(Windows)' || '' }}
+          env_vars: TOXENV,TEST_QUICK,TEST_KEYBOARD,TEST_RAW

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,11 +66,6 @@ jobs:
             toxenv: py35
             test_quick: 1
 
-          - python-version: '3.4'
-            os:  ubuntu-18.04
-            toxenv: py34
-            test_quick: 1
-
           - python-version: '2.7'
             os:  ubuntu-20.04
             toxenv: py27

--- a/bin/display-fpathconf.py
+++ b/bin/display-fpathconf.py
@@ -11,7 +11,6 @@ import sys
 
 def display_fpathconf():
     """Program entry point."""
-
     if not hasattr(os, "pathconf_names"):
         return
 

--- a/bin/tprint.py
+++ b/bin/tprint.py
@@ -2,9 +2,9 @@
 """
 A simple cmd-line tool for displaying FormattingString capabilities.
 
-For example::
+For example:
 
-    $ python tprint.py bold A rather bold statement.
+$ python tprint.py bold A rather bold statement.
 """
 # std
 from __future__ import print_function

--- a/bin/worms.py
+++ b/bin/worms.py
@@ -108,7 +108,7 @@ def change_bearing(f_mov, segment, term):
 
 def bearing_flipped(dir1, dir2):
     """
-    direction-flipped check.
+    Direction-flipped check.
 
     Return true if dir2 travels in opposite direction of dir1.
     """

--- a/blessed/formatters.py
+++ b/blessed/formatters.py
@@ -289,14 +289,13 @@ class NullCallableString(six.text_type):
         """
         Allow empty string to be callable, returning given string, if any.
 
-        When called with an int as the first arg, return an empty Unicode. An
-        int is a good hint that I am a :class:`ParameterizingString`, as there
-        are only about half a dozen string-returning capabilities listed in
-        terminfo(5) which accept non-int arguments, they are seldom used.
+        When called with an int as the first arg, return an empty Unicode. An int is a good hint
+        that I am a :class:`ParameterizingString`, as there are only about half a dozen string-
+        returning capabilities listed in terminfo(5) which accept non-int arguments, they are seldom
+        used.
 
-        When called with a non-int as the first arg (no no args at all), return
-        the first arg, acting in place of :class:`FormattingString` without
-        any attributes.
+        When called with a non-int as the first arg (no no args at all), return the first arg,
+        acting in place of :class:`FormattingString` without any attributes.
         """
         if not args or isinstance(args[0], int):
             # As a NullCallableString, even when provided with a parameter,

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -986,14 +986,14 @@ class Terminal(object):
 
         Common return values are 0, 8, 16, 256, or 1 << 24.
 
-        This may be used to test whether the terminal supports colors,
-        and at what depth, if that's a concern.
+        This may be used to test whether the terminal supports colors, and at what depth, if that's
+        a concern.
 
         If this property is assigned a value of 88, the value 16 will be saved. This is due to the
         the rarity of 88 color support and the inconsistency of behavior between implementations.
 
-        Assigning this property to a value other than 0, 4, 8, 16, 88, 256, or 1 << 24 will
-        raise an :py:exc:`AssertionError`.
+        Assigning this property to a value other than 0, 4, 8, 16, 88, 256, or 1 << 24 will raise an
+        :py:exc:`AssertionError`.
         """
         return self._number_of_colors
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -277,7 +277,7 @@ autodoc_member_order = 'bysource'
 
 # when linking to standard python library, use and prefer python 3
 # documentation.
-intersphinx_mapping = {'https://docs.python.org/3/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # Both the class’ and the __init__ method’s docstring are concatenated and
 # inserted.

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -77,7 +77,7 @@ Exemplary 3rd-party examples which use *blessed*,
 Requirements
 ------------
 
-*Blessed* works with Windows, Mac, Linux, and BSD's, on Python 2.7, 3.4, 3.5, 3.6, 3.7, and 3.8.
+*Blessed* works with Windows, Mac, Linux, and BSD's, on Python 2.7, 3.5+.
 
 Brief Overview
 --------------

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setuptools.setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -192,20 +192,6 @@ commands =
     python {toxinidir}/bin/display-terminalinfo.py
     python {toxinidir}/bin/display-fpathconf.py
 
-[testenv:codecov]
-basepython = {env:TOXPYTHON:{[testenv]basepython}}
-passenv =
-    TOXENV
-    CI
-    TRAVIS
-    TRAVIS_*
-    CODECOV_*
-    TEST_*
-    GITHUB_*
-deps =
-    codecov>=2.1
-commands = codecov -e TOXENV
-
 [testenv:develop]
 commands =
     {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist =
     pydocstyle
     mypy
     sphinx
-    py{27,34,35,36,37,38,39,310,311}
+    py{27,35,36,37,38,39,310,311}
 
 
 ####### Python Test Environments #######
@@ -53,15 +53,6 @@ deps =
     pytest <= 4.7
     pytest-cov  # 2.7 still supported as of 2.12.1
     pytest-xdist==1.34.0
-
-[testenv:py34]
-deps =
-    mock
-    pytest <= 4.7
-    pytest-cov==2.8.1
-    pytest-xdist==1.31.0
-    attrs==20.3.0
-    apipkg==2.0.1
 
 
 ####### Linting and Formatting Environments #######

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
     pytest-cov
     pytest-xdist
 commands =
-    {envpython} -m pytest {posargs: --strict-markers --verbose --durations=3} tests
+    pytest {posargs: --strict-markers --verbose --durations=3} tests
 
 [testenv:py311]
 setenv =
@@ -42,7 +42,7 @@ deps =
     {[testenv]deps}
     pytest-rerunfailures
 commands =
-    {envpython} -m pytest {posargs: --reruns 5 --strict-markers --verbose --durations=3} tests
+    pytest {posargs: --reruns 5 --strict-markers --verbose --durations=3} tests
 
 [testenv:py27]
 setenv =
@@ -61,14 +61,14 @@ deps =
 deps =
     autopep8
 commands =
-    {envbindir}/autopep8 --in-place  --recursive --aggressive --aggressive blessed/ bin/ setup.py
+    autopep8 --in-place  --recursive --aggressive --aggressive blessed/ bin/ setup.py
 
 [testenv:docformatter]
 deps =
     docformatter
     untokenize
 commands =
-    {envbindir}/docformatter \
+    docformatter \
         --in-place \
         --recursive \
         --pre-summary-newline \
@@ -84,7 +84,7 @@ deps =
     docformatter
     untokenize
 commands =
-    {envbindir}/docformatter \
+    docformatter \
         --check \
         --recursive \
         --pre-summary-newline \
@@ -99,13 +99,13 @@ commands =
 deps =
     flake8
 commands =
-    {envbindir}/flake8 --exclude=tests,docs/sphinxext/github.py setup.py docs/ blessed/ bin/
+    flake8 --exclude=tests,docs/sphinxext/github.py setup.py docs/ blessed/ bin/
 
 [testenv:flake8_tests]
 deps =
     {[testenv:flake8]deps}
 commands =
-    {envbindir}/flake8 --ignore=W504,F401 tests/
+    flake8 --ignore=W504,F401 tests/
 
 [testenv:isort]
 deps =
@@ -113,26 +113,26 @@ deps =
     -r docs/requirements.txt
     isort
 commands =
-    {envbindir}/isort blessed
+    isort blessed
 
 
 [testenv:isort_check]
 deps =
     {[testenv:isort]deps}
 commands =
-    {envbindir}/isort --diff --check-only blessed
+    isort --diff --check-only blessed
 
 [testenv:linkcheck]
 deps =
     -r {toxinidir}/docs/requirements.txt
 commands =
-    {envbindir}/sphinx-build -v -W -d {toxinidir}/docs/_build/doctrees -b linkcheck docs docs/_build/linkcheck
+    sphinx-build -v -W -d {toxinidir}/docs/_build/doctrees -b linkcheck docs docs/_build/linkcheck
 
 [testenv:mypy]
 deps =
     mypy
 commands =
-    {envpython} -m mypy --strict {toxinidir}/blessed
+    mypy --strict {toxinidir}/blessed
 
 [testenv:pydocstyle]
 deps =
@@ -141,21 +141,21 @@ deps =
     doc8
     pygments
 commands =
-    {envbindir}/pydocstyle --source --explain {toxinidir}/blessed
-    {envbindir}/rst-lint README.rst
-    {envbindir}/doc8 --ignore-path docs/_build --ignore D000 docs
+    pydocstyle --source --explain {toxinidir}/blessed
+    rst-lint README.rst
+    doc8 --ignore-path docs/_build --ignore D000 docs
 
 [testenv:pylint]
 deps =
     pylint
 commands =
-    {envbindir}/pylint {posargs} blessed
+    pylint {posargs} blessed
 
 [testenv:pylint_tests]
 deps =
     pylint
 commands =
-    {envbindir}/pylint \
+    pylint \
         --disable invalid-name,import-error,import-outside-toplevel \
         --disable protected-access,superfluous-parens,unused-argument \
         {posargs} tests
@@ -207,7 +207,7 @@ commands =
 deps =
     -r {toxinidir}/docs/requirements.txt
 commands =
-    {envbindir}/sphinx-build {posargs:-v -W -d {toxinidir}/docs/_build/doctrees -b html docs {toxinidir}/docs/_build/html}
+    sphinx-build {posargs:-v -W -d {toxinidir}/docs/_build/doctrees -b html docs {toxinidir}/docs/_build/html}
 
 [testenv:stamp]
 commands =


### PR DESCRIPTION
Github dropped the Ubuntu 18.04 image we were using to test 3.4 and my distro doesn't have a package for it, so I think it's time to drop support.

If the query is correct, Blessed was only downloaded 509 times for Python 3.4 in the last 6 months.

This should fix the failing CI tests.
