### PR TITLE
Optimize Sequence.padd for non-horizontal sequences

### DIFF
--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -447,7 +447,7 @@ class Sequence(TextType):
                 outp += ' ' * value
             elif value < 0:
                 outp = outp[:value]
-            elif not strip:
+            else:
                 outp += text
 
         # Capture any remaining unmatched text

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -421,7 +421,7 @@ class Sequence(TextType):
         data = self
         if self._term.caps_compiled.search(data) is None:
             return TextType(data)
-        elif strip:  # strip all except CAPABILITIES_HORIZONTAL_DISTANCE
+        if strip:  # strip all except CAPABILITIES_HORIZONTAL_DISTANCE
             # pylint: disable-next=protected-access
             data = self._term._caps_xxx.sub("", data)
 

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -418,18 +418,25 @@ class Sequence(TextType):
         :rtype: str
         :returns: Text adjusted for horizontal movement
         """
-        if self._term.caps_compiled.search(self) is None:
-            return TextType(self)
+        data = self
+        if self._term.caps_compiled.search(data) is None:
+            return TextType(data)
+        elif strip:  # strip all except CAPABILITIES_HORIZONTAL_DISTANCE
+            # pylint: disable-next=protected-access
+            data = self._term._caps_xxx.sub("", data)
+
+            if self._term.caps_compiled.search(data) is None:
+                return TextType(data)
 
         outp = ''
         last_end = 0
 
         # pylint: disable-next=protected-access
-        for match in self._term._caps_named_compiled.finditer(self):
+        for match in self._term._caps_named_compiled.finditer(data):
 
             # Capture unmatched text between matched capabilities
             if match.start() > last_end:
-                outp += self[last_end:match.start()]
+                outp += data[last_end:match.start()]
 
             last_end = match.end()
 
@@ -444,8 +451,8 @@ class Sequence(TextType):
                 outp += text
 
         # Capture any remaining unmatched text
-        if last_end < len(self):
-            outp += self[last_end:]
+        if last_end < len(data):
+            outp += data[last_end:]
 
         return outp
 

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -423,7 +423,7 @@ class Sequence(TextType):
             return TextType(data)
         if strip:  # strip all except CAPABILITIES_HORIZONTAL_DISTANCE
             # pylint: disable-next=protected-access
-            data = self._term._caps_xxx.sub("", data)
+            data = self._term._caps_compiled_without_hdist.sub("", data)
 
             if self._term.caps_compiled.search(data) is None:
                 return TextType(data)

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -302,7 +302,7 @@ class Terminal(object):
             '|'.join(cap.named_pattern for cap in self.caps.values())
         )
         # Used with padd() to strip non-horizontal caps
-        self._caps_xxx = re.compile('|'.join(
+        self._caps_compiled_without_hdist = re.compile('|'.join(
             cap.pattern for cap in self.caps.values()
             if cap.name not in CAPABILITIES_HORIZONTAL_DISTANCE)
         )

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -35,7 +35,7 @@ from .formatters import (COLORS,
                          split_compound,
                          resolve_attribute,
                          resolve_capability)
-from ._capabilities import CAPABILITY_DATABASE, CAPABILITIES_ADDITIVES, CAPABILITIES_RAW_MIXIN
+from ._capabilities import CAPABILITY_DATABASE, CAPABILITIES_ADDITIVES, CAPABILITIES_RAW_MIXIN, CAPABILITIES_HORIZONTAL_DISTANCE
 
 # isort: off
 
@@ -297,6 +297,10 @@ class Terminal(object):
         # Used with padd() to separate plain text from caps
         self._caps_named_compiled = re.compile(
             '|'.join(cap.named_pattern for cap in self.caps.values())
+        )
+        # Used with padd() to strip non-horizontal caps
+        self._caps_xxx = re.compile(
+            '|'.join(cap.pattern for cap in self.caps.values() if cap.name not in CAPABILITIES_HORIZONTAL_DISTANCE)
         )
         # for tokenizer, the '.lastgroup' is the primary lookup key for
         # 'self.caps', unless 'MISMATCH'; then it is an unmatched character.

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -35,7 +35,10 @@ from .formatters import (COLORS,
                          split_compound,
                          resolve_attribute,
                          resolve_capability)
-from ._capabilities import CAPABILITY_DATABASE, CAPABILITIES_ADDITIVES, CAPABILITIES_RAW_MIXIN, CAPABILITIES_HORIZONTAL_DISTANCE
+from ._capabilities import (CAPABILITY_DATABASE,
+                            CAPABILITIES_ADDITIVES,
+                            CAPABILITIES_RAW_MIXIN,
+                            CAPABILITIES_HORIZONTAL_DISTANCE)
 
 # isort: off
 
@@ -299,8 +302,9 @@ class Terminal(object):
             '|'.join(cap.named_pattern for cap in self.caps.values())
         )
         # Used with padd() to strip non-horizontal caps
-        self._caps_xxx = re.compile(
-            '|'.join(cap.pattern for cap in self.caps.values() if cap.name not in CAPABILITIES_HORIZONTAL_DISTANCE)
+        self._caps_xxx = re.compile('|'.join(
+            cap.pattern for cap in self.caps.values()
+            if cap.name not in CAPABILITIES_HORIZONTAL_DISTANCE)
         )
         # for tokenizer, the '.lastgroup' is the primary lookup key for
         # 'self.caps', unless 'MISMATCH'; then it is an unmatched character.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,6 +2,11 @@
 
 Version History
 ===============
+next
+  * performance improvements to :meth:`~Terminal.length` and
+    :meth:`~Terminal.wrap` via :ghpull:`286`, :ghpull:`287`, :ghpull:`289`, and
+    :ghpull:`291`
+
 1.21
   * bugfix infinite loop in :meth:`~Terminal.wrap` when "Wide" characters of
     width 2 (East-Asian or Emoji) are used with a wrap width of 1, and a small


### PR DESCRIPTION
When a string includes a terminal escape sequence, Sequence.padd skips the early return from commit 8977680a

Test code:
```
import cProfile
import pstats

from blessed import Terminal
from blessed.sequences import Sequence

t = Terminal()
text = 'a'*5000 + t.restore
s = Sequence(text, t)

with cProfile.Profile() as pr: 
    for _ in range(1000):
        s.padd(strip=True)

p = pstats.Stats(pr)
p.strip_dirs().sort_stats('cumtime').print_stats(25)
```
Before profile with Python 3.12.3:
```
         10002 function calls in 11.462 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1000   11.453    0.011   11.462    0.011 sequences.py:413(padd)
```

This branch strips all sequences (except horizontal ones) so that more strings can early return from padd.
This positively affects the performance of Sequence.length and Terminal.wrap

After:
```
         4002 function calls in 0.030 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1000    0.000    0.000    0.030    0.000 sequences.py:413(padd)
```