### PR TITLE
wrap perf improvement when breaking long words

### DIFF
--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -215,10 +215,10 @@ class SequenceTextWrapper(textwrap.TextWrapper):
         if self.break_long_words:
             term = self.term
             chunk = reversed_chunks[-1]
-            idx = nxt = 0
+            idx = nxt = seq_length = 0
             for text, _ in iter_parse(term, chunk):
                 nxt += len(text)
-                seq_length = Sequence(chunk[:nxt], term).length()
+                seq_length += Sequence(text, term).length()
                 if seq_length > space_left:
                     if cur_len == 0 and width == 1 and nxt == 1 and seq_length == 2:
                         # Emoji etc. cannot be split under 2 cells, so in the


### PR DESCRIPTION
Spend less time recomputing the length of characters by keeping a running length of the sequence

Test code:
```python
Terminal().wrap('a'*5000)
```

Profile before:
```
         781279 function calls in 0.215 seconds

   Ordered by: cumulative time
   List reduced from 49 to 25 due to restriction <25>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.215    0.215 terminal.py:1219(wrap)
        1    0.000    0.000    0.215    0.215 textwrap.py:347(wrap)
        1    0.000    0.000    0.214    0.214 sequences.py:146(_wrap_chunks)
     5085    0.003    0.000    0.177    0.000 sequences.py:345(length)
     5085    0.032    0.000    0.170    0.000 {built-in method builtins.sum}
       62    0.005    0.000    0.140    0.002 sequences.py:192(_handle_long_word)
   369747    0.083    0.000    0.138    0.000 sequences.py:372(<genexpr>)
   364662    0.054    0.000    0.054    0.000 {built-in method builtins.max}
     5022    0.028    0.000    0.029    0.000 sequences.py:453(iter_parse)
     5211    0.002    0.000    0.005    0.000 sequences.py:413(padd)
     5211    0.003    0.000    0.003    0.000 {method 'search' of 're.Pattern' objects}
     5211    0.001    0.000    0.002    0.000 sequences.py:259(__new__)
```

Profile after:
```
         379519 function calls in 0.120 seconds

   Ordered by: cumulative time
   List reduced from 49 to 25 due to restriction <25>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.120    0.120 terminal.py:1219(wrap)
        1    0.000    0.000    0.120    0.120 textwrap.py:347(wrap)
        1    0.000    0.000    0.119    0.119 sequences.py:146(_wrap_chunks)
     5085    0.003    0.000    0.083    0.000 sequences.py:345(length)
     5085    0.015    0.000    0.077    0.000 {built-in method builtins.sum}
   168867    0.038    0.000    0.061    0.000 sequences.py:372(<genexpr>)
       62    0.004    0.000    0.046    0.001 sequences.py:192(_handle_long_word)
     5022    0.028    0.000    0.029    0.000 sequences.py:453(iter_parse)
   163782    0.024    0.000    0.024    0.000 {built-in method builtins.max}
     5211    0.002    0.000    0.004    0.000 sequences.py:413(padd)
     5211    0.001    0.000    0.002    0.000 sequences.py:259(__new__)
```