### PR TITLE
Read the Docs configuration fixes

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,10 +1,17 @@
 # https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
+
 sphinx:
   configuration: docs/conf.py
+
 formats: all
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: '3'
+
 python:
-  version: 3.7
   install:
     - method: setuptools
       path: .


### PR DESCRIPTION
Noticed Read the Docs builds are failing. We need to specify the OS. Unfortunately they haven't added support a latest tag on the OS yet.
I also moved the Python version to the new location and changed it to only specify the major version so it should use the latest supported.

I couldn't test this, but we could [enable PR builds in RTD](https://docs.readthedocs.io/en/stable/guides/pull-requests.html). Or add me as a maintainer in RTD and I'll do it.