### PR TITLE
Pylint fixes for .pyi files

### DIFF
--- a/blessed/_capabilities.pyi
+++ b/blessed/_capabilities.pyi
@@ -1,3 +1,5 @@
+"""Type hint for terminal capability builder patterns"""
+
 # std imports
 from typing import Any, Dict, Tuple, OrderedDict
 

--- a/blessed/color.pyi
+++ b/blessed/color.pyi
@@ -1,7 +1,11 @@
+"""Type hints for color functions"""
+
 # std imports
 from typing import Dict, Tuple, Callable
 
 _RGB = Tuple[int, int, int]
+
+# pylint: disable=unused-argument,missing-function-docstring
 
 def rgb_to_xyz(red: int, green: int, blue: int) -> Tuple[float, float, float]: ...
 def xyz_to_lab(

--- a/blessed/colorspace.pyi
+++ b/blessed/colorspace.pyi
@@ -1,7 +1,11 @@
+"""Type hints for color reference data"""
+
 # std imports
 from typing import Set, Dict, Tuple, NamedTuple
 
 CGA_COLORS: Set[str]
+
+#pylint: disable=missing-class-docstring
 
 class RGBColor(NamedTuple):
     red: int

--- a/blessed/formatters.pyi
+++ b/blessed/formatters.pyi
@@ -1,3 +1,5 @@
+"""Type hints for sequence-formatting functions"""
+
 # std imports
 from typing import (Any,
                     Set,
@@ -18,6 +20,8 @@ COLORS: Set[str]
 COMPOUNDABLES: Set[str]
 
 _T = TypeVar("_T")
+
+# pylint: disable=unused-argument,missing-function-docstring,missing-class-docstring
 
 class ParameterizingString(str):
     def __new__(cls: Type[_T], cap: str, normal: str = ..., name: str = ...) -> _T: ...

--- a/blessed/formatters.pyi
+++ b/blessed/formatters.pyi
@@ -1,7 +1,8 @@
 """Type hints for sequence-formatting functions"""
 
 # std imports
-from typing import (Any,
+from typing import (TYPE_CHECKING,
+                    Any,
                     Set,
                     List,
                     Type,
@@ -13,8 +14,9 @@ from typing import (Any,
                     Optional,
                     overload)
 
-# local
-from .terminal import Terminal
+if TYPE_CHECKING:
+    # local
+    from .terminal import Terminal
 
 COLORS: Set[str]
 COMPOUNDABLES: Set[str]
@@ -62,13 +64,13 @@ class NullCallableString(str):
     def __call__(self, *args: str) -> str: ...
 
 def get_proxy_string(
-    term: Terminal, attr: str
+    term: 'Terminal', attr: str
 ) -> Optional[ParameterizingProxyString]: ...
 def split_compound(compound: str) -> List[str]: ...
-def resolve_capability(term: Terminal, attr: str) -> str: ...
+def resolve_capability(term: 'Terminal', attr: str) -> str: ...
 def resolve_color(
-    term: Terminal, color: str
+    term: 'Terminal', color: str
 ) -> Union[NullCallableString, FormattingString]: ...
 def resolve_attribute(
-    term: Terminal, attr: str
+    term: 'Terminal', attr: str
 ) -> Union[ParameterizingString, FormattingString]: ...

--- a/blessed/keyboard.pyi
+++ b/blessed/keyboard.pyi
@@ -1,3 +1,5 @@
+"""Type hints for 'keyboard awareness'"""
+
 # std imports
 from typing import Set, Dict, Type, Mapping, TypeVar, Iterable, Optional, OrderedDict
 
@@ -5,6 +7,8 @@ from typing import Set, Dict, Type, Mapping, TypeVar, Iterable, Optional, Ordere
 from .terminal import Terminal
 
 _T = TypeVar("_T")
+
+# pylint: disable=unused-argument,missing-function-docstring,missing-class-docstring
 
 class Keystroke(str):
     def __new__(

--- a/blessed/keyboard.pyi
+++ b/blessed/keyboard.pyi
@@ -1,10 +1,11 @@
 """Type hints for 'keyboard awareness'"""
 
 # std imports
-from typing import Set, Dict, Type, Mapping, TypeVar, Iterable, Optional, OrderedDict
+from typing import TYPE_CHECKING, Set, Dict, Type, Mapping, TypeVar, Iterable, Optional, OrderedDict
 
-# local
-from .terminal import Terminal
+if TYPE_CHECKING:
+    # local
+    from .terminal import Terminal
 
 _T = TypeVar("_T")
 
@@ -25,7 +26,7 @@ class Keystroke(str):
     def code(self) -> Optional[int]: ...
 
 def get_keyboard_codes() -> Dict[int, str]: ...
-def get_keyboard_sequences(term: Terminal) -> OrderedDict[str, int]: ...
+def get_keyboard_sequences(term: 'Terminal') -> OrderedDict[str, int]: ...
 def get_leading_prefixes(sequences: Iterable[str]) -> Set[str]: ...
 def resolve_sequence(
     text: str, mapper: Mapping[str, int], codes: Mapping[int, str]

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -15,6 +15,8 @@ from blessed._capabilities import CAPABILITIES_CAUSE_MOVEMENT
 __all__ = ('Sequence', 'SequenceTextWrapper', 'iter_parse', 'measure_length')
 
 
+# pylint: disable=unused-argument,missing-function-docstring
+
 class Termcap(object):
     """Terminal capability of given variable name and pattern."""
 

--- a/blessed/sequences.pyi
+++ b/blessed/sequences.pyi
@@ -2,10 +2,19 @@
 
 # std imports
 import textwrap
-from typing import Any, Type, Tuple, Pattern, TypeVar, Iterator, Optional, SupportsIndex
+from typing import (TYPE_CHECKING,
+                    Any,
+                    Type,
+                    Tuple,
+                    Pattern,
+                    TypeVar,
+                    Iterator,
+                    Optional,
+                    SupportsIndex)
 
-# local
-from .terminal import Terminal
+if TYPE_CHECKING:
+    # local
+    from .terminal import Terminal
 
 _T = TypeVar("_T")
 
@@ -38,11 +47,11 @@ class Termcap:
     ) -> "Termcap": ...
 
 class SequenceTextWrapper(textwrap.TextWrapper):
-    term: Terminal = ...
-    def __init__(self, width: int, term: Terminal, **kwargs: Any) -> None: ...
+    term: 'Terminal' = ...
+    def __init__(self, width: int, term: 'Terminal', **kwargs: Any) -> None: ...
 
 class Sequence(str):
-    def __new__(cls: Type[_T], sequence_text: str, term: Terminal) -> _T: ...
+    def __new__(cls: Type[_T], sequence_text: str, term: 'Terminal') -> _T: ...
     def ljust(self, width: SupportsIndex, fillchar: str = ...) -> str: ...
     def rjust(self, width: SupportsIndex, fillchar: str = ...) -> str: ...
     def center(self, width: SupportsIndex, fillchar: str = ...) -> str: ...
@@ -55,6 +64,6 @@ class Sequence(str):
     def padd(self, strip: bool = ...) -> str: ...
 
 def iter_parse(
-    term: Terminal, text: str
+    term: 'Terminal', text: str
 ) -> Iterator[Tuple[str, Optional[Termcap]]]: ...
-def measure_length(text: str, term: Terminal) -> int: ...
+def measure_length(text: str, term: 'Terminal') -> int: ...

--- a/blessed/sequences.pyi
+++ b/blessed/sequences.pyi
@@ -1,3 +1,5 @@
+"""Type hints for 'sequence awareness'"""
+
 # std imports
 import textwrap
 from typing import Any, Type, Tuple, Pattern, TypeVar, Iterator, Optional, SupportsIndex
@@ -6,6 +8,9 @@ from typing import Any, Type, Tuple, Pattern, TypeVar, Iterator, Optional, Suppo
 from .terminal import Terminal
 
 _T = TypeVar("_T")
+
+# pylint: disable=unused-argument,missing-function-docstring,missing-class-docstring
+# pylint: disable=super-init-not-called
 
 class Termcap:
     name: str = ...

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -894,6 +894,7 @@ class Terminal(object):
         inadvertently returning another terminal capability.
         """
         formatters = split_compound(value)
+        # Pylint sometimes thinks formatters isn't a list  # pylint: disable=not-an-iterable
         if all((fmt in COLORS or fmt in COMPOUNDABLES) for fmt in formatters):
             return getattr(self, value)
 

--- a/blessed/terminal.pyi
+++ b/blessed/terminal.pyi
@@ -4,6 +4,7 @@
 from typing import IO, Any, List, Tuple, Union, Optional, OrderedDict, SupportsIndex, ContextManager
 
 # local
+# The type hints do have circular imports, but the code doesn't  # pylint: disable=cyclic-import
 from .keyboard import Keystroke
 from .sequences import Termcap
 from .formatters import (FormattingString,

--- a/blessed/terminal.pyi
+++ b/blessed/terminal.pyi
@@ -4,7 +4,6 @@
 from typing import IO, Any, List, Tuple, Union, Optional, OrderedDict, SupportsIndex, ContextManager
 
 # local
-# The type hints do have circular imports, but the code doesn't  # pylint: disable=cyclic-import
 from .keyboard import Keystroke
 from .sequences import Termcap
 from .formatters import (FormattingString,

--- a/blessed/terminal.pyi
+++ b/blessed/terminal.pyi
@@ -1,3 +1,5 @@
+"""Type hints for :class:`Terminal`, the primary API entry point."""
+
 # std imports
 from typing import IO, Any, List, Tuple, Union, Optional, OrderedDict, SupportsIndex, ContextManager
 
@@ -10,6 +12,9 @@ from .formatters import (FormattingString,
                          FormattingOtherString)
 
 HAS_TTY: bool
+
+# pylint: disable=unused-argument,missing-function-docstring,missing-class-docstring
+# pylint: disable=too-many-public-methods,too-few-public-methods
 
 class Terminal:
     caps: OrderedDict[str, Termcap]
@@ -105,4 +110,5 @@ class Terminal:
         self, timeout: Optional[float] = ..., esc_delay: float = ...
     ) -> Keystroke: ...
 
-class WINSZ: ...
+class WINSZ:
+    ...

--- a/blessed/win_terminal.pyi
+++ b/blessed/win_terminal.pyi
@@ -1,8 +1,12 @@
+"""Type hints for Windows version of :class:`Terminal`."""
+
 # std imports
 from typing import Optional, ContextManager
 
 # local
 from .terminal import Terminal as _Terminal
+
+# pylint: disable=missing-class-docstring
 
 class Terminal(_Terminal):
     def getch(self) -> str: ...


### PR DESCRIPTION
Pylint recently started checking .pyi files but there are some messages that either don't make sense (ex: unused argument) or aren't strictly necessary in a type hints file (ex: no function docstring).

There is some discussion in https://github.com/pylint-dev/pylint/issues/9096 of quieting these, but rather than wait, I figured we can fix the ones that made sense to fix and disable the others.
