### PR TITLE
Add Terminal.scroll_region() context manager

### DIFF
--- a/bin/scroll_region.py
+++ b/bin/scroll_region.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+"""Example of Terminal.scroll_region()."""
+from blessed import Terminal
+
+term = Terminal()
+
+with term.fullscreen(), term.cbreak():
+    # Draw header
+    print(term.home + term.clear, end='')
+    print(term.reverse(term.center("Scroll region demo")), end='')
+
+    # Draw footer
+    print(term.move_yx(term.height - 1, 0), end='')
+    print(term.reverse(term.center("Press any key to stop")), end='')
+
+    # create scrolling region
+    with term.scroll_region(top=1, height=term.height - 2):
+        # Print text within scrolling region
+        print(term.move_yx(1, 0), end='')
+        for line_num in range(1000):
+            print(f'\n{line_num:4d}: Lorem ipsum dolor sit amet, consectetur adipiscing elit.', end='')
+            if term.inkey(0.01):
+                break

--- a/bin/scroll_region.py
+++ b/bin/scroll_region.py
@@ -18,6 +18,6 @@ with term.fullscreen(), term.cbreak():
         # Print text within scrolling region
         print(term.move_yx(1, 0), end='')
         for line_num in range(1000):
-            print(f'\n{line_num:4d}: Lorem ipsum dolor sit amet, consectetur adipiscing elit.', end='')
+            print(f'\n{line_num:4d}: Lorem ipsum dolor sit amet.', end='')
             if term.inkey(0.01):
                 break

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -143,6 +143,7 @@ class Terminal():
         'cursor_request': 'u7',
         'terminal_answerback': 'u8',
         'terminal_enquire': 'u9',
+        'change_scroll_region': 'csr',
     }
 
     #: DEC Private Mode constants accessible via Terminal.DecPrivateMode or term.DecPrivateMode
@@ -1896,6 +1897,46 @@ class Terminal():
             yield
         finally:
             self.stream.write(self.normal_cursor)
+            self.stream.flush()
+
+    @contextlib.contextmanager
+    def scroll_region(self, top: int = 0,
+                      height: Optional[int] = None) -> Generator[None, None, None]:
+        """
+        Context manager that sets a scrolling region, resetting on exit.
+
+        :arg int top: Top row of the scrolling region (0-indexed). Defaults to 0.
+        :arg int height: Number of rows in the scrolling region. Defaults to
+            ``self.height - top`` (extending to the bottom of the screen).
+        :return: a context manager.
+        :rtype: Iterator
+
+        A scrolling region restricts scrolling to a portion of the screen. When text
+        scrolls within the region, content outside the region remains fixed. This is
+        useful for creating interfaces with fixed headers, footers, or status bars::
+
+            with term.fullscreen(), term.scroll_region(top=1, height=term.height - 2):
+                # row 0 and the last row remain fixed
+                # scrolling happens only in the middle region
+                for i in range(100):
+                    print(f'Line {i}')
+
+        The cursor position may be reset to the home position when the scroll region
+        changes. Use :meth:`move_yx` to reposition as needed after entering the
+        context.
+
+        .. note:: :meth:`scroll_region` calls cannot be nested: only one
+            should be entered at a time.
+        """
+        if height is None:
+            height = self.height - top
+        bottom = top + height - 1
+        self.stream.write(self.change_scroll_region(top, bottom))
+        self.stream.flush()
+        try:
+            yield
+        finally:
+            self.stream.write(self.change_scroll_region(0, self.height - 1))
             self.stream.flush()
 
     def move_xy(self, x: int, y: int) -> str:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -176,3 +176,12 @@ https://github.com/jquast/blessed/blob/master/bin/mouse_paint.py
 .. figure:: https://dxtz6bzwq9sxx.cloudfront.net/mouse_paint.gif
 
 This is a basic "paint" program using :ref:`mouse input` with the :ref:`report_motion` feature.
+
+.. _scroll_region.py:
+
+scroll_region.py
+----------------
+https://github.com/jquast/blessed/blob/master/bin/scroll_region.py
+
+This program demonstrates the :meth:`~.Terminal.scroll_region` context manager to create a
+scrollable area with a fixed header and status bar.

--- a/docs/location.rst
+++ b/docs/location.rst
@@ -108,3 +108,18 @@ Produces output, ``(12, 12)``
 Although this wouldn't be suggested in most applications because of its latency, it certainly
 simplifies many applications, and, can also be timed, to make a determination of the round-trip
 time, perhaps even the bandwidth constraints, of a remote terminal!
+
+Scroll Region
+-------------
+
+A **scroll region** restricts scrolling to a portion of the screen. When text scrolls within the
+region, content outside the region remains fixed. This is the mechanism behind interfaces like
+:linuxman:`less(1)`, or irc chat clients, where new messages scroll while an input area stays in
+place.
+
+A :func:`contextlib.contextmanager`, :meth:`~.Terminal.scroll_region` is provided to set a scrolling
+region on entry and restore to full screen region on exit:
+
+.. literalinclude:: ../bin/scroll_region.py
+   :language: python
+   :lines: 2-

--- a/tests/accessories.py
+++ b/tests/accessories.py
@@ -293,6 +293,8 @@ def pty_test(child_func, parent_func=None, test_name=None, rows=24, cols=80):
     """
     Wrapper for PTY-based tests to reduce boilerplate.
 
+    Note that TTY-alike behaviors, such as terminal window size does not work with Windows
+
     Handles the common pattern of forking a PTY, running test code in the child
     process with coverage tracking, and optionally running parent-side code.
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,7 +17,7 @@ import pytest
 
 # local
 from .conftest import IS_WINDOWS
-from .accessories import TestTerminal, unicode_cap, as_subprocess
+from .accessories import TestTerminal, unicode_cap, as_subprocess, pty_test
 
 
 def test_export_only_Terminal():
@@ -571,3 +571,29 @@ def test_query_methods_respect_does_styling_and_is_a_tty(force_styling, is_a_tty
         assert stream.getvalue() == ''
 
     child()
+
+
+def test_scroll_region_context_manager():
+    """Test scroll_region context manager sets and resets scroll region."""
+    def child(term):
+        stream = io.StringIO()
+        term._stream = stream
+        with term.scroll_region(top=5, height=10):
+            pass
+        return stream.getvalue()
+
+    output = pty_test(child, rows=24, cols=80)
+    assert output == '\x1b[6;15r\x1b[1;24r'
+
+
+def test_scroll_region_context_manager_defaults():
+    """Test scroll_region context manager with default arguments."""
+    def child(term):
+        stream = io.StringIO()
+        term._stream = stream
+        with term.scroll_region():
+            pass
+        return stream.getvalue()
+
+    output = pty_test(child, rows=24, cols=80)
+    assert output == '\x1b[1;24r\x1b[1;24r'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -573,6 +573,7 @@ def test_query_methods_respect_does_styling_and_is_a_tty(force_styling, is_a_tty
     child()
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="PTY tests not supported on Windows")
 def test_scroll_region_context_manager():
     """Test scroll_region context manager sets and resets scroll region."""
     def child(term):
@@ -586,6 +587,7 @@ def test_scroll_region_context_manager():
     assert output == '\x1b[6;15r\x1b[1;24r'
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="PTY tests not supported on Windows")
 def test_scroll_region_context_manager_defaults():
     """Test scroll_region context manager with default arguments."""
     def child(term):


### PR DESCRIPTION
Also adds _sugar alias, 'change_scroll_region' for csr, though it is not
documented or recommended, you almost always want to reset the scroll
region on error or exit.

Closes #165
