### PR TITLE
fix flit/delete MANIFEST.in and prepare for release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,0 @@
-graft docs
-prune docs/_build
-global-exclude *.py[cod] __pycache__
-include LICENSE
-include version.json
-include *.txt
-include tox.ini
-recursive-include blessed py.typed
-recursive-include tests *.py *.ans

--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -13,4 +13,4 @@ else:
     from blessed.terminal import Terminal  # type: ignore[assignment]
 
 __all__ = ('Terminal',)
-__version__ = "1.26.0"
+__version__ = "1.27.0"

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,9 @@
 Version History
 ===============
 
+1.27
+  * bugfix missing tests, bin, and docs folder in 1.26 release, :ghpull:`341`.
+
 1.26
   * introduced: :meth:`Terminal.detect_ambiguous_width`, :ghpull:`339`.
   * introduced: :meth:`Terminal.no_line_wrap`, context manager for attributes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,20 @@
 requires = ['flit_core >=3.11,<4']
 build-backend = 'flit_core.buildapi'
 
+[tool.flit.sdist]
+include = [
+    'docs/',
+    'tests/',
+    'bin/',
+    '*.rst',
+    '*.txt',
+    'tox.ini',
+    'version.json',
+]
+exclude = [
+    'docs/_build/',
+]
+
 [project]
 name = 'blessed'
 description = """\


### PR DESCRIPTION
Closes #340 migrates setuptools-based MANIFEST.in to pyproject.toml flit-compatible,

This causes source distribution of 1.25.0 and 1.27.0 to be as follows:

-.editorconfig
-.github workflows tests.yml
-.gitignore
-.readthedocs.yml
-.spelling-ignore-words.txt
 CONTRIBUTING.rst
 LICENSE
-MANIFEST.in
README.rst
 bin bounce.py
 bin cnn.py
@@ -21,6 +15,7 @@
 bin display-modes.py
 bin display-sighandlers.py
 bin display-terminalinfo.py
+bin display-unicode.py
 bin display-version.py
 bin editor.py
 bin generate-keycodes.py
@@ -43,6 +38,7 @@
 bin plasma.py
 bin progress_bar.py
 bin resize.py
+bin scroll_region.py
 bin sixel_query.py
 bin strip.py
 bin tprint.py

Which looks correct