### PR TITLE
Add Terminal.color_hex('#rgb'), Bugfix get_fgcolor() 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,4 @@ indent_size = tab
 indent_space = space
 trim_trailing_whitespace = true
 insert_final_newline = true
+max_line_length = 100

--- a/bin/cnn.py
+++ b/bin/cnn.py
@@ -1,13 +1,8 @@
 """Basic example of hyperlinks -- show CNN news site with clickable URL's."""
-# std imports
-import random
-
 # 3rd party
 import requests
-
-# local
-# 3rd-party
 from bs4 import BeautifulSoup
+
 # local imports
 from blessed import Terminal
 
@@ -19,33 +14,42 @@ def embolden(phrase):
 
 def make_bold(term, text):
     # embolden text
-    return ' '.join(term.bold(phrase) if embolden(phrase) else phrase
+    return ' '.join(term.color_hex('#ecc')(phrase) if embolden(phrase) else phrase
                     for phrase in text.split(' '))
 
 
-def whitespace_only(term, line):
-    # return only left-hand whitespace of `line'.
-    return line[:term.length(line) - term.length(line.lstrip())]
-
-
 def find_articles(soup):
-    return (a_link for a_link in soup.find_all('a') if '/article' in a_link.get('href'))
+    return (a_link for a_link in soup.find_all('a') if a_link.get('href').startswith('/')
+            and a_link.text != 'CNN')
 
 
 def main():
     term = Terminal()
-    cnn_url = 'https://lite.cnn.io'
+    cnn_url = 'https://lite.cnn.com'
     soup = BeautifulSoup(requests.get(cnn_url).content, 'html.parser')
     textwrap_kwargs = {
         'width': term.width - (term.width // 4),
-        'initial_indent': ' ' * (term.width // 6) + '* ',
-        'subsequent_indent': (' ' * (term.width // 6)) + ' ' * 2,
+        'initial_indent': ' * ',
+        'subsequent_indent': '   ',
     }
+    print(term.center('CNN Headlines'))
+    print(term.center('============='))
+    print()
+    line_num = 1
     for a_href in find_articles(soup):
-        url_id = random.randrange(0, 1 << 24)
-        for line in term.wrap(make_bold(term, a_href.text), **textwrap_kwargs):
-            print(whitespace_only(term, line), end='')
-            print(term.link(cnn_url + a_href.get('href'), line.lstrip(), url_id))
+        # create headlines with colors and placeholder for clickable hyperlink
+        ansi_text = make_bold(term, a_href.text.strip() + ' [view]')
+        for line in term.wrap(ansi_text, **textwrap_kwargs):
+            # replace with a clickable hyperlink
+            if '[view]' in line:
+                text = term.bright_black('[view]')
+                url = cnn_url + a_href.get('href')
+                line = line.replace('[view]', term.link(url=url, text=text, url_id=line_num))
+            print(' ' * (term.width//8) + line.rstrip())
+            line_num += 1
+        if line_num > term.height - 6:
+            break
+    print()
 
 
 if __name__ == '__main__':

--- a/bin/cnn.py
+++ b/bin/cnn.py
@@ -45,7 +45,7 @@ def main():
                 text = term.bright_black('[view]')
                 url = cnn_url + a_href.get('href')
                 line = line.replace('[view]', term.link(url=url, text=text, url_id=line_num))
-            print(' ' * (term.width//8) + line.rstrip())
+            print(' ' * (term.width // 8) + line.rstrip())
             line_num += 1
         if line_num > term.height - 6:
             break

--- a/bin/color_query.py
+++ b/bin/color_query.py
@@ -4,18 +4,11 @@ from blessed import Terminal
 
 term = Terminal()
 
-# Get foreground color
-r, g, b = term.get_fgcolor()
-if (r, g, b) != (-1, -1, -1):
-    print(f"Foreground color: RGB({r}, {g}, {b})")
-    print(f"  Hex: #{r:04x}{g:04x}{b:04x}")
-else:
-    print("Could not determine foreground color")
+fg_hex = term.get_fgcolor_hex()
+bg_hex = term.get_bgcolor_hex()
 
-# Get background color
-r, g, b = term.get_bgcolor()
-if (r, g, b) != (-1, -1, -1):
-    print(f"Background color: RGB({r}, {g}, {b})")
-    print(f"  Hex: #{r:04x}{g:04x}{b:04x}")
-else:
-    print("Could not determine background color")
+bg_rgb = term.get_bgcolor(bits=8)
+fg_rgb = term.get_fgcolor(bits=8)
+
+print(f"Foreground {fg_hex} {fg_rgb}")
+print(f"Background {bg_hex} {bg_rgb}")

--- a/bin/display-modes.py
+++ b/bin/display-modes.py
@@ -39,6 +39,7 @@ def display_device_attributes(term):
         extension_desc = {
             1: "132 columns",
             2: "Printer port",
+            3: "ReGIS graphics",
             4: "Sixel graphics",
             6: "Selective erase",
             7: "DRCS (soft character set)",
@@ -46,14 +47,21 @@ def display_device_attributes(term):
             9: "NRCS (national replacement character sets)",
             12: "SCS extension (Serbian/Croatian/Slovakian)",
             15: "Technical character set",
+            16: "Locator port",
+            17: "Terminal state interrogation",
             18: "Windowing capability",
+            19: "Sessions capability",
             21: "Horizontal scrolling",
+            22: "ANSI color",
             23: "Greek extension",
             24: "Turkish extension",
+            28: "Rectangular editing",
+            29: "ANSI text locator",
             42: "ISO Latin-2 character set",
             44: "PCTerm",
             45: "Soft key map",
-            46: "ASCII emulation"
+            46: "ASCII emulation",
+            52: "OSC 52 clipboard",
         }
 
         print("  Extension details:")

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -805,7 +805,10 @@ class Terminal():
 
     def get_fgcolor(self, timeout: float = 1, bits: int = 16) -> Tuple[int, int, int]:
         """
-        Return tuple (r, g, b) of foreground color.
+        Return tuple (r, g, b) of default foreground color.
+
+        This returns the terminal's default color for uncolored text, not any
+        currently active color set by escape sequences.
 
         When :attr:`is_a_tty` is False, no sequences are transmitted or response
         awaited, and the value ``(-1, -1, -1)`` is returned without inquiry.
@@ -844,7 +847,10 @@ class Terminal():
 
     def get_bgcolor(self, timeout: float = 1, bits: int = 16) -> Tuple[int, int, int]:
         """
-        Return tuple (r, g, b) of background color.
+        Return tuple (r, g, b) of default background color.
+
+        This returns the terminal's default background color, not any currently
+        active color set by escape sequences.
 
         When :attr:`is_a_tty` is False, no sequences are transmitted or response
         awaited, and the value ``(-1, -1, -1)`` is returned without inquiry.
@@ -883,7 +889,7 @@ class Terminal():
 
     def get_fgcolor_hex(self, timeout: float = 1, maybe_short: bool = False) -> str:
         """
-        Return foreground color as hex string.
+        Return default foreground color as hex string.
 
         :arg float timeout: Return after time elapsed in seconds with empty string
             if the remote end did not respond.
@@ -901,7 +907,7 @@ class Terminal():
 
     def get_bgcolor_hex(self, timeout: float = 1, maybe_short: bool = False) -> str:
         """
-        Return background color as hex string.
+        Return default background color as hex string.
 
         :arg float timeout: Return after time elapsed in seconds with empty string
             if the remote end did not respond.

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -894,10 +894,10 @@ class Terminal():
         Convenience wrapper combining :meth:`get_fgcolor` and
         :func:`~blessed.colorspace.rgb_to_hex`.
         """
-        r, g, b = self.get_fgcolor(timeout=timeout, bits=8)
-        if (r, g, b) == (-1, -1, -1):
+        rgb = self.get_fgcolor(timeout=timeout, bits=8)
+        if rgb == (-1, -1, -1):
             return ''
-        return rgb_to_hex(r, g, b, maybe_short=maybe_short)
+        return rgb_to_hex(*rgb, maybe_short=maybe_short)
 
     def get_bgcolor_hex(self, timeout: float = 1, maybe_short: bool = False) -> str:
         """

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -829,14 +829,11 @@ class Terminal():
 
         .. note::
 
-            Terminals respond with 16-bit color values per the XParseColor
-            specification. For most uses, 8-bit values are preferred::
+            The default return value is 16-bit, matching the XParseColor specification of the
+            underlying protocol. For most uses, 8-bit values are preferred::
 
                 rgb = term.get_fgcolor(bits=8)
-                term.color_rgb(*rgb)  # Round-trip to set same color
-
-            See :func:`~blessed.colorspace.xparse_color` for details on how
-            terminal color responses are scaled.
+                term.color_rgb(*rgb)  # reset foreground to default
         """
         if bits not in (8, 16):
             raise ValueError(f"bits must be 8 or 16, got {bits}")
@@ -871,14 +868,11 @@ class Terminal():
 
         .. note::
 
-            Terminals respond with 16-bit color values per the XParseColor
-            specification. For most uses, 8-bit values are preferred::
+            The default return value is 16-bit, matching the XParseColor specification of the
+            underlying protocol. For most uses, 8-bit values are preferred::
 
                 rgb = term.get_bgcolor(bits=8)
-                term.on_color_rgb(*rgb)  # Round-trip to set same color
-
-            See :func:`~blessed.colorspace.xparse_color` for details on how
-            terminal color responses are scaled.
+                term.on_color_rgb(*rgb)  # reset background to default
         """
         if bits not in (8, 16):
             raise ValueError(f"bits must be 8 or 16, got {bits}")

--- a/docs/colors.rst
+++ b/docs/colors.rst
@@ -75,10 +75,11 @@ These methods accept multiple hex formats, and the ``#`` prefix is optional:
 Querying Terminal Colors
 -------------------------
 
-You can query the terminal's current foreground and background colors using
+You can query the terminal's default foreground and background colors using
 :meth:`~.Terminal.get_fgcolor` and :meth:`~.Terminal.get_bgcolor`, or use
 :meth:`~.Terminal.get_fgcolor_hex` and :meth:`~.Terminal.get_bgcolor_hex` for
-hex string output:
+hex string output. These return the colors used for default, uncolored text -
+not any currently active color set by escape sequences:
 
 .. literalinclude:: ../bin/color_query.py
    :language: python

--- a/docs/colors.rst
+++ b/docs/colors.rst
@@ -20,18 +20,30 @@ And combine two colors using "``_on_``", as in "``foreground_on_background``":
 
     >>> print(term.peru_on_seagreen('All systems functioning within defined parameters.'))
 
+If you have an exact color in mind, you can use direct ``(r, g, b)`` values of
+0-255 with :meth:`~.Terminal.color_rgb` and :meth:`~.Terminal.on_color_rgb` for
+foreground and background colors, and, :meth:`~.Terminal.color_hex` and
+:meth:`~.Terminal.on_color_hex` with popular html color codes:
+
+    >>> print(term.color_rgb(255, 0, 255)("Bright Magenta"))
+    >>> print(term.color_hex("#cafe00")("green goo"))
+
 24-bit Colors
 -------------
 
 Most Terminal emulators, even Windows, has supported 24-bit colors since roughly 2016. To test or
-force-set whether the terminal emulator supports 24-bit colors, check or set the terminal attribute
+whether the terminal emulator supports 24-bit colors, check terminal attribute
 :meth:`~Terminal.number_of_colors`:
 
     >>> print(term.number_of_colors == 1 << 24)
     True
 
-Even if the terminal only supports ``256``, or worse, ``16`` colors, the nearest color supported by
-the terminal is automatically mapped:
+This value is automatically determined 24-bit when environment ``COLORTERM`` is
+set to ``truecolor`` or ``24bit``. The attribute can be modified directly for
+the desired color depth.
+
+Even if the terminal only supports ``256``, or worse, ``16`` colors, the nearest
+color supported by the terminal is automatically mapped:
 
     >>> term.number_of_colors = 1 << 24
     >>> term.darkolivegreen
@@ -45,36 +57,57 @@ the terminal is automatically mapped:
     >>> term.darkolivegreen
     '\x1b[90m'
 
-And finally, the direct ``(r, g, b)`` values of 0-255 can be used for :meth:`~.Terminal.color_rgb`
-and :meth:`~.Terminal.on_color_rgb` for foreground and background colors, to access each and every
-color!
+Hex Colors
+----------
 
-.. include:: all_the_colors.txt
+For convenience, colors can be specified in standard web hex format using
+:meth:`~.Terminal.color_hex` and :meth:`~.Terminal.on_color_hex`:
+
+    >>> print(term.color_hex('#ff5733')('Warning!'))
+    >>> print(term.on_color_hex('#ff5733')('System Error!'))
+
+These methods accept multiple hex formats, and the ``#`` prefix is optional:
+
+- **3-digit**: ``#RGB`` expands to ``#RRGGBB`` (e.g., ``#faf`` -> ``#ffaaff``)
+- **6-digit**: ``#RRGGBB`` standard web format (e.g., ``#ff5733``)
+- **12-digit**: ``#RRRRGGGGBBBB``
 
 Querying Terminal Colors
 -------------------------
 
 You can query the terminal's current foreground and background colors using
-:meth:`~.Terminal.get_fgcolor` and :meth:`~.Terminal.get_bgcolor`. These methods return RGB tuples
-that represent the actual colors configured in the terminal emulator:
+:meth:`~.Terminal.get_fgcolor` and :meth:`~.Terminal.get_bgcolor`, or use
+:meth:`~.Terminal.get_fgcolor_hex` and :meth:`~.Terminal.get_bgcolor_hex` for
+hex string output:
 
 .. literalinclude:: ../bin/color_query.py
    :language: python
 
+.. note:: The keyword argument ``bits=8`` is recommended for the more common RGB
+   return values in range of 0-255 with :meth:`~.Terminal.get_fgcolor` and
+   :meth:`~.Terminal.get_bgcolor` as demonstrated here.
+
+   These methods otherwise return 16-bit RGB values (0-65535) per the
+   XParseColor specification used by the underlying protocol.
+
 These methods are useful for adapting your application's color scheme to match the user's terminal
-theme, or for detecting whether the terminal has a light or dark background.
+theme, or for detecting whether the terminal has a light or dark background. The RGB methods
+return ``(-1, -1, -1)`` on timeout, while the hex methods return an empty string.
 
 256 Colors
 ----------
 
-The built-in capability :meth:`~.Terminal.color` accepts a numeric index of any value
-between 0 and 254, I guess you could call this "Color by number...", it not recommended, there are
-many common cases where the colors do not match across terminals!
+The built-in capability :meth:`~.Terminal.color` accepts a numeric index of any
+value between 0 and 254, you could call this "Color by number..." and is the
+highest color depth for some legacy terminals and systems. It not recommended to
+use directly.  It is better to use RGB and Hex value methods, which map to the
+nearest color automatically.
 
 16 Colors
 ---------
 
-Recommended for common CLI applications.
+Recommended for common CLI applications, where the user's preferred color
+palette is used.
 
 Traditional terminals are only capable of 8 colors:
 
@@ -145,3 +178,8 @@ than selecting a background color directly:: the same desired background color e
 >>>  print(term.green_reverse('Though some terminals standout more than others'))
 
 The second phrase appears as *black on green* on both color terminals and a green monochrome vt220.
+
+Color chart
+-----------
+
+.. include:: all_the_colors.txt

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,10 +4,11 @@ Version History
 ===============
 
 *next release*
-  * improved: performance of :meth:`Terminal.wrap`, :ghpull:`331` by
-    :ghuser:`grayjk`.
-  * improved: add :meth:`Terminal.wrap` break_on_hyphen support matching
-    behavior of :func:`textwrap.wrap` by :ghuser:`ps06756`.
+  * introduced: New methods :meth:`Terminal.color_hex` and :meth:`Terminal.on_color_hex`.
+  * bugfix: Support parsing of uncommon responses in :meth:`Terminal.get_fgcolor` and bgcolor.
+  * improved: performance of :meth:`Terminal.wrap`, :ghpull:`331` by :ghuser:`grayjk`.
+  * improved: add :meth:`Terminal.wrap` break_on_hyphen support matching behavior of
+    :func:`textwrap.wrap` by :ghuser:`ps06756`.
 
 1.25
   * bugfix: The "Copy globals" fix in 1.20 got reverted in release in 1.23
@@ -34,26 +35,26 @@ Version History
   * bugfix: default timeout for get_bgcolor, get_fgcolor :ghpull:`315`
 
 1.22
-  * performance improvements to :meth:`~Terminal.length` and
+  * improved: performance of :meth:`~Terminal.length` and
     :meth:`~Terminal.wrap` via :ghpull:`286`, :ghpull:`287`, :ghpull:`289`, and
     :ghpull:`291`
   * spelling fixes, :ghpull:`278`, :ghpull:`293`
 
 1.21
-  * bugfix infinite loop in :meth:`~Terminal.wrap` when "Wide" characters of
+  * bugfix: infinite loop in :meth:`~Terminal.wrap` when "Wide" characters of
     width 2 (East-Asian or Emoji) are used with a wrap width of 1, and a small
     performance enhancement, :ghissue:`273` and :ghpull:`274` by :ghuser:`grayjk`
     merged as :ghpull:`275`.
 
 1.20
-  * introduced :meth:`~Terminal.get_fgcolor` and :meth:`~Terminal.get_bgcolor` to query
+  * introduced: :meth:`~Terminal.get_fgcolor` and :meth:`~Terminal.get_bgcolor` to query
     the terminal for the currently set colors. :ghissue:`237` by :ghuser:`stefanholek`
   * bugfix: Copy globals dict before iterating to avoid RuntimeError in multithreaded
     applications, :ghissue:`248` by :ghuser:`adamnovak`
 
 
 1.19
-  * introduced :meth:`~Terminal.truncate` to truncate a string while
+  * introduced: :meth:`~Terminal.truncate` to truncate a string while
     retaining the sequences, :ghissue:`211` by :ghuser:`fishermans-friend`
   * enhancement: Add small sleep in :meth:`~Terminal.kbhit` on Windows
     to reduce CPU load :ghissue:`209` by :ghuser:`numerlor`

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -571,3 +571,12 @@ def test_query_methods_respect_does_styling_and_is_a_tty(force_styling, is_a_tty
         assert stream.getvalue() == ''
 
     child()
+
+
+def test_get_fgcolor_bgcolor_invalid_bits():
+    """Test get_fg/bgcolor raises ValueError for invalid bits parameter."""
+    term = TestTerminal(stream=StringIO())
+    with pytest.raises(ValueError, match=r"bits must be 8 or 16, got 24"):
+        term.get_fgcolor(bits=24)
+    with pytest.raises(ValueError, match=r"bits must be 8 or 16, got 32"):
+        term.get_bgcolor(bits=32)

--- a/tests/test_full_keyboard.py
+++ b/tests/test_full_keyboard.py
@@ -579,7 +579,7 @@ def test_get_fgcolor_0s_reply_via_ungetch():
         stime = time.time()
         term.ungetch('\x1b]10;rgb:a0/52/2d\x07')  # sienna
 
-        rgb = term.get_fgcolor(timeout=0.01)
+        rgb = term.get_fgcolor(timeout=0.01, bits=8)
         assert math.floor(time.time() - stime) == 0.0
         assert rgb == (160, 82, 45)
     child()
@@ -591,13 +591,24 @@ def test_get_fgcolor_styling_indifferent():
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
         term.ungetch('\x1b]10;rgb:d2/b4/8c\x07')  # tan
-        rgb = term.get_fgcolor(timeout=0.01)
+        rgb = term.get_fgcolor(timeout=0.01, bits=8)
         assert rgb == (210, 180, 140)
 
         term = TestTerminal(stream=StringIO(), force_styling=False, is_a_tty=True)
         term.ungetch('\x1b]10;rgb:40/e0/d0\x07')  # turquoise
-        rgb = term.get_fgcolor(timeout=0.01)
+        rgb = term.get_fgcolor(timeout=0.01, bits=8)
         assert rgb == (64, 224, 208)
+    child()
+
+
+def test_get_fgcolor_16bit_reply_via_ungetch():
+    """get_fgcolor call with default 16-bit response."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
+        term.ungetch('\x1b]10;rgb:a099/5277/2d44\x07')  # sienna-ish
+        rgb = term.get_fgcolor(timeout=0.01)
+        assert rgb == (0xa099, 0x5277, 0x2d44)
     child()
 
 
@@ -621,7 +632,7 @@ def test_get_bgcolor_0s_reply_via_ungetch():
         stime = time.time()
         term.ungetch('\x1b]11;rgb:99/32/cc\x07')  # darkorchid
 
-        rgb = term.get_bgcolor(timeout=0.01)
+        rgb = term.get_bgcolor(timeout=0.01, bits=8)
         assert math.floor(time.time() - stime) == 0.0
         assert rgb == (153, 50, 204)
     child()
@@ -633,13 +644,24 @@ def test_get_bgcolor_styling_indifferent():
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
         term.ungetch('\x1b]11;rgb:ff/e4/c4\x07')  # bisque
-        rgb = term.get_bgcolor(timeout=0.01)
+        rgb = term.get_bgcolor(timeout=0.01, bits=8)
         assert rgb == (255, 228, 196)
 
         term = TestTerminal(stream=StringIO(), force_styling=False, is_a_tty=True)
         term.ungetch('\x1b]11;rgb:de/b8/87\x07')  # burlywood
-        rgb = term.get_bgcolor(timeout=0.01)
+        rgb = term.get_bgcolor(timeout=0.01, bits=8)
         assert rgb == (222, 184, 135)
+    child()
+
+
+def test_get_bgcolor_16bit_reply_via_ungetch():
+    """get_bgcolor call with default 16-bit response."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
+        term.ungetch('\x1b]11;rgb:9988/3255/cc11\x07')  # darkorchid-ish
+        rgb = term.get_bgcolor(timeout=0.01)
+        assert rgb == (0x9988, 0x3255, 0xcc11)
     child()
 
 


### PR DESCRIPTION
This PR supersedes #290

Major
=====

Correct our XParseColor support for terminal methods get_fgcolor() and bgcolor().

- Fix with use of new function xparse_color() for each 'rgb' component.
- Add new optional keyword argument, ``bits=8`` which is used in all examples.
- Update docs to explain why a 16-bit value is returned, and that bits=8 is recommended.

Add new methods, color_hex() and on_color_hex()

- Add hex_to_rgb() with 3, 6, and 12-digit format support
- Add rgb_to_hex() with maybe_short option for #RGB shorthand
- Update docs/colors.rst to reference XParseColor specification

Minor
=====

Minor unrelated changes made along the way,

- Small additions to DA1 "extensions" descriptions in bin/display-modes.py
- Bugfix/improve cnn.py example program and use color_hex
- Update .editorconfig for project line length (matching pylint)
