### PR TITLE
call length() less in wrap()

### DIFF
--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -201,16 +201,18 @@ class SequenceTextWrapper(textwrap.TextWrapper):
 
             while chunks:
                 chunk_len = Sequence(chunks[-1], term).length()
+
+                # The current line is full, and the next chunk is too big to fit on *any* line
+                if chunk_len > width:
+                    self._handle_long_word(chunks, cur_line, cur_len, width)
+                    cur_len = sum(Sequence(chunk, term).length() for chunk in cur_line)
+                    break
+
                 if cur_len + chunk_len > width:
                     break
 
                 cur_line.append(chunks.pop())
                 cur_len += chunk_len
-
-            # The current line is full, and the next chunk is too big to fit on *any* line
-            if chunks and chunk_len > width:
-                self._handle_long_word(chunks, cur_line, cur_len, width)
-                cur_len = sum(Sequence(chunk, term).length() for chunk in cur_line)
 
             # If the last chunk on this line is all whitespace, drop it.
             if self.drop_whitespace and cur_line:


### PR DESCRIPTION
I started looking at a performance slowdown with wrap() from commit 331e9be to commit cee680f

Test code
```python
import cProfile
import pstats

from blessed import Terminal

t = Terminal()
text = 'a'*5000 + t.clear + '\t' + t.restore

with cProfile.Profile() as pr:
    for _ in range(100):
        t.wrap(text)

p = pstats.Stats(pr)
p.strip_dirs().sort_stats('cumtime').print_stats(25)
```

commit 331e9be
```
         31225306 function calls in 5.126 seconds

   Ordered by: cumulative time
   List reduced from 47 to 25 due to restriction <25>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      100    0.000    0.000    5.126    0.051 terminal.py:2366(wrap)
      100    0.000    0.000    5.125    0.051 textwrap.py:347(wrap)
      100    0.009    0.000    5.111    0.051 sequences.py:158(_wrap_chunks)
   509900    0.134    0.000    3.297    0.000 sequences.py:355(length)
```
HEAD/commit cee680f
```
         57328206 function calls (57323306 primitive calls) in 8.092 seconds

   Ordered by: cumulative time
   List reduced from 47 to 25 due to restriction <25>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      100    0.000    0.000    8.092    0.081 terminal.py:2366(wrap)
      100    0.000    0.000    8.091    0.081 textwrap.py:347(wrap)
      100    0.011    0.000    8.077    0.081 sequences.py:159(_wrap_chunks)
   519800    0.138    0.000    6.250    0.000 sequences.py:409(length)
```
length() is called more often now

This branch:
```
         32274506 function calls (32269606 primitive calls) in 5.262 seconds

   Ordered by: cumulative time
   List reduced from 47 to 25 due to restriction <25>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      100    0.000    0.000    5.262    0.053 terminal.py:2366(wrap)
      100    0.000    0.000    5.261    0.053 textwrap.py:347(wrap)
      100    0.009    0.000    5.245    0.052 sequences.py:159(_wrap_chunks)
   514900    0.133    0.000    3.418    0.000 sequences.py:409(length)
```