### PR TITLE
Upgrade to wcwidth 0.5.0, drop Python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,6 @@ jobs:
           # python release candidate testing
           - python-version: '3.15'
             container: 'python:3.15-rc'
-            optional: true
             test_quick: 0
 
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,7 @@ jobs:
           # python release candidate testing
           - python-version: '3.15'
             container: 'python:3.15-rc'
+            optional: true
             test_quick: 0
 
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: Tests
 
 on:
   push:
+    branches: [master]
   pull_request:
   release:
   schedule:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:  ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version:  ['3.8', '3.9', '3.10', '3.11', '3.12']
         test_quick: [1]
 
         include:

--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -13,4 +13,4 @@ else:
     from blessed.terminal import Terminal  # type: ignore[assignment]
 
 __all__ = ('Terminal',)
-__version__ = "1.27.0"
+__version__ = "1.28.0"

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -13,7 +13,6 @@ from wcwidth import ljust as wcwidth_ljust
 from wcwidth import rjust as wcwidth_rjust
 from wcwidth import width as wcwidth_width
 from wcwidth import center as wcwidth_center
-from wcwidth import wcwidth, wcswidth
 
 # local
 from blessed._capabilities import CAPABILITIES_CAUSE_MOVEMENT, CAPABILITIES_HORIZONTAL_DISTANCE

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 
 # std imports
 import re
-import sys
 import textwrap
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Tuple, Pattern, Iterator, Optional, SupportsIndex
 
 # 3rd party
 from wcwidth import clip as wcwidth_clip
@@ -19,16 +18,6 @@ from blessed._capabilities import CAPABILITIES_CAUSE_MOVEMENT, CAPABILITIES_HORI
 
 if TYPE_CHECKING:  # pragma: no cover
     from blessed.terminal import Terminal
-
-# std imports
-from typing import List, Tuple, Pattern, Iterator, Optional
-
-# SupportsIndex was added in Python 3.8
-if sys.version_info >= (3, 8):
-    # std imports
-    from typing import SupportsIndex
-else:
-    SupportsIndex = int
 
 __all__ = ('Sequence', 'SequenceTextWrapper', 'iter_parse', 'measure_length')
 

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -17,6 +17,7 @@ from wcwidth import center as wcwidth_center
 from blessed._capabilities import CAPABILITIES_CAUSE_MOVEMENT, CAPABILITIES_HORIZONTAL_DISTANCE
 
 if TYPE_CHECKING:  # pragma: no cover
+    # local
     from blessed.terminal import Terminal
 
 __all__ = ('Sequence', 'SequenceTextWrapper', 'iter_parse', 'measure_length')
@@ -439,12 +440,15 @@ class Sequence(str):
         Truncate a string in a sequence-aware manner.
 
         Any printable characters beyond ``width`` are removed, while all
-        sequences remain in place. Horizontal Sequences are first expanded
+        sequences remain in place. Horizontal sequences are first expanded
         by :meth:`padd`.
+
+        Wide characters (such as CJK or emoji) that would partially exceed
+        ``width`` are replaced with space padding to maintain exact width.
 
         :arg int width: The printable width to truncate the string to.
         :rtype: str
-        :returns: String truncated to at most ``width`` printable characters.
+        :returns: String truncated to exactly ``width`` printable characters.
         """
         # Use padd() to expand terminal-specific cursor movements to spaces,
         # then use wcwidth's clip() to truncate while preserving all sequences.
@@ -454,10 +458,9 @@ class Sequence(str):
         r"""
         Return the printable length of string containing sequences.
 
-        Strings containing ``term.left`` or ``\b`` will cause "overstrike",
-        but a length less than 0 is not ever returned. So ``_\b+`` is a
-        length of 1 (displays as ``+``), but ``\b`` alone is simply a
-        length of 0.
+        Returns the maximum horizontal cursor extent reached while processing
+        the string. Backspace and cursor-left movements do not reduce the
+        length below the maximum position reached.
 
         Some characters may consume more than one cell, mainly CJK (Chinese,
         Japanese, Korean) and Emojis and some kinds of symbols.

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -410,7 +410,7 @@ class Sequence(str):
         :returns: String of ``text``, left-aligned by ``width``.
         :rtype: str
         """
-        return wcwidth_ljust(str(self), width.__index__(), fillchar, control_codes='ignore')
+        return wcwidth_ljust(self, width.__index__(), fillchar, control_codes='ignore')
 
     def rjust(self, width: SupportsIndex, fillchar: str = ' ') -> str:
         """
@@ -421,7 +421,7 @@ class Sequence(str):
         :returns: String of ``text``, right-aligned by ``width``.
         :rtype: str
         """
-        return wcwidth_rjust(str(self), width.__index__(), fillchar, control_codes='ignore')
+        return wcwidth_rjust(self, width.__index__(), fillchar, control_codes='ignore')
 
     def center(self, width: SupportsIndex, fillchar: str = ' ') -> str:
         """
@@ -432,7 +432,7 @@ class Sequence(str):
         :returns: String of ``text``, centered by ``width``.
         :rtype: str
         """
-        return wcwidth_center(str(self), width.__index__(), fillchar, control_codes='ignore')
+        return wcwidth_center(self, width.__index__(), fillchar, control_codes='ignore')
 
     def truncate(self, width: SupportsIndex) -> str:
         """
@@ -475,7 +475,7 @@ class Sequence(str):
             as ``term.clear`` will not give accurate returns, it is not
             considered lengthy (a length of 0).
         """
-        return wcwidth_width(str(self))
+        return wcwidth_width(self)
 
     def strip(self, chars: Optional[str] = None) -> str:
         """

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -446,6 +446,10 @@ class Sequence(str):
         Wide characters (such as CJK or emoji) that would partially exceed
         ``width`` are replaced with space padding to maintain exact width.
 
+        SGR (terminal styling) sequences are propagated: the result begins
+        with any active style at the start position and ends with a reset
+        sequence if styles were active.
+
         :arg int width: The printable width to truncate the string to.
         :rtype: str
         :returns: String truncated to exactly ``width`` printable characters.

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -8,14 +8,12 @@ import textwrap
 from typing import TYPE_CHECKING
 
 # 3rd party
+from wcwidth import clip as wcwidth_clip
+from wcwidth import ljust as wcwidth_ljust
+from wcwidth import rjust as wcwidth_rjust
+from wcwidth import width as wcwidth_width
+from wcwidth import center as wcwidth_center
 from wcwidth import wcwidth, wcswidth
-from wcwidth import (
-    width as wcwidth_width,
-    ljust as wcwidth_ljust,
-    rjust as wcwidth_rjust,
-    center as wcwidth_center,
-    clip as wcwidth_clip,
-)
 
 # local
 from blessed._capabilities import CAPABILITIES_CAUSE_MOVEMENT, CAPABILITIES_HORIZONTAL_DISTANCE

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -2474,12 +2474,16 @@ class Terminal():
 
     def truncate(self, text: str, width: Optional[SupportsIndex] = None) -> str:
         r"""
-        Truncate ``text`` to maximum ``width`` printable characters, retaining terminal sequences.
+        Truncate ``text`` to ``width`` printable characters, retaining terminal sequences.
+
+        Wide characters (such as CJK or emoji) that would partially exceed
+        ``width`` are replaced with space padding to maintain exact width.
 
         :arg str text: Text to truncate
-        :arg int width: The maximum width to truncate it to
+        :arg int width: The width to truncate to. If unspecified, the whole
+            width of the terminal is used.
         :rtype: str
-        :returns: ``text`` truncated to at most ``width`` printable characters
+        :returns: ``text`` truncated to exactly ``width`` printable characters
 
         >>> term.truncate('xyz\x1b[0;3m', 2)
         'xy\x1b[0;3m'
@@ -2492,10 +2496,13 @@ class Terminal():
         """
         Return printable length of a string containing sequences.
 
+        Returns the maximum horizontal cursor extent reached while processing
+        the string. Backspace and cursor-left movements do not reduce the
+        length below the maximum position reached.
+
         :arg str text: String to measure. May contain terminal sequences.
         :rtype: int
-        :returns: The number of terminal character cells the string will occupy
-            when printed
+        :returns: The maximum terminal character cell position reached
 
         Wide characters that consume 2 character cells are supported:
 

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -13,14 +13,7 @@ import platform
 import warnings
 import contextlib
 import collections
-from typing import IO, Dict, List, Match, Tuple, Union, Optional, Generator
-
-# SupportsIndex was added in Python 3.8
-if sys.version_info >= (3, 8):
-    # std imports
-    from typing import SupportsIndex
-else:
-    SupportsIndex = int  # type: ignore
+from typing import IO, Dict, List, Match, Tuple, Union, Optional, Generator, SupportsIndex
 
 # local
 from .color import COLOR_DISTANCE_ALGORITHMS, xterm256gray_from_rgb, xterm256color_from_rgb

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,8 +4,8 @@ Version History
 ===============
 
 *next release*
-  * improved: upgrade to wcwidth 0.3.1, improving performance of :meth:`Terminal.wrap`_,
-    :meth:`Terminal.ljust`_, and related functions, :ghpull:`344`.
+  * improved: upgrade to wcwidth 0.3.1, improving performance of :meth:`Terminal.wrap`,
+    :meth:`Terminal.ljust`, and related functions, :ghpull:`344`.
   * deprecated: Python 3.7 and earlier no longer supported. :ghpull:`344`.
 
 1.27

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,9 +3,9 @@
 Version History
 ===============
 
-*next release*
-  * improved: upgrade to wcwidth 0.3.1, improving performance of :meth:`Terminal.wrap`,
-    :meth:`Terminal.ljust`, and related functions, :ghpull:`344`.
+1.28
+  * improved: upgrade to wcwidth 0.5, improving performance and correctness
+    of :meth:`Terminal.wrap`, :meth:`Terminal.ljust`, and related functions, :ghpull:`344`.
   * deprecated: Python 3.7 and earlier no longer supported. :ghpull:`344`.
 
 1.27

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,11 @@
 Version History
 ===============
 
+*next release*
+  * improved: upgrade to wcwidth 0.3.1, improving performance of :meth:`Terminal.wrap`_,
+    :meth:`Terminal.ljust`_, and related functions, :ghpull:`344`.
+  * deprecated: Python 3.7 and earlier no longer supported. :ghpull:`344`.
+
 1.27
   * bugfix missing tests, bin, and docs folder in 1.26 release, :ghpull:`341`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ classifiers = [
     'Typing :: Typed',
 ]
 dependencies = [
-    'wcwidth>=0.3.0',
+    'wcwidth>=0.3.1',
     'jinxed>=1.1.0; platform_system == "Windows"',
 ]
 dynamic = ['version']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ classifiers = [
     'Operating System :: POSIX',
     'Operating System :: Microsoft :: Windows',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
@@ -58,7 +57,7 @@ license-files = ['LICENSE']
 keywords = ['terminal', 'sequences', 'tty', 'curses', 'ncurses', 'formatting',
             'style', 'color', 'console', 'keyboard', 'ansi', 'xterm']
 readme = 'docs/intro.rst'
-requires-python = '>=3.7'
+requires-python = '>=3.8'
 
 [project.optional-dependencies]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
     'Typing :: Typed',
 ]
 dependencies = [
-    'wcwidth>=0.3.1',
+    'wcwidth>=0.5',
     'jinxed>=1.1.0; platform_system == "Windows"',
 ]
 dynamic = ['version']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ classifiers = [
     'Typing :: Typed',
 ]
 dependencies = [
-    'wcwidth>=0.2.14',
+    'wcwidth>=0.3.0',
     'jinxed>=1.1.0; platform_system == "Windows"',
 ]
 dynamic = ['version']

--- a/tests/test_length_sequence.py
+++ b/tests/test_length_sequence.py
@@ -281,7 +281,11 @@ def test_sequence_length(all_terms):
         # accounted for as a "length", as <x><move right 10><y>
         # will result in a printed column length of 12 (even
         # though columns 2-11 are non-destructive space
-        assert term.length('x\b') == 0
+
+        # NOTE: As of wcwidth 0.3.0, length() returns "maximum extent" rather
+        # than "effective length after destructive cursor movements". So 'x\b'
+        # returns 1 (cursor reached column 1) not 0 (cursor ended at column 0).
+        assert term.length('x\b') == 1
         assert term.strip('x\b') == ''
 
         # characters where wcwidth returns -1
@@ -291,11 +295,13 @@ def test_sequence_length(all_terms):
         assert term.length('\t') in {8, 9}
         assert term.strip('\t') == ''
 
-        assert term.length(f'_{term.move_left}') == 0
+        # NOTE: With wcwidth 0.3.0, these return "maximum extent" not "final position"
+        assert term.length(f'_{term.move_left}') == 1
         assert term.length(term.move_right) == 1
 
         if term.cub:
-            assert term.length(f'{"_" * 10}{term.cub(10)}') == 0
+            # cursor moved right 10, then back 10 - max extent was 10
+            assert term.length(f'{"_" * 10}{term.cub(10)}') == 10
 
         if term.cuf:
             assert term.length(term.cuf(10)) == 10

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -9,7 +9,8 @@ import pytest
 
 # local
 from .conftest import IS_WINDOWS
-from .accessories import MockTigetstr, TestTerminal, unicode_cap, unicode_parm, as_subprocess, pty_test
+from .accessories import (
+    MockTigetstr, TestTerminal, unicode_cap, unicode_parm, as_subprocess, pty_test)
 
 try:
     # std imports

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -743,7 +743,6 @@ def test_truncate_default(all_terms):
     @as_subprocess
     def child(kind):
         # std imports
-        import sys
         import fcntl
         import struct
         import termios

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -9,7 +9,7 @@ import pytest
 
 # local
 from .conftest import IS_WINDOWS
-from .accessories import MockTigetstr, TestTerminal, unicode_cap, unicode_parm, as_subprocess
+from .accessories import MockTigetstr, TestTerminal, unicode_cap, unicode_parm, as_subprocess, pty_test
 
 try:
     # std imports
@@ -738,14 +738,9 @@ def test_truncate_padding(all_terms):
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="requires fcntl")
-def test_truncate_default(all_terms):
+def test_truncate_default():
     """Ensure that terminal.truncate functions with the default argument."""
-    @as_subprocess
-    def child(kind):
-        # local
-        from blessed import Terminal
-
-        term = Terminal(kind)
+    def child(term):
         assert term.width == 80
 
         test = f'Testing {term.red("attention ")}{term.blue("please.")}'
@@ -753,9 +748,7 @@ def test_truncate_default(all_terms):
         assert term.length(trunc) <= term.width
         assert term.truncate(term.red('x' * 1000)) == term.red('x' * term.width)
 
-    pty_test(child, all_terms, test_name='test_truncate_default')
- 
-    child(all_terms)
+    pty_test(child, parent_func=None, test_name='test_truncate_default')
 
 
 def test_truncate_zwj_emoji(all_terms):

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -742,16 +742,8 @@ def test_truncate_default(all_terms):
     """Ensure that terminal.truncate functions with the default argument."""
     @as_subprocess
     def child(kind):
-        # std imports
-        import fcntl
-        import struct
-        import termios
         # local
         from blessed import Terminal
-
-        # Set pty to a known width
-        val = struct.pack('HHHH', 25, 80, 0, 0)
-        fcntl.ioctl(sys.__stdout__.fileno(), termios.TIOCSWINSZ, val)
 
         term = Terminal(kind)
         assert term.width == 80
@@ -761,6 +753,8 @@ def test_truncate_default(all_terms):
         assert term.length(trunc) <= term.width
         assert term.truncate(term.red('x' * 1000)) == term.red('x' * term.width)
 
+    pty_test(child, all_terms, test_name='test_truncate_default')
+ 
     child(all_terms)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist =
     pydocstyle
     mypy
     sphinx
-    py{37,38,39,310,311,312,313,314}
+    py{38,39,310,311,312,313,314}
 
 
 ####### Python Test Environments #######


### PR DESCRIPTION
CI
--

- drops Python 3.7
  - because wcwidth doesn't support it
  - I guess because of the new pyproject.toml stuff, wcwidth [wasn't compatible](https://github.com/jquast/wcwidth/pull/156#issuecomment-3563492768)
- bugfix build dupes, do not "double-build" all tests (push and pull)
- bugfix enforcing pty window size with semaphore
  - similar to how pexpect / pty_process project does it

Performance
-------------------

- Upgrade dependency wcwidth to 0.5.0 (today's release)
- Replace custom `Sequence` method implementations with wcwidth's new functions: `ljust()`, `rjust()`, `center()`,
  `clip()`, and `width()` using `control_codes='ignore'`, new since 0.3.0.
- See benchmark [results below](https://github.com/jquast/blessed/pull/344#issuecomment-3786814877)

2 Changing Behaviors
--------------------------------

1. The `length()` method now returns **maximum cursor extent** rather than **final relative cursor position**:
  - `term.length('x\b')` was `0`, now `1`!
  - `term.length(f'{"_" * 10}{term.cub(10)}')` was `0`, now `10`!

This [is preferred](https://github.com/jquast/blessed/pull/338#issuecomment-3785387891) !

> I think blessed is doing this wrong by default -- the most common use case is only, "how much screen real estate this takes up", and, likely to use direct cursor positioning yourself to display each wrapped/centered/etc line -- the ending position of the cursor has no consequence.

2. The `truncate()` method now **fills with space** when a wide character doesn't fit:

For leading space this new behavior is absolutely necessary, like if we wanted to do horizontal scrolling of CJK characters, to do this 1 cell at a time will require an oscillating leading ``' '`` at the beginning of the string.

        >>> wcwidth.clip("AB\uff23", 0, 3)
        'AB '
        >>> wcwidth.clip("AB\uff23", 0, 4)
        'ABＣ'
        >>> wcwidth.clip("\uff23BA", 0, 4)
        'ＣBA'
        >>> wcwidth.clip("\uff23BA", 0, 3)
        'ＣB'
        >>> wcwidth.clip("\uff23BA", 1, 3)
        ' B'
        >>> wcwidth.clip("\uff23BA", 1, 4)
        ' BA'
        >>> wcwidth.clip("\uff23BA", 0, 4)
        'ＣBA'

I admit trailing space is a little bit questionable, we want a string "no wider than x", and if it is less that is probably fine and there is no need for trailing space, the caller could use 'ljust()' to padd it if necessary, this is just how it worked out in the wcwidth implementation.