### PR TITLE
Test fixes June 2024

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,13 +66,22 @@ jobs:
       TOXPYTHON: python${{ matrix.toxpython || matrix.python-version }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-        if: ${{ matrix.python-version != '2.7' }}
+        if: ${{ matrix.python-version != '2.7' && matrix.python-version != '3.5' }}
+
+      # Workaround for https://github.com/actions/setup-python/issues/866
+      - name: Set up Python 3.5 (Workaround)
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.5
+        env:
+          PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
+        if: ${{ matrix.python-version == '3.5' }}
 
       - name: Install tox
         run: pip install tox

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -325,6 +325,7 @@ class Terminal(object):
             # set input encoding and initialize incremental decoder
 
             if IS_WINDOWS:
+                # pylint: disable-next=possibly-used-before-assignment
                 self._encoding = get_console_input_encoding() \
                     or locale.getpreferredencoding() or 'UTF-8'
             else:
@@ -459,7 +460,7 @@ class Terminal(object):
             - ``ws_ypixel``: height of terminal by pixels (not accurate).
         """
         if HAS_TTY:
-            # pylint: disable=protected-access
+            # pylint: disable=protected-access,possibly-used-before-assignment
             data = fcntl.ioctl(fd, termios.TIOCGWINSZ, WINSZ._BUF)
             return WINSZ(*struct.unpack(WINSZ._FMT, data))
         return WINSZ(ws_row=25, ws_col=80, ws_xpixel=0, ws_ypixel=0)
@@ -1350,6 +1351,7 @@ class Terminal(object):
             # Save current terminal mode:
             save_mode = termios.tcgetattr(self._keyboard_fd)
             save_line_buffered = self._line_buffered
+            # pylint: disable-next=possibly-used-before-assignment
             tty.setcbreak(self._keyboard_fd, termios.TCSANOW)
             try:
                 self._line_buffered = False

--- a/tests/accessories.py
+++ b/tests/accessories.py
@@ -6,7 +6,6 @@ from __future__ import print_function, with_statement
 import os
 import sys
 import codecs
-import platform
 import functools
 import traceback
 import contextlib
@@ -67,7 +66,7 @@ class as_subprocess(object):  # pylint: disable=too-few-public-methods
             return
 
         pid_testrunner = os.getpid()
-        pid, master_fd = pty.fork()
+        pid, master_fd = pty.fork()  # pylint: disable=possibly-used-before-assignment
         if pid == self._CHILD_PID:
             # child process executes function, raises exception
             # if failed, causing a non-zero exit code, using the
@@ -185,7 +184,8 @@ def read_until_eof(fd, encoding='utf8'):
 @contextlib.contextmanager
 def echo_off(fd):
     """Ensure any bytes written to pty fd are not duplicated as output."""
-    if platform.system() != 'Windows':
+    if not IS_WINDOWS:
+        # pylint: disable=possibly-used-before-assignment
         try:
             attrs = termios.tcgetattr(fd)
             attrs[3] = attrs[3] & ~termios.ECHO

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -2,13 +2,13 @@
 """Tests for keyboard support."""
 # std imports
 import os
-import sys
 import platform
 import tempfile
 import functools
 
 # 3rd party
 import pytest
+import six
 
 # local
 from .accessories import TestTerminal, as_subprocess
@@ -24,9 +24,6 @@ if platform.system() != 'Windows':
     import tty  # pylint: disable=unused-import  # NOQA
 else:
     import jinxed as curses
-
-if sys.version_info[0] == 3:
-    unichr = chr
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="?")
@@ -311,12 +308,12 @@ def test_keypad_mixins_and_aliases():  # pylint: disable=too-many-statements
                                     mapper=term._keymap,
                                     codes=term._keycodes)
 
-        assert resolve(unichr(10)).name == "KEY_ENTER"
-        assert resolve(unichr(13)).name == "KEY_ENTER"
-        assert resolve(unichr(8)).name == "KEY_BACKSPACE"
-        assert resolve(unichr(9)).name == "KEY_TAB"
-        assert resolve(unichr(27)).name == "KEY_ESCAPE"
-        assert resolve(unichr(127)).name == "KEY_BACKSPACE"
+        assert resolve(six.unichr(10)).name == "KEY_ENTER"
+        assert resolve(six.unichr(13)).name == "KEY_ENTER"
+        assert resolve(six.unichr(8)).name == "KEY_BACKSPACE"
+        assert resolve(six.unichr(9)).name == "KEY_TAB"
+        assert resolve(six.unichr(27)).name == "KEY_ESCAPE"
+        assert resolve(six.unichr(127)).name == "KEY_BACKSPACE"
         assert resolve(u"\x1b[A").name == "KEY_UP"
         assert resolve(u"\x1b[B").name == "KEY_DOWN"
         assert resolve(u"\x1b[C").name == "KEY_RIGHT"

--- a/tests/test_length_sequence.py
+++ b/tests/test_length_sequence.py
@@ -335,6 +335,7 @@ def test_winsize(many_lines, many_columns):
     def child(lines=25, cols=80):
         # set the pty's virtual window size
         val = struct.pack('HHHH', lines, cols, pixel_width, pixel_height)
+        # pylint: disable-next=possibly-used-before-assignment
         fcntl.ioctl(sys.__stdout__.fileno(), termios.TIOCSWINSZ, val)
         term = TestTerminal()
         winsize = term._height_and_width()


### PR DESCRIPTION
This fixes two issues causing the tests to fail:

1.) It seems PyPI updated their SSL config and the certs can't be verified by the version of pip included with 3.5. I've implemented a workaround to explicitly trust the necessary domains, only for 3.5 and only when installing Python. I thought about just pulling 3.5 instead, but I think we can wait until the next time something breaks. We're at 1173 downloads for 3.5 from PyPI in the last 6 months, 74 in the last 30 days (likely accelerated by this issue)

2.) Pylint recently introduced ``possibly-used-before-assignment``, which mostly flagged cases where we import a library like termios that doesn't exist on Windows. All the cases are guarded, but not always directly, so Pylint can't figure it out. Mostly I just disabled these in-line.