### PR TITLE
Use Python containers for Gitlab CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,24 +14,25 @@ jobs:
 
     continue-on-error: ${{ matrix.optional || false }}
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
-    container: ${{ matrix.container }}
+    container: ${{ !startsWith(matrix.os, 'windows') && (matrix.container || format('python:{0}', matrix.python-version)) || null }}
     name: ${{ matrix.label || matrix.python-version }} ${{ startsWith(matrix.os, 'windows') && '(Windows)' || '' }} ${{ matrix.optional && '[OPTIONAL]' }}
 
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version:  ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         test_quick: [1]
 
         include:
           - python-version: '3.13'
             label: Linting
             toxenv: docformatter_check,flake8,flake8_tests,isort_check,mypy,sphinx,pydocstyle,pylint,pylint_tests
+            os-deps:
+              - enchant-2
 
-          - python-version: '3.14-dev'
+          - python-version: '3.14'
+            container: 'python:3.14-rc'
             optional: true
-            toxenv: py314
-            toxpython: 3.14
 
           - python-version: '3.13'
             test_keyboard: 1
@@ -42,25 +43,10 @@ jobs:
             os: windows-latest
             test_quick: 0
 
-          - python-version: '3.7'
-            os: ubuntu-22.04
-            toxenv: py37
-
-          - python-version: '3.6'
-            os:  ubuntu-20.04
-            toxenv: py36
-
-          - python-version: '3.5'
-            os:  ubuntu-20.04
-            toxenv: py35
-
           - python-version: '2.7'
-            container: {image: 'python:2.7.18-buster'}
-            toxenv: py27
             test_keyboard: 1
             test_raw: 1
             test_quick: 0
-
 
     env:
       TOXENV: ${{ matrix.toxenv || format('py{0}', matrix.python-version) }}
@@ -70,22 +56,16 @@ jobs:
       TOXPYTHON: python${{ matrix.toxpython || matrix.python-version }}
 
     steps:
+      # This is only needed for Python 3.6 and earlier because Tox 4 requires 3.7+
+      - name: Fix TOXENV
+        run: echo "TOXENV=$(echo $TOXENV | sed 's/\.//g')" >> $GITHUB_ENV
+        if: ${{ contains(fromJson('["2.7", "3.5", "3.6"]'), matrix.python-version) }}
+
+      - name: Install OS Dependencies
+        run: apt update && apt -y install ${{ join(matrix.os-deps, ' ') }}
+        if: ${{ matrix.os-deps }}
+
       - uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-        if: ${{ matrix.python-version != '2.7' && matrix.python-version != '3.5' }}
-
-      # Workaround for https://github.com/actions/setup-python/issues/866
-      - name: Set up Python 3.5 (Workaround)
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.5
-        env:
-          PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
-        if: ${{ matrix.python-version == '3.5' }}
 
       - name: Install tox
         run: pip install tox
@@ -97,7 +77,7 @@ jobs:
         run: tox
 
       - name: Upload to Codecov
-        if: ${{ matrix.label != 'linting' && matrix.python-version != '2.7' }}
+        if: ${{ matrix.label != 'linting' && !contains(fromJson('["2.7", "3.5"]'), matrix.python-version) }}
 
         uses: codecov/codecov-action@v4
         with:
@@ -109,8 +89,8 @@ jobs:
           env_vars: TOXENV,TEST_QUICK,TEST_KEYBOARD,TEST_RAW
 
       # Work around for https://github.com/codecov/codecov-action/issues/1277
-      - name: Upload to Codecov (2.7 workaround)
-        if: ${{ matrix.python-version == '2.7' && matrix.label != 'linting' }}
+      - name: Upload to Codecov Workaround
+        if: ${{ matrix.label != 'linting' && contains(fromJson('["2.7", "3.5"]'), matrix.python-version) }}
 
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
Tests are currently failing because the OS image we were using for 3.5 and 3.6 has been removed. Initially I was going to work around this the way it was done for 2.7, pinning it to a Python container, but thought it would be better to just do everything (except Windows) in Python containers.

While Python containers do exist for Windows, Windows containers aren't supported in GitHub Actions, so Windows stays the same. Interestingly, the Windows images have multiple Python versions installed, so we don't even need the Python install task. Setting ``TOXPYTHON`` will do.

For the rest, they use ``python:{matrix.python-version}`` for the container unless it's specified. These docker images will get updated when new Python versions come out. For unsupported versions they remain static, but that's ok.

This should simplify thing and get us out of having to deal with OS image deprecation.