### PR TITLE
Housekeeping

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,20 @@ jobs:
         run: tox
 
       - name: Upload to Codecov
-        if: ${{ matrix.label != 'linting' }}
+        if: ${{ matrix.label != 'linting' && matrix.python-version != '2.7' }}
+
+        uses: codecov/codecov-action@v4
+        with:
+          verbose: true
+          name: ${{ matrix.label || matrix.python-version }} ${{ startsWith(matrix.os, 'windows') && '(Windows)' || '' }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          os: ${{ startsWith(matrix.os, 'windows') && 'windows' || 'linux' }}
+          env_vars: TOXENV,TEST_QUICK,TEST_KEYBOARD,TEST_RAW
+
+      # Work around for https://github.com/codecov/codecov-action/issues/1277
+      - name: Upload to Codecov (2.7 workaround)
+        if: ${{ matrix.python-version == '2.7' && matrix.label != 'linting' }}
 
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,25 +20,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         test_quick: [1]
 
         include:
-          - python-version: '3.12'
+          - python-version: '3.13'
             label: Linting
             toxenv: docformatter_check,flake8,flake8_tests,isort_check,mypy,sphinx,pydocstyle,pylint,pylint_tests
 
-          - python-version: '3.13-dev'
+          - python-version: '3.14-dev'
             optional: true
-            toxenv: py313
-            toxpython: 3.13
+            toxenv: py314
+            toxpython: 3.14
 
-          - python-version: '3.12'
+          - python-version: '3.13'
             test_keyboard: 1
             test_raw: 1
             test_quick: 0
 
-          - python-version: '3.12'
+          - python-version: '3.13'
             os: windows-latest
             test_quick: 0
 

--- a/bin/generate-keycodes.py
+++ b/bin/generate-keycodes.py
@@ -17,7 +17,7 @@ def main():
     csv_header = """
 .. csv-table:: All Terminal class attribute Keyboard codes, by name
    :delim: |
-   :header: "Name", "Value", "Example Sequence(s)"
+   :header: "Name"| "Value"| "Example Sequence(s)"
 
 """
     fname = os.path.abspath(

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -85,7 +85,7 @@ class Termcap(object):
 
         return 0
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-positional-arguments
     @classmethod
     def build(cls, name, capability, attribute, nparams=0,
               numeric=99, match_grouped=False, match_any=False,

--- a/blessed/sequences.pyi
+++ b/blessed/sequences.pyi
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 _T = TypeVar("_T")
 
 # pylint: disable=unused-argument,missing-function-docstring,missing-class-docstring
-# pylint: disable=super-init-not-called
+# pylint: disable=super-init-not-called,too-many-positional-arguments
 
 class Termcap:
     name: str = ...

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,6 @@ import runpy
 import functools
 
 # 3rd party
-import sphinx_rtd_theme
 import sphinx.environment
 from docutils.utils import get_source_line
 
@@ -155,7 +154,7 @@ html_theme = "sphinx_rtd_theme"
 # html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,8 @@ setuptools.setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: User Interfaces',
         'Topic :: Terminals',

--- a/tox.ini
+++ b/tox.ini
@@ -17,13 +17,13 @@ envlist =
     pydocstyle
     mypy
     sphinx
-    py{27,35,36,37,38,39,310,311,312}
+    py{27,35,36,37,38,39,310,311,312,313}
 
 
 ####### Python Test Environments #######
 
 [testenv]
-basepython = python3.12
+basepython = python3.13
 passenv =
     TEST_QUICK
     TEST_KEYBOARD
@@ -37,7 +37,7 @@ deps =
 commands =
     pytest {posargs: --strict-markers --verbose --durations=3} tests
 
-[testenv:py312]
+[testenv:py313]
 setenv =
     TEST_QUICK = {env:TEST_QUICK:0}
     TEST_KEYBOARD = {env:TEST_KEYBOARD:1}


### PR DESCRIPTION
A few housekeeping tasks
- Fix pylint errors that were breaking CI tests
  - Too many positional arguments on ``Termcap.build()``
- Fix Sphinx issues that were breaking CI tests
  - Deprecated behavior in conf.py
  - ``csv-table`` used for keycodes now requires the deliminator in the header rather than a comma
- Update Python versions
  - Default for testing switched to 3.13
  - Added 3.14-pre as optional in CI
- Added logic to CI to use Codecov uploader version 4 except for Python 2.7, which uses version 3
  - Maybe this will help with the random rate limit errors
  - They released version 5 on November 14th, but it might be good to wait since they have done 7 bug releases since then