### PR TITLE
Add break_on_hyphens support for text with escape sequences

### DIFF
--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -189,13 +189,14 @@ def test_greedy_join_with_cojoining():
     def child():
         term = TestTerminal()
         given = 'cafe\u0301-latte'
-        result = term.wrap(given, 5)
+        # Use break_on_hyphens=False to test combining character handling
+        result = term.wrap(given, 5, break_on_hyphens=False)
         assert result == ['cafe\u0301-', 'latte']
-        result = term.wrap(given, 4)
+        result = term.wrap(given, 4, break_on_hyphens=False)
         assert result == ['cafe\u0301', '-lat', 'te']
-        result = term.wrap(given, 3)
+        result = term.wrap(given, 3, break_on_hyphens=False)
         assert result == ['caf', 'e\u0301-l', 'att', 'e']
-        result = term.wrap(given, 2)
+        result = term.wrap(given, 2, break_on_hyphens=False)
         assert result == ['ca', 'fe\u0301', '-l', 'at', 'te']
 
     child()
@@ -235,6 +236,25 @@ def test_placeholder():
         text = 'short 1234567890 extra'
         kwargs = {'width': 10, 'max_lines': 2, 'placeholder': '...'}
         assert term.wrap(text, **kwargs) == textwrap.wrap(text, **kwargs)
+
+    child()
+
+
+def test_break_on_hyphens_in_handle_long_word():
+    """Test break_on_hyphens is respected in _handle_long_word()."""
+    @as_subprocess
+    def child():
+        term = TestTerminal()
+
+        # Edge case: word forces _handle_long_word() to break it
+        text = 'a-b-c-d'
+        width = 3
+
+        result = term.wrap(text, width=width, break_on_hyphens=True)
+        assert result == ['a-', 'b-', 'c-d']
+
+        result = term.wrap(text, width=width, break_on_hyphens=False)
+        assert result == ['a-b', '-c-', 'd']
 
     child()
 


### PR DESCRIPTION
## Summary
- Adds sequence-aware `_split()` override in `SequenceTextWrapper` to properly handle `break_on_hyphens` when text contains escape sequences
- Adds test coverage for `break_on_hyphens` parameter

## Problem
When text had per-character escape sequences (e.g., each letter colored separately), the parent's `_split()` regex couldn't correctly identify hyphens as break points because escape sequences were mixed into the text.

## Solution
The new `_split()` method:
1. Strips sequences to get the "logical" text
2. Calls the parent's `_split()` on stripped text to find break points
3. Maps those break points back to the original text with sequences intact

Fixes #329