### PR TITLE
Add Python 3.14.0 to tox and gh workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:  ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version:  ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.14']
         test_quick: [1]
 
         include:
@@ -29,11 +29,6 @@ jobs:
             toxenv: docformatter_check,flake8,flake8_tests,isort_check,mypy,sphinx,pydocstyle,pylint,pylint_tests,codespell
             os-deps:
               - enchant-2
-
-          - python-version: '3.14'
-            container: 'python:3.14-rc'
-            optional: true
-            test_quick: 0
 
           - python-version: '3.13'
             test_keyboard: 1

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -471,7 +471,7 @@ CURSES_KEYCODE_OVERRIDE_MIXIN = (
 #: escape sequences.  This is too long for modern applications, so we set it to
 #: 350ms, or 0.35 seconds. It is still a bit conservative, for remote telnet or
 #: ssh servers, for example.
-DEFAULT_ESCDELAY = 0.35
+DEFAULT_ESCDELAY = 0.35  # pylint: disable=invalid-name
 
 
 def _reinit_escdelay() -> None:

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -51,7 +51,7 @@ from ._capabilities import (CAPABILITY_DATABASE,
 
 # isort: off
 
-HAS_TTY = True
+HAS_TTY = True  # pylint: disable=invalid-name
 if platform.system() == 'Windows':
     IS_WINDOWS = True
     import jinxed as curses  # pylint: disable=import-error
@@ -73,9 +73,9 @@ else:
             f"unless a deriving class overrides them: {', '.join(_TTY_METHODS)}."
         )
         warnings.warn(_MSG_NOSUPPORT)
-        HAS_TTY = False
+        HAS_TTY = False  # pylint: disable=invalid-name
 
-_CUR_TERM = None  # See comments at end of file
+_CUR_TERM = None  # See comments at end of file pylint: disable=invalid-name
 _RE_GET_FGCOLOR_RESPONSE = re.compile(
     '\x1b]10;rgb:([0-9a-fA-F]+)/([0-9a-fA-F]+)/([0-9a-fA-F]+)\x07')
 _RE_GET_BGCOLOR_RESPONSE = re.compile(

--- a/tox.ini
+++ b/tox.ini
@@ -13,13 +13,13 @@ envlist =
     pydocstyle
     mypy
     sphinx
-    py{37,38,39,310,311,312,313}
+    py{37,38,39,310,311,312,313,314}
 
 
 ####### Python Test Environments #######
 
 [testenv]
-basepython = python3.13
+basepython = python3.14
 passenv =
     TEST_QUICK
     TEST_KEYBOARD
@@ -33,17 +33,10 @@ deps =
 commands =
     pytest {posargs: --strict-markers --verbose --durations=3} tests
 
-[testenv:py313]
+[testenv:py314]
 setenv =
     TEST_QUICK = {env:TEST_QUICK:0}
     TEST_KEYBOARD = {env:TEST_KEYBOARD:1}
-deps =
-    {[testenv]deps}
-    pytest-rerunfailures
-commands =
-    pytest {posargs: --reruns 5 --strict-markers --verbose --durations=3} tests
-
-
 
 ####### Linting and Formatting Environments #######
 
@@ -54,6 +47,8 @@ commands =
     autopep8 --in-place  --recursive --aggressive --aggressive blessed/ bin/
 
 [testenv:docformatter]
+# docformatter not yet compatible with py314
+basepython = python3.13
 deps =
     docformatter>=1.7.7
     untokenize
@@ -69,6 +64,8 @@ commands =
         {toxinidir}/docs/conf.py
 
 [testenv:docformatter_check]
+# docformatter not yet compatible with py314
+basepython = python3.13
 deps =
     docformatter>=1.7.7
     untokenize
@@ -182,6 +179,8 @@ commands =
               --summary --count
 
 [testenv:lint]
+# docformatter not yet compatible with py314
+basepython = python3.13
 deps =
     {[testenv:docformatter_check]deps}
     {[testenv:flake8]deps}


### PR DESCRIPTION
- docformatter broken with python3.14, so all lint tools are still on 3.13.
- pytest-rerunfailures removed, this was added 5 years ago for Travis-CI
- for some reason pylint just started picking up "invalid-name", saying they are not snake case ..