### PR TITLE
optimize Sequence.padd for horizontal sequences

### DIFF
--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -439,11 +439,16 @@ class Sequence(str):
             if self._term.caps_compiled.search(data) is None:
                 return str(data)
 
+            # pylint: disable-next=protected-access
+            caps = self._term._hdist_caps_named_compiled
+        else:
+            # pylint: disable-next=protected-access
+            caps = self._term._caps_named_compiled
+
         outp = ''
         last_end = 0
 
-        # pylint: disable-next=protected-access
-        for match in self._term._caps_named_compiled.finditer(data):
+        for match in caps.finditer(data):
 
             # Capture unmatched text between matched capabilities
             if match.start() > last_end:

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -385,6 +385,11 @@ class Terminal():
             cap.pattern for cap in self.caps.values()
             if cap.name not in CAPABILITIES_HORIZONTAL_DISTANCE)
         )
+        # Used with padd() to iterate horizontal caps
+        self._hdist_caps_named_compiled = re.compile('|'.join(
+            cap.named_pattern for cap in self.caps.values()
+            if cap.name in CAPABILITIES_HORIZONTAL_DISTANCE)
+        )
         # for tokenizer, the '.lastgroup' is the primary lookup key for
         # 'self.caps', unless 'MISMATCH'; then it is an unmatched character.
         self._caps_compiled_any = re.compile(


### PR DESCRIPTION

Test code:
```
import cProfile
import pstats

from blessed import Terminal

t = Terminal()
text = 'a'*5000 + ’\t’

with cProfile.Profile() as pr: 
    for _ in range(1000):
        t.length(text)

p = pstats.Stats(pr)
p.strip_dirs().sort_stats('cumtime').print_stats(25)
```
Before profile with Python 3.12.3:
```
         10034006 function calls in 12.492 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1000    0.000    0.000   12.492    0.012 terminal.py:2237(length)
     1000    0.000    0.000   12.491    0.012 sequences.py:356(length)
     1000   11.388    0.011   11.412    0.011 sequences.py:424(padd)
```

Sequence.padd spends most of its time in finditer.
This branch, for the ``strip=True`` case, reduces the set of terminal caps that are iterated.

After:
```
         10034006 function calls in 1.269 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1000    0.000    0.000    1.269    0.001 terminal.py:2242(length)
     1000    0.000    0.000    1.269    0.001 sequences.py:356(length)
     1000    0.206    0.000    1.083    0.001 {built-in method builtins.sum}
  5009000    0.537    0.000    0.877    0.000 sequences.py:383(<genexpr>)
  5008000    0.341    0.000    0.341    0.000 {built-in method builtins.max}
     1000    0.160    0.000    0.185    0.000 sequences.py:424(padd)
```