### PR TITLE
Pin OS for Python 3.7 in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         test_quick: [1]
 
         include:
@@ -41,6 +41,10 @@ jobs:
           - python-version: '3.13'
             os: windows-latest
             test_quick: 0
+
+          - python-version: '3.7'
+            os: ubuntu-22.04
+            toxenv: py37
 
           - python-version: '3.6'
             os:  ubuntu-20.04


### PR DESCRIPTION
Looks like ubuntu-latest in GitHib Actions moved to 24.04, which dropped support for Python 3.7, so we have to pin it to use 22.04
