### PR TITLE
call length less in _wrap_chunks

### DIFF
--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -189,7 +189,7 @@ class SequenceTextWrapper(textwrap.TextWrapper):
                     break
                 cur_line.append(chunks.pop())
                 cur_len += chunk_len
-            if chunks and Sequence(chunks[-1], term).length() > width:
+            if chunks and chunk_len > width:
                 self._handle_long_word(chunks, cur_line, cur_len, width)
             if drop_whitespace and (
                     cur_line and Sequence(cur_line[-1], term).strip() == ''):


### PR DESCRIPTION
call Sequence.length/iter_parse fewer times

before:
```
         3117 function calls in 0.005 seconds

   Ordered by: cumulative time
   List reduced from 39 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.005    0.005 terminal.py:1215(wrap)
        1    0.000    0.000    0.005    0.005 textwrap.py:342(wrap)
        1    0.000    0.000    0.005    0.005 sequences.py:155(_wrap_chunks)
      777    0.004    0.000    0.004    0.000 sequences.py:431(iter_parse)
```
after
```
         2301 function calls in 0.004 seconds

   Ordered by: cumulative time
   List reduced from 39 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.004    0.004 terminal.py:1215(wrap)
        1    0.000    0.000    0.004    0.004 textwrap.py:342(wrap)
        1    0.000    0.000    0.004    0.004 sequences.py:155(_wrap_chunks)
      585    0.003    0.000    0.003    0.000 sequences.py:431(iter_parse)
```