### PR TITLE
Drop six requirement

### DIFF
--- a/blessed/_compat.py
+++ b/blessed/_compat.py
@@ -1,0 +1,24 @@
+"""Provides compatibility between different Python versions."""
+
+# std imports
+import sys
+
+__all__ = 'PY2', 'unicode_chr', 'StringIO', 'TextType', 'StringType'
+
+# isort: off
+
+# Python 3
+if sys.version_info[0] >= 3:
+    PY2 = False
+    unicode_chr = chr
+    from io import StringIO
+    TextType = str
+    StringType = str
+
+# Python 2
+else:
+    PY2 = True
+    unicode_chr = unichr  # pylint: disable=undefined-variable  # noqa: F821
+    from StringIO import StringIO
+    TextType = unicode  # pylint: disable=undefined-variable  # noqa: F821
+    StringType = basestring  # pylint: disable=undefined-variable  # noqa: F821

--- a/blessed/formatters.py
+++ b/blessed/formatters.py
@@ -2,10 +2,8 @@
 # std imports
 import platform
 
-# 3rd party
-import six
-
 # local
+from blessed._compat import TextType, StringType
 from blessed.colorspace import CGA_COLORS, X11_COLORNAMES_TO_RGB
 
 # isort: off
@@ -48,7 +46,7 @@ COLORS = _make_colors()
 COMPOUNDABLES = set('bold underline reverse blink italic standout'.split())
 
 
-class ParameterizingString(six.text_type):
+class ParameterizingString(TextType):
     r"""
     A Unicode string which can be called as a parameterizing termcap.
 
@@ -70,7 +68,7 @@ class ParameterizingString(six.text_type):
         :arg str normal: terminating sequence for this capability (optional).
         :arg str name: name of this terminal capability (optional).
         """
-        new = six.text_type.__new__(cls, cap)
+        new = TextType.__new__(cls, cap)
         new._normal = normal
         new._name = name
         return new
@@ -97,7 +95,7 @@ class ParameterizingString(six.text_type):
         except TypeError as err:
             # If the first non-int (i.e. incorrect) arg was a string, suggest
             # something intelligent:
-            if args and isinstance(args[0], six.string_types):
+            if args and isinstance(args[0], StringType):
                 raise TypeError(
                     "Unknown terminal capability, %r, or, TypeError "
                     "for arguments %r: %s" % (self._name, args, err))
@@ -108,12 +106,12 @@ class ParameterizingString(six.text_type):
             # ignore 'tparm() returned NULL', you won't get any styling,
             # even if does_styling is True. This happens on win32 platforms
             # with http://www.lfd.uci.edu/~gohlke/pythonlibs/#curses installed
-            if "tparm() returned NULL" not in six.text_type(err):
+            if "tparm() returned NULL" not in TextType(err):
                 raise
             return NullCallableString()
 
 
-class ParameterizingProxyString(six.text_type):
+class ParameterizingProxyString(TextType):
     r"""
     A Unicode string which can be called to proxy missing termcap entries.
 
@@ -150,7 +148,7 @@ class ParameterizingProxyString(six.text_type):
         """
         assert isinstance(fmt_pair, tuple), fmt_pair
         assert callable(fmt_pair[1]), fmt_pair[1]
-        new = six.text_type.__new__(cls, fmt_pair[0])
+        new = TextType.__new__(cls, fmt_pair[0])
         new._fmt_args = fmt_pair[1]
         new._normal = normal
         new._name = name
@@ -172,7 +170,7 @@ class ParameterizingProxyString(six.text_type):
                                 self._normal)
 
 
-class FormattingString(six.text_type):
+class FormattingString(TextType):
     r"""
     A Unicode string which doubles as a callable.
 
@@ -199,7 +197,7 @@ class FormattingString(six.text_type):
         :arg str sequence: terminal attribute sequence.
         :arg str normal: terminating sequence for this attribute (optional).
         """
-        new = six.text_type.__new__(cls, sequence)
+        new = TextType.__new__(cls, sequence)
         new._normal = normal
         return new
 
@@ -217,13 +215,11 @@ class FormattingString(six.text_type):
         #
         # >>> t.red('This is ', t.bold('extremely'), ' dangerous!')
         for idx, ucs_part in enumerate(args):
-            if not isinstance(ucs_part, six.string_types):
-                expected_types = ', '.join(_type.__name__ for _type in six.string_types)
+            if not isinstance(ucs_part, StringType):
                 raise TypeError(
-                    "TypeError for FormattingString argument, "
-                    "%r, at position %s: expected type %s, "
-                    "got %s" % (ucs_part, idx, expected_types,
-                                type(ucs_part).__name__))
+                    "TypeError for FormattingString argument, %r, at position %s: expected type "
+                    "%s, got %s" % (ucs_part, idx, StringType.__name__, type(ucs_part).__name__)
+                )
         postfix = u''
         if self and self._normal:
             postfix = self._normal
@@ -234,7 +230,7 @@ class FormattingString(six.text_type):
         return self + u''.join(args) + postfix
 
 
-class FormattingOtherString(six.text_type):
+class FormattingOtherString(TextType):
     r"""
     A Unicode string which doubles as a callable for another sequence when called.
 
@@ -260,20 +256,20 @@ class FormattingOtherString(six.text_type):
         :arg str direct: capability name for direct formatting, eg ``('x' + term.right)``.
         :arg str target: capability name for callable, eg ``('x' + term.right(99))``.
         """
-        new = six.text_type.__new__(cls, direct)
+        new = TextType.__new__(cls, direct)
         new._callable = target
         return new
 
     def __getnewargs__(self):
         # return arguments used for the __new__ method upon unpickling.
-        return six.text_type.__new__(six.text_type, self), self._callable
+        return TextType.__new__(TextType, self), self._callable
 
     def __call__(self, *args):
         """Return ``text`` by ``target``."""
         return self._callable(*args) if args else self
 
 
-class NullCallableString(six.text_type):
+class NullCallableString(TextType):
     """
     A dummy callable Unicode alternative to :class:`FormattingString`.
 
@@ -283,7 +279,7 @@ class NullCallableString(six.text_type):
 
     def __new__(cls):
         """Class constructor."""
-        return six.text_type.__new__(cls, u'')
+        return TextType.__new__(cls, u'')
 
     def __call__(self, *args):
         """

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -7,8 +7,8 @@ import time
 import platform
 from collections import OrderedDict
 
-# 3rd party
-import six
+# local
+from blessed._compat import TextType, unicode_chr
 
 # isort: off
 # curses
@@ -21,7 +21,7 @@ else:
     from curses.has_key import _capability_names as capability_names
 
 
-class Keystroke(six.text_type):
+class Keystroke(TextType):
     """
     A unicode-derived class for describing a single keystroke.
 
@@ -42,7 +42,7 @@ class Keystroke(six.text_type):
 
     def __new__(cls, ucs='', code=None, name=None):
         """Class constructor."""
-        new = six.text_type.__new__(cls, ucs)
+        new = TextType.__new__(cls, ucs)
         new._name = name
         new._code = code
         return new
@@ -54,9 +54,9 @@ class Keystroke(six.text_type):
 
     def __repr__(self):
         """Docstring overwritten."""
-        return (six.text_type.__repr__(self) if self._name is None else
+        return (TextType.__repr__(self) if self._name is None else
                 self._name)
-    __repr__.__doc__ = six.text_type.__doc__
+    __repr__.__doc__ = TextType.__doc__
 
     @property
     def name(self):
@@ -361,12 +361,12 @@ for keycode_name in _CURSES_KEYCODE_ADDINS:
 DEFAULT_SEQUENCE_MIXIN = (
     # these common control characters (and 127, ctrl+'?') mapped to
     # an application key definition.
-    (six.unichr(10), curses.KEY_ENTER),
-    (six.unichr(13), curses.KEY_ENTER),
-    (six.unichr(8), curses.KEY_BACKSPACE),
-    (six.unichr(9), KEY_TAB),  # noqa  # pylint: disable=undefined-variable
-    (six.unichr(27), curses.KEY_EXIT),
-    (six.unichr(127), curses.KEY_BACKSPACE),
+    (unicode_chr(10), curses.KEY_ENTER),
+    (unicode_chr(13), curses.KEY_ENTER),
+    (unicode_chr(8), curses.KEY_BACKSPACE),
+    (unicode_chr(9), KEY_TAB),  # noqa  # pylint: disable=undefined-variable
+    (unicode_chr(27), curses.KEY_EXIT),
+    (unicode_chr(127), curses.KEY_BACKSPACE),
 
     (u"\x1b[A", curses.KEY_UP),
     (u"\x1b[B", curses.KEY_DOWN),

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -6,10 +6,10 @@ import math
 import textwrap
 
 # 3rd party
-import six
 from wcwidth import wcwidth
 
 # local
+from blessed._compat import TextType
 from blessed._capabilities import CAPABILITIES_CAUSE_MOVEMENT
 
 __all__ = ('Sequence', 'SequenceTextWrapper', 'iter_parse', 'measure_length')
@@ -241,7 +241,7 @@ class SequenceTextWrapper(textwrap.TextWrapper):
 SequenceTextWrapper.__doc__ = textwrap.TextWrapper.__doc__
 
 
-class Sequence(six.text_type):
+class Sequence(TextType):
     """
     A "sequence-aware" version of the base :class:`str` class.
 
@@ -258,7 +258,7 @@ class Sequence(six.text_type):
         :arg str sequence_text: A string that may contain sequences.
         :arg blessed.Terminal term: :class:`~.Terminal` instance.
         """
-        new = six.text_type.__new__(cls, sequence_text)
+        new = TextType.__new__(cls, sequence_text)
         new._term = term
         return new
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 wcwidth>=0.1.4
-six>=1.9.0
 # support python2.6 by using backport of 'orderedict'
 ordereddict==1.1; python_version < "2.7"
 # support python2.7 by using backport of 'functools.lru_cache'

--- a/tests/accessories.py
+++ b/tests/accessories.py
@@ -10,11 +10,9 @@ import functools
 import traceback
 import contextlib
 
-# 3rd party
-import six
-
 # local
 from blessed import Terminal
+from blessed._compat import TextType
 from .conftest import IS_WINDOWS
 
 try:
@@ -105,7 +103,7 @@ class as_subprocess(object):  # pylint: disable=too-few-public-methods
                   .format(pid_testrunner, os.getpid()), file=sys.stderr)
             os._exit(1)
 
-        exc_output = six.text_type()
+        exc_output = TextType()
         decoder = codecs.getincrementaldecoder(self.encoding)()
         while True:
             try:
@@ -145,7 +143,7 @@ def read_until_semaphore(fd, semaphore=RECV_SEMAPHORE, encoding='utf8'):
     # process will read xyz\\r\\n -- this is how pseudo terminals
     # behave; a virtual terminal requires both carriage return and
     # line feed, it is only for convenience that \\n does both.
-    outp = six.text_type()
+    outp = TextType()
     decoder = codecs.getincrementaldecoder(encoding)()
     semaphore = semaphore.decode('ascii')
     while not outp.startswith(semaphore):
@@ -169,7 +167,7 @@ def read_until_eof(fd, encoding='utf8'):
     Return decoded string.
     """
     decoder = codecs.getincrementaldecoder(encoding)()
-    outp = six.text_type()
+    outp = TextType()
     while True:
         try:
             _exc = os.read(fd, 100)

--- a/tests/test_full_keyboard.py
+++ b/tests/test_full_keyboard.py
@@ -10,10 +10,10 @@ import signal
 import platform
 
 # 3rd party
-import six
 import pytest
 
 # local
+from blessed._compat import PY2, StringIO
 from .accessories import (SEMAPHORE,
                           RECV_SEMAPHORE,
                           SEND_SEMAPHORE,
@@ -136,7 +136,7 @@ def test_kbhit_no_kb():
     """kbhit() always immediately returns False without a keyboard."""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=StringIO())
         stime = time.time()
         assert term._keyboard_fd is None
         assert not term.kbhit(timeout=1.1)
@@ -149,7 +149,7 @@ def test_kbhit_no_tty():
     @as_subprocess
     def child():
         with mock.patch('blessed.terminal.HAS_TTY', False):
-            term = TestTerminal(stream=six.StringIO())
+            term = TestTerminal(stream=StringIO())
             stime = time.time()
             assert term.kbhit(timeout=1.1) is False
             assert math.floor(time.time() - stime) == 0
@@ -173,7 +173,7 @@ def test_keystroke_0s_cbreak_noinput_nokb():
     """0-second keystroke without data in input stream and no keyboard/tty."""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=StringIO())
         with term.cbreak():
             stime = time.time()
             inp = term.inkey(timeout=0)
@@ -201,7 +201,7 @@ def test_keystroke_1s_cbreak_noinput_nokb():
     """1-second keystroke without input or keyboard."""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=StringIO())
         with term.cbreak():
             stime = time.time()
             inp = term.inkey(timeout=1)
@@ -582,7 +582,7 @@ def test_get_location_0s():
     """0-second get_location call without response."""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=StringIO())
         stime = time.time()
         y, x = term.get_location(timeout=0)
         assert (math.floor(time.time() - stime) == 0.0)
@@ -650,7 +650,7 @@ def test_get_location_0s_reply_via_ungetch():
     """0-second get_location call with response."""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=StringIO())
         stime = time.time()
         # monkey patch in an invalid response !
         term.ungetch(u'\x1b[10;10R')
@@ -667,7 +667,7 @@ def test_get_location_0s_nonstandard_u6():
 
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=StringIO())
 
         stime = time.time()
         # monkey patch in an invalid response !
@@ -685,12 +685,12 @@ def test_get_location_styling_indifferent():
     """Ensure get_location() behavior is the same regardless of styling"""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO(), force_styling=True)
+        term = TestTerminal(stream=StringIO(), force_styling=True)
         term.ungetch(u'\x1b[10;10R')
         y, x = term.get_location(timeout=0.01)
         assert (y, x) == (9, 9)
 
-        term = TestTerminal(stream=six.StringIO(), force_styling=False)
+        term = TestTerminal(stream=StringIO(), force_styling=False)
         term.ungetch(u'\x1b[10;10R')
         y, x = term.get_location(timeout=0.01)
         assert (y, x) == (9, 9)
@@ -701,7 +701,7 @@ def test_get_location_timeout():
     """0-second get_location call with response."""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=StringIO())
         stime = time.time()
         # monkey patch in an invalid response !
         term.ungetch(u'\x1b[0n')
@@ -716,7 +716,7 @@ def test_get_fgcolor_0s():
     """0-second get_fgcolor call without response."""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=StringIO())
         stime = time.time()
         rgb = term.get_fgcolor(timeout=0)
         assert math.floor(time.time() - stime) == 0.0
@@ -728,7 +728,7 @@ def test_get_fgcolor_0s_reply_via_ungetch():
     """0-second get_fgcolor call with response."""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=StringIO())
         stime = time.time()
         term.ungetch(u'\x1b]10;rgb:a0/52/2d\x07')  # sienna
 
@@ -742,12 +742,12 @@ def test_get_fgcolor_styling_indifferent():
     """Ensure get_fgcolor() behavior is the same regardless of styling"""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO(), force_styling=True)
+        term = TestTerminal(stream=StringIO(), force_styling=True)
         term.ungetch(u'\x1b]10;rgb:d2/b4/8c\x07')  # tan
         rgb = term.get_fgcolor(timeout=0.01)
         assert rgb == (210, 180, 140)
 
-        term = TestTerminal(stream=six.StringIO(), force_styling=False)
+        term = TestTerminal(stream=StringIO(), force_styling=False)
         term.ungetch(u'\x1b]10;rgb:40/e0/d0\x07')  # turquoise
         rgb = term.get_fgcolor(timeout=0.01)
         assert rgb == (64, 224, 208)
@@ -758,7 +758,7 @@ def test_get_bgcolor_0s():
     """0-second get_bgcolor call without response."""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=StringIO())
         stime = time.time()
         rgb = term.get_bgcolor(timeout=0)
         assert math.floor(time.time() - stime) == 0.0
@@ -770,7 +770,7 @@ def test_get_bgcolor_0s_reply_via_ungetch():
     """0-second get_bgcolor call with response."""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=StringIO())
         stime = time.time()
         term.ungetch(u'\x1b]11;rgb:99/32/cc\x07')  # darkorchid
 
@@ -784,19 +784,19 @@ def test_get_bgcolor_styling_indifferent():
     """Ensure get_bgcolor() behavior is the same regardless of styling"""
     @as_subprocess
     def child():
-        term = TestTerminal(stream=six.StringIO(), force_styling=True)
+        term = TestTerminal(stream=StringIO(), force_styling=True)
         term.ungetch(u'\x1b]11;rgb:ff/e4/c4\x07')  # bisque
         rgb = term.get_bgcolor(timeout=0.01)
         assert rgb == (255, 228, 196)
 
-        term = TestTerminal(stream=six.StringIO(), force_styling=False)
+        term = TestTerminal(stream=StringIO(), force_styling=False)
         term.ungetch(u'\x1b]11;rgb:de/b8/87\x07')  # burlywood
         rgb = term.get_bgcolor(timeout=0.01)
         assert rgb == (222, 184, 135)
     child()
 
 
-@pytest.mark.skipif(six.PY2, reason="Python 3 only")
+@pytest.mark.skipif(PY2, reason="Python 3 only")
 def test_detached_stdout():
     """Ensure detached __stdout__ does not raise an exception"""
     import pty

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -8,9 +8,9 @@ import functools
 
 # 3rd party
 import pytest
-import six
 
 # local
+from blessed._compat import unicode_chr
 from .accessories import TestTerminal, as_subprocess
 from .conftest import IS_WINDOWS
 
@@ -308,12 +308,12 @@ def test_keypad_mixins_and_aliases():  # pylint: disable=too-many-statements
                                     mapper=term._keymap,
                                     codes=term._keycodes)
 
-        assert resolve(six.unichr(10)).name == "KEY_ENTER"
-        assert resolve(six.unichr(13)).name == "KEY_ENTER"
-        assert resolve(six.unichr(8)).name == "KEY_BACKSPACE"
-        assert resolve(six.unichr(9)).name == "KEY_TAB"
-        assert resolve(six.unichr(27)).name == "KEY_ESCAPE"
-        assert resolve(six.unichr(127)).name == "KEY_BACKSPACE"
+        assert resolve(unicode_chr(10)).name == "KEY_ENTER"
+        assert resolve(unicode_chr(13)).name == "KEY_ENTER"
+        assert resolve(unicode_chr(8)).name == "KEY_BACKSPACE"
+        assert resolve(unicode_chr(9)).name == "KEY_TAB"
+        assert resolve(unicode_chr(27)).name == "KEY_ESCAPE"
+        assert resolve(unicode_chr(127)).name == "KEY_BACKSPACE"
         assert resolve(u"\x1b[A").name == "KEY_UP"
         assert resolve(u"\x1b[B").name == "KEY_DOWN"
         assert resolve(u"\x1b[C").name == "KEY_RIGHT"

--- a/tests/test_length_sequence.py
+++ b/tests/test_length_sequence.py
@@ -9,10 +9,10 @@ import platform
 import itertools
 
 # 3rd party
-import six
 import pytest
 
 # local
+from blessed._compat import StringIO
 from .accessories import TestTerminal, as_subprocess
 from .conftest import IS_WINDOWS
 
@@ -308,7 +308,7 @@ def test_env_winsize():
         # set the pty's virtual window size
         os.environ['COLUMNS'] = '99'
         os.environ['LINES'] = '11'
-        term = TestTerminal(stream=six.StringIO())
+        term = TestTerminal(stream=StringIO())
         save_init = term._init_descriptor
         save_stdout = sys.__stdout__
         try:

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -5,10 +5,10 @@ import sys
 import platform
 
 # 3rd party
-import six
 import pytest
 
 # local
+from blessed._compat import StringIO
 from .accessories import TestTerminal, unicode_cap, unicode_parm, as_subprocess, MockTigetstr
 from .conftest import IS_WINDOWS
 
@@ -36,7 +36,7 @@ def test_capability_without_tty():
     """Assert capability templates are '' when stream is not a tty."""
     @as_subprocess
     def child():
-        t = TestTerminal(stream=six.StringIO())
+        t = TestTerminal(stream=StringIO())
         assert t.save == u''
         assert t.red == u''
 
@@ -47,7 +47,7 @@ def test_capability_with_forced_tty():
     """force styling should return sequences even for non-ttys."""
     @as_subprocess
     def child():
-        t = TestTerminal(stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(stream=StringIO(), force_styling=True)
         assert t.save == unicode_cap('sc')
 
     child()
@@ -58,7 +58,7 @@ def test_basic_url():
     @as_subprocess
     def child():
         # given
-        t = TestTerminal(stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(stream=StringIO(), force_styling=True)
         given_url = 'https://blessed.readthedocs.org'
         given_text = 'documentation'
         expected_output = ('\x1b]8;;{0}\x1b\\{1}\x1b]8;;\x1b\\'
@@ -78,7 +78,7 @@ def test_url_with_id():
     @as_subprocess
     def child():
         # given
-        t = TestTerminal(stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(stream=StringIO(), force_styling=True)
         given_url = 'https://blessed.readthedocs.org'
         given_text = 'documentation'
         given_url_id = '123'
@@ -128,7 +128,7 @@ def test_location_with_styling(all_terms):
     """Make sure ``location()`` works on all terminals."""
     @as_subprocess
     def child_with_styling(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(kind=kind, stream=StringIO(), force_styling=True)
         with t.location(3, 4):
             t.stream.write(u'hi')
         expected_output = u''.join(
@@ -146,7 +146,7 @@ def test_location_without_styling():
     @as_subprocess
     def child_without_styling():
         """No side effect for location as a context manager without styling."""
-        t = TestTerminal(stream=six.StringIO(), force_styling=None)
+        t = TestTerminal(stream=StringIO(), force_styling=None)
 
         with t.location(3, 4):
             t.stream.write(u'hi')
@@ -160,7 +160,7 @@ def test_horizontal_location(all_terms):
     """Make sure we can move the cursor horizontally without changing rows."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(kind=kind, stream=StringIO(), force_styling=True)
         with t.location(x=5):
             pass
         _hpa = unicode_parm('hpa', 5)
@@ -181,7 +181,7 @@ def test_vertical_location(all_terms):
     """Make sure we can move the cursor horizontally without changing rows."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(kind=kind, stream=StringIO(), force_styling=True)
         with t.location(y=5):
             pass
         _vpa = unicode_parm('vpa', 5)
@@ -203,7 +203,7 @@ def test_inject_move_x():
     """Test injection of hpa attribute for screen/ansi (issue #55)."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(kind=kind, stream=StringIO(), force_styling=True)
         COL = 5
         with mock.patch('curses.tigetstr', side_effect=MockTigetstr(hpa=None)):
             with t.location(x=COL):
@@ -225,7 +225,7 @@ def test_inject_move_y():
     """Test injection of vpa attribute for screen/ansi (issue #55)."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(kind=kind, stream=StringIO(), force_styling=True)
         ROW = 5
         with mock.patch('curses.tigetstr', side_effect=MockTigetstr(vpa=None)):
             with t.location(y=ROW):
@@ -247,7 +247,7 @@ def test_inject_civis_and_cnorm_for_ansi():
     """Test injection of civis attribute for ansi."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(kind=kind, stream=StringIO(), force_styling=True)
         with t.hidden_cursor():
             pass
         expected_output = u'\x1b[?25l\x1b[?25h'
@@ -261,7 +261,7 @@ def test_inject_sc_and_rc_for_ansi():
     """Test injection of sc and rc (save and restore cursor) for ansi."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(kind=kind, stream=StringIO(), force_styling=True)
         with t.location():
             pass
         expected_output = u'\x1b[s\x1b[u'
@@ -274,7 +274,7 @@ def test_zero_location(all_terms):
     """Make sure ``location()`` pays attention to 0-valued args."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO(), force_styling=True)
+        t = TestTerminal(kind=kind, stream=StringIO(), force_styling=True)
         with t.location(0, 0):
             pass
         expected_output = u''.join(
@@ -350,7 +350,7 @@ def test_null_callable_numeric_colors(all_terms):
     """``color(n)`` should be a no-op on null terminals."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(stream=six.StringIO(), kind=kind)
+        t = TestTerminal(stream=StringIO(), kind=kind)
         assert (t.color(5)('smoo') == 'smoo')
         assert (t.on_color(6)('smoo') == 'smoo')
 
@@ -442,7 +442,7 @@ def test_formatting_functions_without_tty(all_terms):
     """Test crazy-ass formatting wrappers when there's no tty."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(kind=kind, stream=six.StringIO(), force_styling=False)
+        t = TestTerminal(kind=kind, stream=StringIO(), force_styling=False)
         assert (t.bold(u'hi') == u'hi')
         assert (t.green('hi') == u'hi')
         # Test non-ASCII chars, no longer really necessary:
@@ -504,7 +504,7 @@ def test_null_callable_string(all_terms):
     """Make sure NullCallableString tolerates all kinds of args."""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(stream=six.StringIO(), kind=kind)
+        t = TestTerminal(stream=StringIO(), kind=kind)
         assert (t.clear == '')
         assert (t.move(False) == '')
         assert (t.move_x(1) == '')
@@ -605,7 +605,7 @@ def test_formatting_other_string(all_terms):
     """FormattingOtherString output depends on how it's called"""
     @as_subprocess
     def child(kind):
-        t = TestTerminal(stream=six.StringIO(), kind=kind, force_styling=True)
+        t = TestTerminal(stream=StringIO(), kind=kind, force_styling=True)
 
         assert (t.move_left == t.cub1)
         assert (t.move_left() == t.cub1)


### PR DESCRIPTION
This is to address #281 in a more complete and performant way. We were only using six things from six (go figure):
- PY2
- unichr
  - made this `unicode_chr` to avoid conflicts with the Python 2 builtin
- StringIO
- text_type
  - Made this `TextType` to make the linter happy about class naming styles
- string_types
  - This was either `(str, )` or `(basestring, )`, so I got rid of the tuples and called it `StringType`
    - This seems to reduce the time `isinstance()` takes by ~40%
- six.moves.reload_module

`reload_module` logic was put in `test_core` since that's the only place it's used and we don't want to import things we don't need. The rest were put in `blessed._compat`

This should help Debian in their efforts, but it also gets rid of importing all of six when we only need a few things. The memory win is small, but it's something.
