### PR TITLE
Unpin docformatter

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -67,9 +67,8 @@ commands =
     autopep8 --in-place  --recursive --aggressive --aggressive blessed/ bin/ setup.py
 
 [testenv:docformatter]
-# docformatter pinned due to https://github.com/PyCQA/docformatter/issues/264
 deps =
-    docformatter<1.7.4
+    docformatter>=1.7.7
     untokenize
 commands =
     docformatter \
@@ -84,9 +83,8 @@ commands =
         {toxinidir}/docs/conf.py
 
 [testenv:docformatter_check]
-# docformatter pinned due to https://github.com/PyCQA/docformatter/issues/264
 deps =
-    docformatter<1.7.4
+    docformatter>=1.7.7
     untokenize
 commands =
     docformatter \


### PR DESCRIPTION
We pinned docformatter to 1.7.4 because it didn't handle ``arg:`` correctly. Version 1.7.7 seems to have fixed it.