### PR TITLE
Improve coverage

### DIFF
--- a/blessed/formatters.py
+++ b/blessed/formatters.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Set, List, Type, Tuple, Union, TypeVar, Callab
 # local
 from blessed.colorspace import CGA_COLORS, X11_COLORNAMES_TO_RGB
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     # local
     from blessed.terminal import Terminal
 

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -9,7 +9,7 @@ import platform
 from typing import TYPE_CHECKING, Match, TypeVar
 from collections import OrderedDict
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     # local
     from blessed.terminal import Terminal
 

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -13,7 +13,7 @@ from wcwidth import wcwidth
 # local
 from blessed._capabilities import CAPABILITIES_CAUSE_MOVEMENT, CAPABILITIES_HORIZONTAL_DISTANCE
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from blessed.terminal import Terminal
 
 # std imports
@@ -78,6 +78,7 @@ class Termcap():
         :arg str text: for capabilities *parm_left_cursor*, *parm_right_cursor*, provide the
             matching sequence text, its interpreted distance is returned.
         :returns: 0 except for matching '
+        :raises ValueError: ``text`` does not match regex for capability
         """
         value = CAPABILITIES_HORIZONTAL_DISTANCE.get(self.name)
         if value is None:
@@ -87,6 +88,7 @@ class Termcap():
             match = self.re_compiled.match(text)
             if match:
                 return value * int(match.group(1))
+            raise ValueError(f'Invalid parameters for termccap {self.name}: {text!r}')
 
         return value
 

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -1254,14 +1254,11 @@ class Terminal():
         >>> term.split_seqs(term.underline('xyz'), 1)
         ['\x1b[4m', r'xyz\x1b(B\x1b[m']
         """
-        pattern = self._caps_unnamed_any
         result = []
-        for idx, match in enumerate(re.finditer(pattern, text)):
+        for idx, match in enumerate(re.finditer(self._caps_unnamed_any, text)):
             result.append(match.group())
             if maxsplit and idx == maxsplit:
-                remaining = text[match.end():]
-                if remaining:
-                    result[-1] += remaining
+                result[-1] += text[match.end():]
                 break
         return result
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -343,6 +343,22 @@ def test_IOUnsupportedOperation():
     child()
 
 
+def test_stream_no_fileno():
+    """Handle custom stream objects gracefully"""
+    @as_subprocess
+    def child():
+        stream = object()
+        term = TestTerminal(stream=stream)
+        assert term._stream is stream
+        assert 'stream has no fileno method' in term.errors
+        assert 'Output stream is not a default stream' in term.errors
+        assert term._init_descriptor is sys.__stdout__.fileno()
+        assert term._keyboard_fd is None
+        assert term.is_a_tty is False
+
+    child()
+
+
 @pytest.mark.skipif(IS_WINDOWS, reason="has process-wide side-effects")
 def test_winsize_IOError_returns_environ():
     """When _winsize raises IOError, defaults from os.environ given."""

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 """Tests for keyboard support."""
 # std imports
+import functools
+import io
 import os
 import platform
+import sys
 import tempfile
-import functools
 
 # 3rd party
 import pytest
@@ -70,17 +72,56 @@ def test_raw_input_with_kb():
     child()
 
 
-def test_notty_kb_is_None():
-    """term._keyboard_fd should be None when os.isatty returns False."""
-    # in this scenario, stream is sys.__stdout__,
-    # but os.isatty(0) is False,
+def test_stdout_notty_kb_is_None():
+    """term._keyboard_fd should be None when os.isatty returns False for output."""
+    # In this scenario, stream is sys.__stdout__, but os.isatty(1) is False
     # such as when piping output to less(1)
     @as_subprocess
     def child():
-        with mock.patch("os.isatty") as mock_isatty:
-            mock_isatty.return_value = False
+        isatty = os.isatty
+        with mock.patch('os.isatty') as mock_isatty:
+            mock_isatty.side_effect = (
+                lambda fd: False if fd == sys.__stdout__.fileno() else isatty(fd)
+            )
             term = TestTerminal()
             assert term._keyboard_fd is None
+            assert 'Output stream is not a TTY' in term.errors
+    child()
+
+
+def test_stdin_notty_kb_is_None():
+    """term._keyboard_fd should be None when os.isatty returns False for input."""
+    # In this scenario, stream is sys.__stdout__, but os.isatty(0) is False,
+    # such as when piping from another program
+    @as_subprocess
+    def child():
+        isatty = os.isatty
+        with mock.patch('os.isatty') as mock_isatty:
+            mock_isatty.side_effect = (
+                lambda fd:
+                    True if fd == sys.__stdout__.fileno()
+                    else False if fd == sys.__stdin__.fileno()
+                    else isatty(fd)
+            )
+            term = TestTerminal()
+            assert term._keyboard_fd is None
+            assert 'Input stream is not a TTY' in term.errors
+    child()
+
+
+def test_stdin_redirect():
+    """term._keyboard_fd should be None when oys.__stdin__.fileno() raises exception."""
+    # In this scenario, stream is sys.__stdout__, but sys.__stdin__ is BytesIO
+    # This may happen in a test scenario or when the program is wrapped in another interface
+    @as_subprocess
+    def child():
+        with mock.patch('sys.__stdin__', new=io.BytesIO()):
+            term = TestTerminal()
+            assert term._keyboard_fd is None
+            assert any(
+                entry.startswith('Unable to determine input stream file descriptor')
+                for entry in term.errors
+            )
     child()
 
 

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -178,7 +178,7 @@ def test_horizontal_location(all_terms):
 
 
 def test_vertical_location(all_terms):
-    """Make sure we can move the cursor horizontally without changing rows."""
+    """Make sure we can move the cursor vertically without changing columns."""
     @as_subprocess
     def child(kind):
         t = TestTerminal(kind=kind, stream=StringIO(), force_styling=True)
@@ -553,6 +553,9 @@ def test_split_seqs_maxsplit1(all_terms):
             result = list(term.split_seqs(given_text, 1))
             assert result == expected
 
+            # Another case where split matches exactly
+            assert list(term.split_seqs(f'{term.bold}b', 1)) == [term.bold, 'b']
+
     child(all_terms)
 
 
@@ -592,6 +595,18 @@ def test_split_seqs_maxsplit3_and_term_right(all_terms):
             expected = ['X', 'Y', term.move_up(45), 'V', 'K']
             result = list(term.split_seqs(given_text))
             assert result == expected
+
+    child(all_terms)
+
+
+def test_invalid_params_for_horizontal_distance(all_terms):
+    """Raise error if text parametrized horizontal distance is invalid"""
+    @as_subprocess
+    def child(kind):
+        term = TestTerminal(stream=StringIO(), kind=kind, force_styling=True)
+        with pytest.raises(ValueError) as e:
+            term.caps['parm_left_cursor'].horizontal_distance('\x1b[C')
+            assert e.value == "Invalid parameters for termccap parm_left_cursor: '\x1b[C'"
 
     child(all_terms)
 


### PR DESCRIPTION
Some additional tests and tweaks to improve coverage.

There was one case where I had to test indirectly.

https://github.com/jquast/blessed/blob/f934587db33ef91b5d039dd1724dc8c5627fa421/blessed/sequences.py#L86-L89

We weren't testing the case where match is `None`, because that would mean it had been passed a bad value for ``text``. Within the library, this wouldn't happen because we pass what we already matched. But if someone is poking around in the internals or we mess up somehow, it should probably raise an exception instead of failing silently, so I made it raise a `ValueError` and added a contrived test for it. Let me know if you want to handle it differently.