### PR TITLE
bugfix kitty keyboard protocol detection

### DIFF
--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -13,4 +13,4 @@ else:
     from blessed.terminal import Terminal  # type: ignore[assignment]
 
 __all__ = ('Terminal',)
-__version__ = "1.28.0"
+__version__ = "1.29.0"

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,9 @@
 Version History
 ===============
 
+1.29
+  * bugfix: :meth:`Terminal.get_kitty_keyboard_state` failed to match :ghpull:`348`.
+
 1.28
   * improved: upgrade to wcwidth 0.5, improving performance and correctness
     of :meth:`Terminal.wrap`, :meth:`Terminal.ljust`, and related functions, :ghpull:`344`.


### PR DESCRIPTION
The boundary pattern in ``get_kitty_keyboard_state()`` used ``.+`` which matched prematurely!

Existing tests didn't catch this because they use ungetch() which buffers the entire response

The reported codspeed performance adjustment is real, ~20% less for emojis and CJK, for recent fixes in wcwidth release for "standalone" emoji variators and complex Brahmic scripts (Sanskrit etc)

https://github.com/jquast/wcwidth/pull/200
https://github.com/jquast/wcwidth/pull/202
