### PR TITLE
June fixes

### DIFF
--- a/bin/display-maxcanon.py
+++ b/bin/display-maxcanon.py
@@ -2,25 +2,20 @@
 """
 A tool which uses pexpect to test expected Canonical mode length.
 
-All systems use the value of MAX_CANON which can be found using
-fpathconf(3) value PC_MAX_CANON -- with the exception of Linux
-and FreeBSD.
+All systems use the value of MAX_CANON which can be found using fpathconf(3) value PC_MAX_CANON --
+with the exception of Linux and FreeBSD.
 
-Linux, though defining a value of 255, actually honors the value
-of 4096 from linux kernel include file tty.h definition
-N_TTY_BUF_SIZE.
+Linux, though defining a value of 255, actually honors the value of 4096 from linux kernel include
+file tty.h definition N_TTY_BUF_SIZE.
 
-Linux also does not honor IMAXBEL. termios(3) states, "Linux does not
-implement this bit, and acts as if it is always set." Although these
-tests ensure it is enabled, this is a non-op for Linux.
+Linux also does not honor IMAXBEL. termios(3) states, "Linux does not implement this bit, and acts
+as if it is always set." Although these tests ensure it is enabled, this is a non-op for Linux.
 
-FreeBSD supports neither, and instead uses a fraction (1/5) of the tty
-speed which is always 9600.  Therefor, the maximum limited input line
-length is 9600 / 5 = 1920.
+FreeBSD supports neither, and instead uses a fraction (1/5) of the tty speed which is always 9600.
+Therefor, the maximum limited input line length is 9600 / 5 = 1920.
 
-In other words, the only way to determine the true MAX_CANON in a
-cross-platform manner is through this systems integrated test: the given
-system definitions are misleading on some operating systems.
+In other words, the only way to determine the true MAX_CANON in a cross-platform manner is through
+this systems integrated test: the given system definitions are misleading on some operating systems.
 """
 # pylint: disable=invalid-name
 #         Invalid module name "display-sighandlers"

--- a/blessed/color.py
+++ b/blessed/color.py
@@ -24,13 +24,13 @@ def rgb_to_xyz(red, green, blue):
     """
     Convert standard RGB color to XYZ color.
 
+    D65/2° standard illuminant.
+
     :arg int red: RGB value of Red.
     :arg int green: RGB value of Green.
     :arg int blue: RGB value of Blue.
     :returns: Tuple (X, Y, Z) representing XYZ color
     :rtype: tuple
-
-    D65/2° standard illuminant
     """
     rgb = []
     for val in red, green, blue:
@@ -58,9 +58,7 @@ def xyz_to_lab(x_val, y_val, z_val):
     :arg float y_val: XYZ value of Y.
     :arg float z_val: XYZ value of Z.
     :returns: Tuple (L, a, b) representing CIE-Lab color
-    :rtype: tuple
-
-    D65/2° standard illuminant
+    :rtype: tuple  D65/2° standard illuminant
     """
     xyz = []
     for val, ref in (x_val, 95.047), (y_val, 100.0), (z_val, 108.883):
@@ -85,9 +83,7 @@ def rgb_to_lab(red, green, blue):
     :arg int green: RGB value of Green.
     :arg int blue: RGB value of Blue.
     :returns: Tuple (L, a, b) representing CIE-Lab color
-    :rtype: tuple
-
-    D65/2° standard illuminant
+    :rtype: tuple  D65/2° standard illuminant
     """
     return xyz_to_lab(*rgb_to_xyz(red, green, blue))
 
@@ -120,13 +116,9 @@ def dist_rgb_weighted(rgb1, rgb2):
     :arg tuple rgb1: RGB color definition
     :arg tuple rgb2: RGB color definition
     :returns: Square of the distance between provided colors
-    :rtype: float
-
-    Similar to a standard distance formula, the values are weighted
-    to approximate human perception of color differences
-
-    For efficiency, the square of the distance is returned
-    which is sufficient for comparisons
+    :rtype: float Similar to a standard distance formula, the values are weighted to approximate
+        human perception of color differences For efficiency, the square of the distance is returned
+        which is sufficient for comparisons
     """
     red_mean = (rgb1[0] + rgb2[0]) / 2.0
 
@@ -142,10 +134,8 @@ def dist_cie76(rgb1, rgb2):
     :arg tuple rgb1: RGB color definition
     :arg tuple rgb2: RGB color definition
     :returns: Square of the distance between provided colors
-    :rtype: float
-
-    For efficiency, the square of the distance is returned
-    which is sufficient for comparisons
+    :rtype: float For efficiency, the square of the distance is returned which is sufficient for
+        comparisons
     """
     l_1, a_1, b_1 = rgb_to_lab(*rgb1)
     l_2, a_2, b_2 = rgb_to_lab(*rgb2)
@@ -160,10 +150,8 @@ def dist_cie94(rgb1, rgb2):
     :arg tuple rgb1: RGB color definition
     :arg tuple rgb2: RGB color definition
     :returns: Square of the distance between provided colors
-    :rtype: float
-
-    For efficiency, the square of the distance is returned
-    which is sufficient for comparisons
+    :rtype: float For efficiency, the square of the distance is returned which is sufficient for
+        comparisons
     """
     l_1, a_1, b_1 = rgb_to_lab(*rgb1)
     l_2, a_2, b_2 = rgb_to_lab(*rgb2)
@@ -195,10 +183,8 @@ def dist_cie2000(rgb1, rgb2):
     :arg tuple rgb1: RGB color definition
     :arg tuple rgb2: RGB color definition
     :returns: Square of the distance between provided colors
-    :rtype: float
-
-    For efficiency, the square of the distance is returned
-    which is sufficient for comparisons
+    :rtype: float For efficiency, the square of the distance is returned which is sufficient for
+        comparisons
     """
     s_l = k_l = k_c = k_h = 1
 

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -59,10 +59,8 @@ class Termcap(object):
         Horizontal carriage adjusted by capability, may be negative.
 
         :rtype: int
-        :arg str text: for capabilities *parm_left_cursor*,
-            *parm_right_cursor*, provide the matching sequence
-            text, its interpreted distance is returned.
-
+        :arg str text: for capabilities *parm_left_cursor*, *parm_right_cursor*, provide the
+            matching sequence text, its interpreted distance is returned.
         :returns: 0 except for matching '
         """
         value = {

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -705,8 +705,10 @@ def test_truncate_padding(all_terms):
     def child(kind):
         from blessed import Terminal
         term = Terminal(kind)
-        test_right_string = term.blue(u"one" + term.move_right(5) + u"two")
-        assert term.truncate(test_right_string, 9) == term.blue(u"one     t")
+
+        if term.move_right(5):
+            test_right_string = term.blue(u"one" + term.move_right(5) + u"two")
+            assert term.truncate(test_right_string, 9) == term.blue(u"one     t")
 
         test_bs_string = term.blue(u"one\b\b\btwo")
         assert term.truncate(test_bs_string, 3) == term.blue(u"two")

--- a/tox.ini
+++ b/tox.ini
@@ -226,6 +226,7 @@ source =
     blessed
 omit =
     tests/*
+data_file = .coverage.${TOX_ENV_NAME}
 
 [coverage:report]
 precision = 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,7 @@
 [tox]
+requires =
+    # Pin virtualenv to the last version supporting 2.7 and 3.6
+    virtualenv<=20.21.1
 ignore_basepython_conflict = True
 skip_missing_interpreters = True
 envlist =


### PR DESCRIPTION
- Fix docformatter issues failing in CI
- Gate `move_right()` in `truncate()` tests
  - This address some of the failures in #251 
- Pin virtualenv for Tox
  - virtualenv recently dropped support for 2.7 and 3.6
  - This causes Tox to create a virtual environment with the pinned version and use it to create the tox environments
  - This could potentially cause another issue down the road, but probably still worth it for now
   