### PR TITLE
Add additional options to codecov-action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,8 +95,11 @@ jobs:
       - name: Upload to Codecov
         if: ${{ matrix.label != 'linting' }}
 
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           verbose: true
           name: ${{ matrix.label || matrix.python-version }} ${{ startsWith(matrix.os, 'windows') && '(Windows)' || '' }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          os: ${{ startsWith(matrix.os, 'windows') && 'windows' || 'linux' }}
           env_vars: TOXENV,TEST_QUICK,TEST_KEYBOARD,TEST_RAW

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Upload to Codecov
         if: ${{ matrix.label != 'linting' }}
 
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           verbose: true
           name: ${{ matrix.label || matrix.python-version }} ${{ startsWith(matrix.os, 'windows') && '(Windows)' || '' }}


### PR DESCRIPTION
I noticed after the last PR that a CodeCov report hadn't been generated. It looks like they haven't worked for a few months. It seems they are now requiring a token where previously it was optional. I also added the option to fail if codecov fails, which used to happen when we used the cli directly, but is disabled by default with the codecov action.

I also tried to update the action to V4, but that failed for 2.7 because the action (both V3 and V4) use a PyInstaller wrapped binary of the codecov-cli and one of the subcommands used in V4 is looking for a slightly newer version of glibc than the docker image for 2.7 provides. https://github.com/codecov/codecov-action/issues/1277
