### PR TITLE
Update Python versions in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,25 +20,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         test_quick: [1]
 
         include:
-          - python-version: '3.11'
+          - python-version: '3.12'
             label: Linting
             toxenv: docformatter_check,flake8,flake8_tests,isort_check,mypy,sphinx,pydocstyle,pylint,pylint_tests
 
-          - python-version: '3.12-dev'
+          - python-version: '3.13-dev'
             optional: true
-            toxenv: py312
-            toxpython: 3.12
+            toxenv: py313
+            toxpython: 3.13
 
-          - python-version: '3.11'
+          - python-version: '3.12'
             test_keyboard: 1
             test_raw: 1
             test_quick: 0
 
-          - python-version: '3.11'
+          - python-version: '3.12'
             os: windows-latest
             test_quick: 0
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ sphinx:
 formats: all
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
     python: '3'
 

--- a/bin/generate-x11-colorchart.py
+++ b/bin/generate-x11-colorchart.py
@@ -70,8 +70,8 @@ def main():
         hsv = colorsys.rgb_to_hsv(*rgb)
         csv_rows += ('   '
                      f'{x11_color}, |{x11_color}|, '
-                     f'{rgb[0]/255:0.1%}, {rgb[1]/255:0.1%}, {rgb[2]/255:0.1%}, '
-                     f'{hsv[0]:0.1%}, {hsv[1]:0.1%}, {hsv[2]/255:0.1%}\n')
+                     f'{rgb[0] / 255:0.1%}, {rgb[1] / 255:0.1%}, {rgb[2] / 255:0.1%}, '
+                     f'{hsv[0]:0.1%}, {hsv[1]:0.1%}, {hsv[2] / 255:0.1%}\n')
 
     output = aliases + '\n\n' + csv_table + '\n' + csv_rows
     filepath_txt = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir, 'docs',

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -219,7 +219,7 @@ The same program with *Blessed* is simply:
     :target: https://codecov.io/gh/jquast/blessed/
 .. |linux| image:: https://img.shields.io/badge/Linux-yes-success?logo=linux
     :alt: Linux supported
-.. |windows| image:: https://img.shields.io/badge/Windows-NEW-success?logo=windows
+.. |windows| image:: https://img.shields.io/badge/Windows-yes-success?logo=windows
     :alt: Windows supported
 .. |mac| image:: https://img.shields.io/badge/MacOS-yes-success?logo=apple
     :alt: MacOS supported

--- a/tox.ini
+++ b/tox.ini
@@ -17,13 +17,13 @@ envlist =
     pydocstyle
     mypy
     sphinx
-    py{27,35,36,37,38,39,310,311}
+    py{27,35,36,37,38,39,310,311,312}
 
 
 ####### Python Test Environments #######
 
 [testenv]
-basepython = python3.11
+basepython = python3.12
 passenv =
     TEST_QUICK
     TEST_KEYBOARD
@@ -37,7 +37,7 @@ deps =
 commands =
     pytest {posargs: --strict-markers --verbose --durations=3} tests
 
-[testenv:py311]
+[testenv:py312]
 setenv =
     TEST_QUICK = {env:TEST_QUICK:0}
     TEST_KEYBOARD = {env:TEST_KEYBOARD:1}


### PR DESCRIPTION
- Moves base Python for testing to 3.12
- Adds 3.13-dev
- Uses new image option for Read the Docs, ubuntu-lts-latest, so we always use the latest
- fixes small difference in Windows tag between intro and readme docs
