### PR TITLE
Minor fixes for failing tests

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -9,6 +9,7 @@ load-plugins=
 persistent = no
 jobs = 0
 unsafe-load-any-extension = yes
+ignore-paths=.*.pyi
 
 [MESSAGES CONTROL]
 disable=

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,4 +15,5 @@ python:
   install:
     - method: setuptools
       path: .
+    - requirements: requirements.txt
     - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 Pillow
 Sphinx>3
-jinxed
 sphinx-paramlinks
 sphinx_rtd_theme
 sphinxcontrib-manpage

--- a/tests/test_length_sequence.py
+++ b/tests/test_length_sequence.py
@@ -12,7 +12,7 @@ import itertools
 import pytest
 
 # local
-from blessed._compat import StringIO
+from blessed._compat import StringIO, PY2
 from .accessories import TestTerminal, as_subprocess
 from .conftest import IS_WINDOWS
 
@@ -56,12 +56,16 @@ def test_length_ansiart():
     """Test length of ANSI art"""
     @as_subprocess
     def child(kind):
-        import codecs
+        if PY2:
+            from codecs import open as open_
+        else:
+            open_ = open
+
         term = TestTerminal(kind=kind)
         # this 'ansi' art contributed by xzip!impure for another project,
         # unlike most CP-437 DOS ansi art, this is actually utf-8 encoded.
         fname = os.path.join(os.path.dirname(__file__), 'wall.ans')
-        with codecs.open(fname, 'r', 'utf-8') as ansiart:
+        with open_(fname, 'r', encoding='utf-8') as ansiart:
             lines = ansiart.readlines()
         assert term.length(lines[0]) == 67  # ^[[64C^[[34m▄▓▄
         assert term.length(lines[1]) == 75


### PR DESCRIPTION
- [Pylint bug](https://github.com/pylint-dev/pylint/issues/10418) counts entire file as duplicate code if ``.pyi`` file is present
  - Set ``ignore-paths=.*.pyi`` in Pylint config as a workaround
- With Python 3.14, ``codec.open()`` raises a deprecation warning
  - Added a conditional to cover Python 2
  - Had to define ``open_`` or interpreter would complain local ``open`` wasn't defined

Read the Docs build failed on the first run because it couldn't find wcwidth. Not sure how it worked before, but fixed by pointing it to the requirements file in addition to the docs requirements file.