### PR TITLE
New method: Terminal.detect_ambiguous_width() -> [1, 2]

### DIFF
--- a/.spelling-ignore-words.txt
+++ b/.spelling-ignore-words.txt
@@ -2,3 +2,4 @@ padd
 parms
 iTerm
 THIRDPARTY
+claus

--- a/bin/display-unicode.py
+++ b/bin/display-unicode.py
@@ -92,8 +92,8 @@ def main():
 
     print('- Wide characters ' + term.bold_green(f'supported (v{wide_ver})'))
 
-    zwj_ver = detect_zwj_version(term)
     print('- Emojis with ZWJ ', end='')
+    zwj_ver = detect_zwj_version(term)
     if zwj_ver:
         print(term.bold_green(f'supported (v{zwj_ver})'))
     else:
@@ -104,7 +104,6 @@ def main():
         print(term.bold_green('supported'))
     else:
         print(term.bold_red('not supported'))
-    vs16 = detect_vs16_support(term)
 
     ambig_txt = 'wide (2)' if term.detect_ambiguous_width() == 2 else 'narrow (1)'
     print(f'- Ambiguous width is {ambig_txt}')

--- a/bin/display-unicode.py
+++ b/bin/display-unicode.py
@@ -23,6 +23,7 @@ def measure_width(term, text, timeout=1):
 
 WIDE_VERSION_TESTS = (
     # First NEW wide character introduced in each Unicode version (9.0+)
+    # Source: https://unicode.org/Public/{version}/ucd/EastAsianWidth.txt
     ('9.0.0', '\u231A'),      # U+231A WATCH (first new wide in 9.0)
     ('10.0.0', '\u312E'),     # U+312E BOPOMOFO LETTER O WITH DOT ABOVE
     ('11.0.0', '\u312F'),     # U+312F BOPOMOFO LETTER NN
@@ -36,15 +37,22 @@ WIDE_VERSION_TESTS = (
 )
 
 EMOJI_ZWJ_TESTS = (
-    # First NEW ZWJ emoji sequence per Emoji version (11.0+)
-    ('11.0', '\U0001F468\u200D\U0001F9B0'),  # man: red hair
-    ('12.0', '\U0001F9D1\u200D\U0001F91D\u200D\U0001F9D1'),  # people holding hands
-    ('12.1', '\U0001F9D1\u200D\U0001F33E'),  # farmer
-    ('13.0', '\U0001F9D1\u200D\U0001F384'),  # mx claus
-    ('13.1', '\u2764\uFE0F\u200D\U0001F525'),  # heart on fire
-    ('14.0', '\U0001FAF1\U0001F3FB\u200D\U0001FAF2\U0001F3FC'),  # handshake: light, medium-light
-    ('15.0', '\U0001F426\u200D\u2B1B'),  # black bird
-    ('15.1', '\U0001F3C3\u200D\u27A1\uFE0F'),  # person running facing right
+    # First NEW ZWJ emoji sequence per Emoji version
+    # E1.0-E5.0: separate numbering from Unicode (use E prefix)
+    # E11.0+: synchronized with Unicode version (use v prefix)
+    # Exception: E13.1 was released with Unicode 13.0
+    # Source: https://unicode.org/Public/emoji/{version}/emoji-zwj-sequences.txt
+    ('E2.0', '\U0001F468\u200D\u2764\uFE0F\u200D\U0001F468'),  # couple with heart: man, man
+    ('E4.0', '\U0001F468\u200D\U0001F466'),  # family: man, boy
+    ('E5.0', '\U0001F9D6\u200D\u2640\uFE0F'),  # woman in steamy room
+    ('v11', '\U0001F468\u200D\U0001F9B0'),  # man: red hair
+    ('v12', '\U0001F9D1\u200D\U0001F91D\u200D\U0001F9D1'),  # people holding hands
+    ('v12.1', '\U0001F9D1\u200D\U0001F33E'),  # farmer
+    ('v13', '\U0001F9D1\u200D\U0001F384'),  # mx claus
+    ('v13.1', '\u2764\uFE0F\u200D\U0001F525'),  # heart on fire (E13.1 → Unicode 13.0)
+    ('v14', '\U0001FAF1\U0001F3FB\u200D\U0001FAF2\U0001F3FC'),  # handshake: light, medium-light
+    ('v15', '\U0001F426\u200D\u2B1B'),  # black bird
+    ('v15.1', '\U0001F3C3\u200D\u27A1\uFE0F'),  # person running facing right
 )
 
 VS16_TEST = '\u231A\uFE0F'  # watch + VS16
@@ -95,7 +103,7 @@ def main():
     print('- Emojis with ZWJ ', end='')
     zwj_ver = detect_zwj_version(term)
     if zwj_ver:
-        print(term.bold_green(f'supported (v{zwj_ver})'))
+        print(term.bold_green(f'supported ({zwj_ver})'))
     else:
         print(term.bold_red('not supported'))
 

--- a/bin/display-unicode.py
+++ b/bin/display-unicode.py
@@ -37,15 +37,14 @@ WIDE_VERSION_TESTS = (
 
 EMOJI_ZWJ_TESTS = (
     # First NEW ZWJ emoji sequence per Emoji version (11.0+)
-    ('11.0', '\U0001F9D1\u200D\U0001F91D\u200D\U0001F9D1'),  # people holding hands
-    ('12.0', '\U0001F9D1\u200D\U0001F9B0'),  # person: red hair
-    ('12.1', '\U0001F9D1\u200D\U0001F9BC'),  # person in motorized wheelchair
+    ('11.0', '\U0001F468\u200D\U0001F9B0'),  # man: red hair
+    ('12.0', '\U0001F9D1\u200D\U0001F91D\u200D\U0001F9D1'),  # people holding hands
+    ('12.1', '\U0001F9D1\u200D\U0001F33E'),  # farmer
     ('13.0', '\U0001F9D1\u200D\U0001F384'),  # mx claus
-    ('13.1', '\U0001F468\u200D\U0001F469\u200D\U0001F466\u200D\U0001F466'),  # family variant
-    ('14.0', '\U0001F9D1\u200D\U0001F37C'),  # person feeding baby
-    ('15.0', '\U0001F426\u200D\U0001F525'),  # phoenix (bird + ZWJ + fire)
-    ('15.1', '\U0001FAF1\U0001F3FB\u200D\U0001FAF2\U0001F3FC'),  # handshake
-    ('16.0', '\U0001F9D1\u200D\U0001F9D1\u200D\U0001F9D2'),  # family: adult, adult, child
+    ('13.1', '\u2764\uFE0F\u200D\U0001F525'),  # heart on fire
+    ('14.0', '\U0001FAF1\U0001F3FB\u200D\U0001FAF2\U0001F3FC'),  # handshake: light, medium-light
+    ('15.0', '\U0001F426\u200D\u2B1B'),  # black bird
+    ('15.1', '\U0001F3C3\u200D\u27A1\uFE0F'),  # person running facing right
 )
 
 VS16_TEST = '\u231A\uFE0F'  # watch + VS16

--- a/bin/display-unicode.py
+++ b/bin/display-unicode.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+"""Display terminal Unicode support using cursor location detection."""
+# pylint: disable=invalid-name
+#         Invalid module name "display-unicode"
+import sys
+
+
+def measure_width(term, text, timeout=1):
+    """Measure actual rendered width of text using CPR."""
+    _, x1 = term.get_location(timeout=timeout)
+    if x1 == -1:
+        return None
+    sys.stdout.write(text)
+    sys.stdout.flush()
+    _, x2 = term.get_location(timeout=timeout)
+    if x2 == -1:
+        return None
+    # Clear the test character
+    sys.stdout.write(term.move_x(x1) + ' ' * (x2 - x1) + term.move_x(x1))
+    sys.stdout.flush()
+    return x2 - x1
+
+
+WIDE_VERSION_TESTS = (
+    # First NEW wide character introduced in each Unicode version (9.0+)
+    ('9.0.0', '\u231A'),      # U+231A WATCH (first new wide in 9.0)
+    ('10.0.0', '\u312E'),     # U+312E BOPOMOFO LETTER O WITH DOT ABOVE
+    ('11.0.0', '\u312F'),     # U+312F BOPOMOFO LETTER NN
+    ('12.0.0', '\U00016FE2'),  # U+16FE2 OLD CHINESE HOOK MARK
+    ('12.1.0', '\u32FF'),     # U+32FF SQUARE ERA NAME REIWA
+    ('13.0.0', '\u31BB'),     # U+31BB BOPOMOFO FINAL LETTER G
+    ('14.0.0', '\U0001AFF0'),  # U+1AFF0 KATAKANA LETTER MINNAN TONE-2
+    ('15.0.0', '\U0001B132'),  # U+1B132 HIRAGANA LETTER SMALL KO
+    ('15.1.0', '\u2FFC'),     # U+2FFC KANGXI RADICAL SIMPLIFIED WALK
+    ('16.0.0', '\u2630'),     # U+2630 TRIGRAM FOR HEAVEN
+)
+
+EMOJI_ZWJ_TESTS = (
+    # First NEW ZWJ emoji sequence per Emoji version (11.0+)
+    ('11.0', '\U0001F9D1\u200D\U0001F91D\u200D\U0001F9D1'),  # people holding hands
+    ('12.0', '\U0001F9D1\u200D\U0001F9B0'),  # person: red hair
+    ('12.1', '\U0001F9D1\u200D\U0001F9BC'),  # person in motorized wheelchair
+    ('13.0', '\U0001F9D1\u200D\U0001F384'),  # mx claus
+    ('13.1', '\U0001F468\u200D\U0001F469\u200D\U0001F466\u200D\U0001F466'),  # family variant
+    ('14.0', '\U0001F9D1\u200D\U0001F37C'),  # person feeding baby
+    ('15.0', '\U0001F426\u200D\U0001F525'),  # phoenix (bird + ZWJ + fire)
+    ('15.1', '\U0001FAF1\U0001F3FB\u200D\U0001FAF2\U0001F3FC'),  # handshake
+    ('16.0', '\U0001F9D1\u200D\U0001F9D1\u200D\U0001F9D2'),  # family: adult, adult, child
+)
+
+VS16_TEST = '\u231A\uFE0F'  # watch + VS16
+
+
+def detect_wide_version(term, timeout=0.5):
+    """Detect highest supported Unicode version for wide characters."""
+    best_version = None
+    for version, char in WIDE_VERSION_TESTS:
+        width = measure_width(term, char, timeout)
+        if width == 2:
+            best_version = version
+    return best_version
+
+
+def detect_zwj_version(term, timeout=0.5):
+    """Detect highest supported Emoji ZWJ version."""
+    best_version = None
+    for version, seq in EMOJI_ZWJ_TESTS:
+        width = measure_width(term, seq, timeout)
+        # ZWJ sequences should render as width 2 (single emoji)
+        if width == 2:
+            best_version = version
+    return best_version
+
+
+def detect_vs16_support(term, timeout=1):
+    return measure_width(term, VS16_TEST, timeout) == 2
+
+
+def main():
+    """Program entry point."""
+    # local
+    from blessed import Terminal
+
+    term = Terminal()
+    print('Unicode Support Report')
+    print('======================')
+    print()
+
+    wide_ver = detect_wide_version(term)
+    if not wide_ver:
+        print(term.bold_red('This terminal does not support unicode'))
+        return
+
+    print('- Wide characters ' + term.bold_green(f'supported (v{wide_ver})'))
+
+    zwj_ver = detect_zwj_version(term)
+    print('- Emojis with ZWJ ', end='')
+    if zwj_ver:
+        print(term.bold_green(f'supported (v{zwj_ver})'))
+    else:
+        print(term.bold_red('not supported'))
+
+    print('- Emojis with VS-16 ', end='')
+    if detect_vs16_support(term):
+        print(term.bold_green('supported'))
+    else:
+        print(term.bold_red('not supported'))
+    vs16 = detect_vs16_support(term)
+
+    ambig_txt = 'wide (2)' if term.detect_ambiguous_width() == 2 else 'narrow (1)'
+    print(f'- Ambiguous width is {ambig_txt}')
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/dec_modes.rst
+++ b/docs/dec_modes.rst
@@ -96,7 +96,7 @@ The :class:`~blessed.dec_modes.DecModeResponse` object provides helper propertie
 
 Query results are automatically cached. Use ``force=True`` to bypass the cache:
 
-Try the :ref:`display_modes.py` example program to detect and report all supported
+Try the :ref:`display-modes.py` example program to detect and report all supported
 sequences for a given terminal.
 
 Context Managers

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -148,14 +148,24 @@ https://github.com/jquast/blessed/blob/master/bin/x11_colorpicker.py
 This program shows all of the X11 colors, demonstrates a basic keyboard-interactive program and
 color selection, but is also a useful utility to pick colors!
 
-.. _display_modes.py:
+.. _display-modes.py:
 
-display_modes.py
+display-modes.py
 ----------------
-https://github.com/jquast/blessed/blob/master/bin/display_modes.py
+https://github.com/jquast/blessed/blob/master/bin/display-modes.py
 
 Detect and report all known DEC Private Modes supported by the Terminal and
 display a report.
+
+.. _display-unicode.py:
+
+display-unicode.py
+------------------
+https://github.com/jquast/blessed/blob/master/bin/display-unicode.py
+
+Basic Unicode detection support, for Wide characters, Emojis with ZWJ, Emojis with VS-16, and
+Ambiguous Width as Wide or Narrow by writing effects to the screen and measuring the cursor
+position.
 
 .. _strip.py:
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -8,6 +8,7 @@ Version History
     :ghuser:`grayjk`.
   * improved: add :meth:`Terminal.wrap` break_on_hyphen support matching
     behavior of :func:`textwrap.wrap` by :ghuser:`ps06756`.
+  * new: :meth:`Terminal.detect_ambiguous_width`, :ghpull:`XXX`.
 
 1.25
   * bugfix: The "Copy globals" fix in 1.20 got reverted in release in 1.23

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -8,7 +8,7 @@ Version History
     :ghuser:`grayjk`.
   * improved: add :meth:`Terminal.wrap` break_on_hyphen support matching
     behavior of :func:`textwrap.wrap` by :ghuser:`ps06756`.
-  * new: :meth:`Terminal.detect_ambiguous_width`, :ghpull:`XXX`.
+  * new: :meth:`Terminal.detect_ambiguous_width`, :ghpull:`339`.
 
 1.25
   * bugfix: The "Copy globals" fix in 1.20 got reverted in release in 1.23


### PR DESCRIPTION
This is a supporting method for the wcwidth library documentation in PR https://github.com/jquast/wcwidth/pull/172

I don't want the "wcwidth" library to be bogged down with terminal support, but I need a place to
document, "this is how you can detect ambiguous wide support", for forthcoming ambiguous_wide=2
argument, in popular use by CJK folk.
