### PR TITLE
Additional Pylint fixes

### DIFF
--- a/blessed/keyboard.pyi
+++ b/blessed/keyboard.pyi
@@ -1,7 +1,17 @@
 """Type hints for 'keyboard awareness'"""
 
 # std imports
-from typing import TYPE_CHECKING, Set, Dict, Type, Mapping, TypeVar, Iterable, Optional, OrderedDict
+from typing import (TYPE_CHECKING,
+                    Set,
+                    Dict,
+                    Type,
+                    Match,
+                    Tuple,
+                    Mapping,
+                    TypeVar,
+                    Iterable,
+                    Optional,
+                    OrderedDict)
 
 if TYPE_CHECKING:
     # local
@@ -31,3 +41,10 @@ def get_leading_prefixes(sequences: Iterable[str]) -> Set[str]: ...
 def resolve_sequence(
     text: str, mapper: Mapping[str, int], codes: Mapping[int, str]
 ) -> Keystroke: ...
+def _time_left(stime: float, timeout: Optional[float]) -> Optional[float]: ...
+def _read_until(
+        term: 'Terminal', pattern: str, timeout: Optional[float]
+    ) -> Tuple[Optional[Match[str]], str]: ...
+
+
+DEFAULT_ESCDELAY: float

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -528,7 +528,7 @@ class Terminal(object):
             self.stream.flush()
 
             # Wait for response
-            match, data = _read_until(term=self,
+            match, data = _read_until(term=self,  # pylint: disable=unpacking-non-sequence
                                       pattern=response_re,
                                       timeout=timeout)
 
@@ -1496,7 +1496,7 @@ class Terminal(object):
         if ks.code == self.KEY_ESCAPE:
             esctime = time.time()
             while (ks.code == self.KEY_ESCAPE and
-                   ucs in self._keymap_prefixes and
+                   ucs in self._keymap_prefixes and  # pylint: disable=unsupported-membership-test
                    self.kbhit(timeout=_time_left(esctime, esc_delay))):
                 ucs += self.getch()
                 ks = resolve_sequence(ucs, self._keymap, self._keycodes)


### PR DESCRIPTION
Hopefully this takes care of the rest of the issues.

- Added type hints for `_time_left()`, `_read_until`, and `DEFAULT_ESCDELAY` in `keyboard.pyi`
- Removed `functools.partial()` in `Terminal.inkey()`
  - Pylint complained about no return value
  - It doesn't seem necessary anymore. I think at one point it consolidated some complicated code, but now these calls are pretty simple
- Ignore two cases where Pylint reported a false positive
