### PR TITLE
LineEditor and async_inkey()

### DIFF
--- a/.spelling-ignore-words.txt
+++ b/.spelling-ignore-words.txt
@@ -3,3 +3,4 @@ parms
 iTerm
 THIRDPARTY
 claus
+hel

--- a/bin/editor.py
+++ b/bin/editor.py
@@ -23,6 +23,7 @@ import collections
 
 # local
 from blessed import Terminal
+from blessed.line_editor import LineEditor
 
 
 def echo(text):
@@ -55,27 +56,20 @@ Cursor = collections.namedtuple('Cursor', ('y', 'x', 'term'))
 
 
 def readline(term, width=20):
-    """A rudimentary readline implementation."""
-    text = ''
+    """Read a line of input using :class:`~blessed.line_editor.LineEditor`."""
+    col = term.get_location()[1]
+    editor = LineEditor(limit=width, max_width=width)
     while True:
         inp = term.inkey()
-        if inp.code == term.KEY_ENTER:
-            break
-        elif inp.code == term.KEY_ESCAPE or inp == chr(3):
-            text = None
-            break
-        elif not inp.is_sequence and len(text) < width:
-            text += inp
-            echo(inp)
-        elif inp.code in (term.KEY_BACKSPACE, term.KEY_DELETE):
-            text = text[:-1]
-            # https://utcc.utoronto.ca/~cks/space/blog/unix/HowUnixBackspaces
-            #
-            # "When you hit backspace, the kernel tty line discipline rubs out
-            # your previous character by printing (in the simple case)
-            # Ctrl-H, a space, and then another Ctrl-H."
-            echo('\b \b')
-    return text
+        result = editor.feed_key(inp)
+        if result.line is not None:
+            return result.line
+        if result.eof or result.interrupt:
+            return None
+        if result.changed:
+            ds = editor.display
+            echo(term.move_x(col) + term.clear_eol + ds.text
+                 + term.move_x(col + ds.cursor))
 
 
 def save(screen, fname):
@@ -209,7 +203,7 @@ def main():
     csr = Cursor(0, 0, term)
     screen = {}
     with term.hidden_cursor(), \
-            term.raw(), \
+            term.cbreak(), \
             term.location(), \
             term.fullscreen(), \
             term.keypad(), \

--- a/bin/line_editor_form.py
+++ b/bin/line_editor_form.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Line editor demo with styled input, history, and horizontal scrolling."""
+from blessed import Terminal
+from blessed.line_editor import LineEditor, LineHistory
+
+term = Terminal()
+history = LineHistory()
+PROMPT = ">>> "
+PROMPT_W = len(PROMPT)
+
+
+def emit(text):
+    """Write text to stdout without newline."""
+    print(text, end="", flush=True)
+
+
+with term.cbreak(), term.hidden_cursor():
+    print("Line editor demo. Up/Down=history, Right=accept suggestion, "
+          "Ctrl+D=quit.\n")
+    while True:
+        width = min(term.width - PROMPT_W, 40)
+        ed = LineEditor(history=history, max_width=width, limit=200,
+                        bg_sgr=term.on_brown)
+        emit(PROMPT)
+        row = term.get_location()[0]
+        emit(ed.render(term, row, width))
+        while True:
+            key = term.inkey()
+            result = ed.feed_key(key)
+            if result.bell:
+                emit(result.bell)
+            if result.changed:
+                # try fast-path for common cases, fall back to full redraw
+                key_str = str(key)
+                out = None
+                if key_str and key_str.isprintable() and len(key_str) == 1:
+                    out = ed.render_insert(term, row, key_str)
+                elif getattr(key, "name", None) == "KEY_BACKSPACE":
+                    out = ed.render_backspace(term, row)
+                if out is None:
+                    out = ed.render(term, row, width)
+                emit(out)
+            if result.line is not None:
+                print()
+                if result.line:
+                    print(f"  => {result.line!r}")
+                break
+            if result.eof:
+                print()
+                raise SystemExit
+            if result.interrupt:
+                print("^C")
+                break

--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -12,5 +12,7 @@ if _platform.system() == 'Windows':
 else:
     from blessed.terminal import Terminal  # type: ignore[assignment]
 
-__all__ = ('Terminal',)
+from blessed.line_editor import LineEditor, LineHistory
+
+__all__ = ('Terminal', 'LineEditor', 'LineHistory')
 __version__ = "1.31.0"

--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -13,4 +13,4 @@ else:
     from blessed.terminal import Terminal  # type: ignore[assignment]
 
 __all__ = ('Terminal',)
-__version__ = "1.30.0"
+__version__ = "1.31.0"

--- a/blessed/line_editor.py
+++ b/blessed/line_editor.py
@@ -67,6 +67,7 @@ class DisplayState:
 
 
 def _is_control(grapheme: str) -> bool:
+    """Return ``True`` if *grapheme* is a C0 or C1 control character."""
     cp = ord(grapheme[0])
     return cp < 0x20 or 0x7F <= cp < 0xA0
 
@@ -131,6 +132,12 @@ class LineEditor:
     Feed keystrokes via :meth:`feed_key`, read display state via
     :attr:`display`.  Accepts blessed :class:`~.Keystroke` objects
     directly (dispatching on ``.name``), or plain strings for testing.
+
+    Custom keymap handlers must be callables accepting a single
+    :class:`LineEditor` argument and returning a :class:`LineEditResult`::
+
+        def my_handler(editor: LineEditor) -> LineEditResult:
+            ...
     """
 
     def __init__(
@@ -147,7 +154,6 @@ class LineEditor:
         suggestion_sgr: str = "\x1b[30m",
         bg_sgr: str = "",
         ellipsis_sgr: str = "",
-        cursor_seq: str = "",
         keymap: Optional[Dict[str, Callable]] = None,
     ) -> None:
         self._buf: List[str] = []
@@ -170,7 +176,6 @@ class LineEditor:
         self.suggestion_sgr: str = suggestion_sgr
         self.bg_sgr: str = bg_sgr
         self.ellipsis_sgr: str = ellipsis_sgr
-        self.cursor_seq: str = cursor_seq
         self.keymap: Dict[str, Callable] = dict(DEFAULT_KEYMAP)
         if keymap:
             self.keymap.update(keymap)
@@ -501,6 +506,7 @@ class LineEditor:
 
     def _delete_at_cursor(self) -> LineEditResult:
         if self._cursor < len(self._buf):
+            self._save_undo()
             del self._buf[self._cursor]
             self._maybe_reset_limit_bell()
             return LineEditResult(changed=True)
@@ -517,13 +523,12 @@ class LineEditor:
         return LineEditResult()
 
     def _kill_line(self) -> LineEditResult:
-        if self._buf:
+        if self._buf and self._cursor > 0:
             self._save_undo()
             killed = "".join(self._buf[:self._cursor])
             del self._buf[:self._cursor]
             self._cursor = 0
-            if killed:
-                self._kill_ring.append(killed)
+            self._kill_ring.append(killed)
             self._maybe_reset_limit_bell()
             return LineEditResult(changed=True)
         return LineEditResult()
@@ -606,7 +611,6 @@ def _apply_hscroll(
     cursor_col: int,
     max_width: int,
     ellipsis: str = "\u2026",
-    scroll_jump: float = 0.5,
     scroll_offset: Optional[int] = None,
 ) -> DisplayState:
     ellipsis_w = wcswidth(ellipsis)
@@ -620,9 +624,9 @@ def _apply_hscroll(
 
     usable = max_width
     if scroll_offset is None:
-        jump = max(1, int(usable * scroll_jump))
         scroll_offset = 0
         if cursor_col >= usable:
+            jump = max(1, usable // 2)
             scroll_offset = cursor_col - usable + jump + 1
 
     overflow_left = scroll_offset > 0

--- a/blessed/line_editor.py
+++ b/blessed/line_editor.py
@@ -1,4 +1,5 @@
-"""Headless line editor with history, auto-suggest, and grapheme-aware editing.
+"""
+Headless line editor with history, auto-suggest, and grapheme-aware editing.
 
 This module provides :class:`LineEditor` for single-line input with readline-style
 editing and :class:`LineHistory` for command recall.
@@ -6,15 +7,16 @@ editing and :class:`LineHistory` for command recall.
 from __future__ import annotations
 
 # std imports
+from typing import TYPE_CHECKING, Dict, List, Deque, Tuple, Union, Callable, Optional
 from collections import deque
-from typing import TYPE_CHECKING, Deque, Dict, List, Tuple, Union, Callable, Optional
 from dataclasses import dataclass
 
 if TYPE_CHECKING:
     from .terminal import Terminal
 
 # 3rd party
-from wcwidth import iter_graphemes, width as wcswidth
+from wcwidth import width as wcswidth
+from wcwidth import iter_graphemes
 
 PASSWORD_CHAR = "\u273b"
 
@@ -44,7 +46,7 @@ class LineEditResult:
 
 
 @dataclass
-class DisplayState:
+class DisplayState:  # pylint: disable=too-many-instance-attributes
     """Current visual state of the editor for rendering."""
 
     #: Visible buffer text (masked in password mode, clipped when scrolling).
@@ -74,12 +76,14 @@ def _is_control(grapheme: str) -> bool:
 
 
 class LineHistory:
-    """In-memory command history with navigation and prefix search.
+    """
+    In-memory command history with navigation and prefix search.
 
     :param max_entries: Maximum number of history entries retained.
     """
 
     def __init__(self, max_entries: int = 5000) -> None:
+        """Initialize history with given maximum capacity."""
         #: History entries list (most recent last).
         self.entries: List[str] = []
         self._max_entries = max_entries
@@ -127,8 +131,9 @@ class LineHistory:
         return self.entries[self._nav_idx]
 
 
-class LineEditor:
-    """Headless single-line editor with grapheme-aware cursor movement.
+class LineEditor:  # pylint: disable=too-many-instance-attributes
+    """
+    Headless single-line editor with grapheme-aware cursor movement.
 
     Feed keystrokes via :meth:`feed_key`, read display state via
     :attr:`display`.  Accepts blessed :class:`~.Keystroke` objects
@@ -141,7 +146,7 @@ class LineEditor:
             ...
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         history: Optional[LineHistory] = None,
         password: bool = False,
@@ -155,8 +160,9 @@ class LineEditor:
         suggestion_sgr: str = "\x1b[30m",
         bg_sgr: str = "",
         ellipsis_sgr: str = "",
-        keymap: Optional[Dict[str, Optional[Callable]]] = None,
+        keymap: Optional[Dict[str, Optional[Callable[..., LineEditResult]]]] = None,
     ) -> None:
+        """Initialize editor with optional history, display, and keymap settings."""
         self._buf: List[str] = []
         self._cursor: int = 0
         self._history = history or LineHistory()
@@ -176,7 +182,7 @@ class LineEditor:
         self.suggestion_sgr: str = suggestion_sgr
         self.bg_sgr: str = bg_sgr
         self.ellipsis_sgr: str = ellipsis_sgr
-        self.keymap: Dict[str, Optional[Callable]] = dict(DEFAULT_KEYMAP)
+        self.keymap: Dict[str, Optional[Callable[..., LineEditResult]]] = dict(DEFAULT_KEYMAP)
         if keymap:
             self.keymap.update(keymap)
         self._prev_cursor: int = 0
@@ -235,7 +241,8 @@ class LineEditor:
         self._prev_scroll_offset = self._scroll_offset
 
     def render(self, term: Terminal, row: int, width: int) -> str:
-        """Build escape sequences to render the current display state.
+        """
+        Build escape sequences to render the current display state.
 
         :param term: Blessed :class:`~.Terminal` instance for cursor/SGR.
         :param row: Terminal row for the input line.
@@ -274,7 +281,8 @@ class LineEditor:
     def render_insert(
         self, term: Terminal, row: int, grapheme: str
     ) -> Optional[str]:
-        """Fast-path render for a single grapheme inserted at end of buffer.
+        """
+        Fast-path render for a single grapheme inserted at end of buffer.
 
         :param term: Blessed :class:`~.Terminal` instance.
         :param row: Terminal row for the input line.
@@ -301,7 +309,8 @@ class LineEditor:
         return "".join(parts)
 
     def render_backspace(self, term: Terminal, row: int) -> Optional[str]:
-        """Fast-path render after a backspace at end of buffer.
+        """
+        Fast-path render after a backspace at end of buffer.
 
         :param term: Blessed :class:`~.Terminal` instance.
         :param row: Terminal row for the input line.
@@ -369,7 +378,7 @@ class LineEditor:
         self._password_mode = enabled
 
     def _needs_hscroll(self) -> bool:
-        return self.max_width > 0 and not (0 < self.limit <= self.max_width)
+        return self.max_width > 0 and not 0 < self.limit <= self.max_width
 
     def _compute_scroll(self, cursor_col: int, content_width: int) -> int:
         usable = self.max_width
@@ -597,7 +606,7 @@ class LineEditor:
         return ""
 
 
-def _apply_hscroll(
+def _apply_hscroll(  # pylint: disable=too-many-locals,too-many-branches,too-many-positional-arguments,too-complex
     text: str,
     suggestion: str,
     cursor_col: int,
@@ -671,7 +680,8 @@ def _apply_hscroll(
     )
 
 
-DEFAULT_KEYMAP: Dict[str, Callable] = {
+# pylint: disable=protected-access
+DEFAULT_KEYMAP: Dict[str, Callable[..., LineEditResult]] = {
     "KEY_ENTER": LineEditor._handle_enter,
     "KEY_CTRL_C": LineEditor._handle_ctrl_c,
     "KEY_CTRL_D": LineEditor._handle_ctrl_d,
@@ -699,3 +709,4 @@ DEFAULT_KEYMAP: Dict[str, Callable] = {
     "KEY_CTRL_P": LineEditor._history_prev,
     "KEY_CTRL_Z": LineEditor._undo,
 }
+# pylint: enable=protected-access

--- a/blessed/line_editor.py
+++ b/blessed/line_editor.py
@@ -1,12 +1,13 @@
 """Headless line editor with history, auto-suggest, and grapheme-aware editing.
 
 This module provides :class:`LineEditor` for single-line input with readline-style
-editing and :class:`LineHistory` for command recall and file persistence.
+editing and :class:`LineHistory` for command recall.
 """
 from __future__ import annotations
 
 # std imports
-from typing import TYPE_CHECKING, Dict, List, Tuple, Union, Callable, Optional
+from collections import deque
+from typing import TYPE_CHECKING, Deque, Dict, List, Tuple, Union, Callable, Optional
 from dataclasses import dataclass
 
 if TYPE_CHECKING:
@@ -73,7 +74,7 @@ def _is_control(grapheme: str) -> bool:
 
 
 class LineHistory:
-    """In-memory command history with optional file persistence.
+    """In-memory command history with navigation and prefix search.
 
     :param max_entries: Maximum number of history entries retained.
     """
@@ -93,7 +94,7 @@ class LineHistory:
             return
         self.entries.append(line)
         if len(self.entries) > self._max_entries:
-            self.entries = self.entries[-self._max_entries:]
+            del self.entries[:-self._max_entries]
 
     def search_prefix(self, prefix: str) -> Optional[str]:
         """Return the most recent entry starting with *prefix*, or ``None``."""
@@ -143,7 +144,7 @@ class LineEditor:
     def __init__(
         self,
         history: Optional[LineHistory] = None,
-        is_password: Optional[Callable[[], bool]] = None,
+        password: bool = False,
         password_char: str = PASSWORD_CHAR,
         max_width: int = 0,
         ellipsis: str = "\u2026",
@@ -154,17 +155,16 @@ class LineEditor:
         suggestion_sgr: str = "\x1b[30m",
         bg_sgr: str = "",
         ellipsis_sgr: str = "",
-        keymap: Optional[Dict[str, Callable]] = None,
+        keymap: Optional[Dict[str, Optional[Callable]]] = None,
     ) -> None:
         self._buf: List[str] = []
         self._cursor: int = 0
         self._history = history or LineHistory()
-        self._is_password: Optional[Callable[[], bool]] = is_password
+        self._password_mode: bool = password
         self.password_char: str = password_char
-        self._kill_ring: List[str] = []
+        self._kill_ring: Deque[str] = deque(maxlen=64)
         self._undo_stack: List[Tuple[List[str], int]] = []
-        self._in_history: bool = False
-        self._password_mode: bool = False
+        self._navigating_history: bool = False
         self.max_width: int = max_width
         self.ellipsis: str = ellipsis
         self.limit: int = limit
@@ -176,12 +176,13 @@ class LineEditor:
         self.suggestion_sgr: str = suggestion_sgr
         self.bg_sgr: str = bg_sgr
         self.ellipsis_sgr: str = ellipsis_sgr
-        self.keymap: Dict[str, Callable] = dict(DEFAULT_KEYMAP)
+        self.keymap: Dict[str, Optional[Callable]] = dict(DEFAULT_KEYMAP)
         if keymap:
             self.keymap.update(keymap)
         self._prev_cursor: int = 0
         self._prev_content_w: int = 0
         self._prev_overflow: Tuple[bool, bool] = (False, False)
+        self._prev_scroll_offset: int = 0
 
     @property
     def history(self) -> LineHistory:
@@ -196,8 +197,6 @@ class LineEditor:
     @property
     def password_mode(self) -> bool:
         """Return whether password mode is currently active."""
-        if self._is_password is not None:
-            return self._is_password()
         return self._password_mode
 
     def _apply_sgr(self, state: DisplayState) -> DisplayState:
@@ -211,29 +210,29 @@ class LineEditor:
     @property
     def display(self) -> DisplayState:
         """Return the current :class:`DisplayState` for rendering."""
-        line = self.line
-        cursor_col = self._cursor_display_col()
         if self.password_mode:
-            pw_text = self.password_char * len(self._buf)
-            pw_cursor = self._cursor * wcswidth(self.password_char)
-            if self._needs_hscroll():
-                cw = wcswidth(pw_text)
-                offset = self._compute_scroll(pw_cursor, cw)
-                return self._apply_sgr(_apply_hscroll(
-                    pw_text, "", pw_cursor, self.max_width, self.ellipsis,
-                    scroll_offset=offset))
-            return self._apply_sgr(
-                DisplayState(text=pw_text, cursor=pw_cursor))
-        suggestion = self._get_suggestion()
+            text = self.password_char * len(self._buf)
+            cursor_col = self._cursor * wcswidth(self.password_char)
+            suggestion = ""
+        else:
+            text = self.line
+            cursor_col = self._cursor_display_col()
+            suggestion = self._get_suggestion()
         if self._needs_hscroll():
-            text_w = wcswidth(line)
-            suggest_w = wcswidth(suggestion)
-            offset = self._compute_scroll(cursor_col, text_w + suggest_w)
+            content_w = wcswidth(text) + wcswidth(suggestion)
+            offset = self._compute_scroll(cursor_col, content_w)
             return self._apply_sgr(_apply_hscroll(
-                line, suggestion, cursor_col, self.max_width, self.ellipsis,
-                scroll_offset=offset))
-        return self._apply_sgr(DisplayState(
-            text=line, cursor=cursor_col, suggestion=suggestion))
+                text, suggestion, cursor_col, self.max_width,
+                self.ellipsis, scroll_offset=offset))
+        return self._apply_sgr(
+            DisplayState(text=text, cursor=cursor_col, suggestion=suggestion))
+
+    def _update_render_state(self, cur: DisplayState, content_w: int) -> None:
+        """Update previous-frame tracking state after rendering."""
+        self._prev_cursor = cur.cursor
+        self._prev_content_w = content_w
+        self._prev_overflow = (cur.overflow_left, cur.overflow_right)
+        self._prev_scroll_offset = self._scroll_offset
 
     def render(self, term: Terminal, row: int, width: int) -> str:
         """Build escape sequences to render the current display state.
@@ -269,9 +268,7 @@ class LineEditor:
             parts.extend((cur.bg_sgr, " " * pad))
 
         parts.extend((term.normal, term.move_yx(row, cur.cursor)))
-        self._prev_cursor = cur.cursor
-        self._prev_content_w = rendered
-        self._prev_overflow = (cur.overflow_left, cur.overflow_right)
+        self._update_render_state(cur, rendered)
         return "".join(parts)
 
     def render_insert(
@@ -289,6 +286,8 @@ class LineEditor:
         cur = self.display
         if (cur.overflow_left, cur.overflow_right) != self._prev_overflow:
             return None
+        if self._scroll_offset != self._prev_scroll_offset:
+            return None
         col = self._prev_cursor
         parts: List[str] = [term.move_yx(row, col), cur.text_sgr, grapheme]
         new_content_w = wcswidth(cur.text) + wcswidth(cur.suggestion)
@@ -298,9 +297,7 @@ class LineEditor:
         if trail > 0:
             parts.extend((cur.bg_sgr, " " * trail))
         parts.extend((term.normal, term.move_yx(row, cur.cursor)))
-        self._prev_cursor = cur.cursor
-        self._prev_content_w = new_content_w
-        self._prev_overflow = (cur.overflow_left, cur.overflow_right)
+        self._update_render_state(cur, new_content_w)
         return "".join(parts)
 
     def render_backspace(self, term: Terminal, row: int) -> Optional[str]:
@@ -315,6 +312,8 @@ class LineEditor:
         cur = self.display
         if (cur.overflow_left, cur.overflow_right) != self._prev_overflow:
             return None
+        if self._scroll_offset != self._prev_scroll_offset:
+            return None
         col = cur.cursor
         new_content_w = wcswidth(cur.text) + wcswidth(cur.suggestion)
         erase = self._prev_content_w - new_content_w
@@ -324,9 +323,7 @@ class LineEditor:
         if erase > 0:
             parts.extend((cur.bg_sgr, " " * erase))
         parts.extend((term.normal, term.move_yx(row, cur.cursor)))
-        self._prev_cursor = cur.cursor
-        self._prev_content_w = new_content_w
-        self._prev_overflow = (cur.overflow_left, cur.overflow_right)
+        self._update_render_state(cur, new_content_w)
         return "".join(parts)
 
     def feed_key(self, key: Union["Keystroke", str]) -> LineEditResult:  # noqa: F821
@@ -343,12 +340,8 @@ class LineEditor:
                 return LineEditResult(
                     changed=False, bell=self._fire_limit_bell())
             self._save_undo()
-            for grapheme in iter_graphemes(key_str):
-                if self._at_limit():
-                    break
-                self._buf.insert(self._cursor, grapheme)
-                self._cursor += 1
-            self._in_history = False
+            self._insert_at_cursor(key_str)
+            self._navigating_history = False
             return LineEditResult(changed=True)
         return LineEditResult()
 
@@ -357,15 +350,9 @@ class LineEditor:
         if self._at_limit():
             return LineEditResult(
                 changed=False, bell=self._fire_limit_bell())
-        old_len = len(self._buf)
         self._save_undo()
-        for grapheme in iter_graphemes(text):
-            if self._at_limit():
-                break
-            if not _is_control(grapheme):
-                self._buf.insert(self._cursor, grapheme)
-                self._cursor += 1
-        if len(self._buf) == old_len:
+        count = self._insert_at_cursor(text, filter_control=True)
+        if count == 0:
             self._undo_stack.pop()
             return LineEditResult(changed=False)
         return LineEditResult(changed=True)
@@ -375,18 +362,14 @@ class LineEditor:
         self._buf.clear()
         self._cursor = 0
         self._scroll_offset = 0
-        self._in_history = False
+        self._navigating_history = False
 
     def set_password_mode(self, enabled: bool) -> None:
-        """Set password mode directly (used when no *is_password* callable)."""
+        """Toggle password masking on or off."""
         self._password_mode = enabled
 
     def _needs_hscroll(self) -> bool:
-        if self.max_width <= 0:
-            return False
-        if self.limit > 0 and self.limit <= self.max_width:
-            return False
-        return True
+        return self.max_width > 0 and not (0 < self.limit <= self.max_width)
 
     def _compute_scroll(self, cursor_col: int, content_width: int) -> int:
         usable = self.max_width
@@ -394,11 +377,11 @@ class LineEditor:
             self._scroll_offset = 0
             return 0
         jump = max(1, int(usable * self.scroll_jump))
-        ecw = wcswidth(self.ellipsis)
-        left_cost = ecw if self._scroll_offset > 0 else 0
-        right_edge = self._scroll_offset + usable - left_cost
+        ellipsis_w = wcswidth(self.ellipsis)
+        left_margin = ellipsis_w if self._scroll_offset > 0 else 0
+        right_edge = self._scroll_offset + usable - left_margin
         if cursor_col >= right_edge:
-            self._scroll_offset = cursor_col - usable + jump + 1 + ecw
+            self._scroll_offset = cursor_col - usable + jump + 1 + ellipsis_w
         elif cursor_col <= self._scroll_offset and self._scroll_offset > 0:
             self._scroll_offset = max(0, cursor_col - jump)
         return self._scroll_offset
@@ -422,7 +405,25 @@ class LineEditor:
     def _save_undo(self) -> None:
         self._undo_stack.append((list(self._buf), self._cursor))
         if len(self._undo_stack) > 100:
-            self._undo_stack = self._undo_stack[-100:]
+            del self._undo_stack[:-100]
+
+    def _insert_at_cursor(self, text: str, check_limit: bool = True,
+                          filter_control: bool = False) -> int:
+        """Insert *text* graphemes at cursor, returning count inserted."""
+        count = 0
+        for grapheme in iter_graphemes(text):
+            if check_limit and self._at_limit():
+                break
+            if filter_control and _is_control(grapheme):
+                continue
+            self._buf.insert(self._cursor, grapheme)
+            self._cursor += 1
+            count += 1
+        return count
+
+    def _set_text(self, text: str) -> None:
+        self._buf = list(iter_graphemes(text))
+        self._cursor = len(self._buf)
 
     def _undo(self) -> LineEditResult:
         if not self._undo_stack:
@@ -553,16 +554,13 @@ class LineEditor:
         if not self._kill_ring:
             return LineEditResult()
         self._save_undo()
-        text = self._kill_ring[-1]
-        for grapheme in iter_graphemes(text):
-            self._buf.insert(self._cursor, grapheme)
-            self._cursor += 1
+        self._insert_at_cursor(self._kill_ring[-1], check_limit=False)
         return LineEditResult(changed=True)
 
     def _history_prev(self) -> LineEditResult:
-        if not self._in_history:
+        if not self._navigating_history:
             self._history.nav_start(self.line)
-            self._in_history = True
+            self._navigating_history = True
         entry = self._history.nav_up()
         if entry is not None:
             self._set_text(entry)
@@ -570,7 +568,7 @@ class LineEditor:
         return LineEditResult()
 
     def _history_next(self) -> LineEditResult:
-        if not self._in_history:
+        if not self._navigating_history:
             return LineEditResult()
         entry = self._history.nav_down()
         if entry is not None:
@@ -583,18 +581,9 @@ class LineEditor:
             suggestion = self._get_suggestion()
             if suggestion:
                 self._save_undo()
-                for grapheme in iter_graphemes(suggestion):
-                    self._buf.append(grapheme)
-                self._cursor = len(self._buf)
+                self._insert_at_cursor(suggestion, check_limit=False)
                 return LineEditResult(changed=True)
-        if self._cursor < len(self._buf):
-            self._cursor += 1
-            return LineEditResult(changed=True)
-        return LineEditResult()
-
-    def _set_text(self, text: str) -> None:
-        self._buf = list(iter_graphemes(text))
-        self._cursor = len(self._buf)
+        return self._move_right()
 
     def _get_suggestion(self) -> str:
         if self.password_mode:

--- a/blessed/line_editor.py
+++ b/blessed/line_editor.py
@@ -1,48 +1,21 @@
-"""
-Headless line editor with history, auto-suggest, and grapheme-aware editing.
+"""Headless line editor with history, auto-suggest, and grapheme-aware editing.
 
 This module provides :class:`LineEditor` for single-line input with readline-style
-editing, :class:`History` for command recall and file persistence, and
-:class:`LiveLineEditor` for rendering the editor at a fixed terminal position using
-an asyncio ``(reader, writer)`` pair or a :class:`~.Terminal` instance.
-
-Grapheme cluster boundaries are used for all cursor movement and display width
-calculations via :func:`wcwidth.iter_graphemes` and :func:`wcwidth.width`.
-
-Example usage with blessed Terminal::
-
-    import asyncio
-    from blessed import Terminal
-    from blessed.line_editor import LineEditor, History
-
-    async def main():
-        term = Terminal()
-        history = History()
-        editor = LineEditor(history=history)
-        with term.cbreak():
-            while True:
-                key = await term.async_inkey()
-                result = editor.feed_key(key)
-                if result.line is not None:
-                    print(f"\\nYou typed: {result.line}")
-                    break
-
-Example usage with asyncio reader/writer::
-
-    editor = LiveLineEditor(reader=stdin_reader, writer=stdout_writer,
-                            row=23, col=0, width=80, history=history)
-    line = await editor.readline()
+editing and :class:`LineHistory` for command recall and file persistence.
 """
 
+# std imports
 import os
+from typing import Dict, List, Tuple, Union, Callable, Optional
 from dataclasses import dataclass
-from typing import Callable, List, Optional, Union
 
+# 3rd party
 from wcwidth import iter_graphemes, width as wcswidth
 
 PASSWORD_CHAR = "\u25cf"
 
 __all__ = (
+    "DisplayState",
     "InputStyle",
     "LineEditResult",
     "LineHistory",
@@ -52,161 +25,69 @@ __all__ = (
 
 @dataclass
 class InputStyle:
-    """SGR styling for the input line, changeable at runtime.
+    """SGR styling for the input line, changeable at runtime."""
 
-    .. py:attribute:: text_sgr
-
-        SGR sequence applied to main input text.
-
-    .. py:attribute:: suggestion_sgr
-
-        SGR sequence applied to auto-suggest suffix.
-
-    .. py:attribute:: bg_sgr
-
-        SGR sequence for the whole input line background.
-
-    .. py:attribute:: ellipsis_sgr
-
-        SGR sequence applied to overflow ellipsis characters.
-
-    .. py:attribute:: cursor_seq
-
-        DECSCUSR sequence for cursor shape (e.g. ``"\\x1b[5 q"``).
-    """
-
+    #: SGR sequence applied to main input text.
     text_sgr: str = ""
+    #: SGR sequence applied to auto-suggest suffix.
     suggestion_sgr: str = ""
+    #: SGR sequence for the whole input line background.
     bg_sgr: str = ""
+    #: SGR sequence applied to overflow ellipsis characters.
     ellipsis_sgr: str = ""
+    #: DECSCUSR sequence for cursor shape (e.g. ``"\\x1b[5 q"``).
     cursor_seq: str = ""
 
 
 @dataclass
 class LineEditResult:
-    """Result of processing a keystroke.
+    """Result of processing a keystroke."""
 
-    .. py:attribute:: line
-
-        The accepted line text when Enter was pressed, otherwise ``None``.
-
-    .. py:attribute:: eof
-
-        ``True`` when Ctrl+D pressed on an empty line.
-
-    .. py:attribute:: interrupt
-
-        ``True`` when Ctrl+C pressed.
-
-    .. py:attribute:: changed
-
-        ``True`` when the display needs redrawing.
-
-    .. py:attribute:: bell
-
-        Bell string to emit (e.g. ``"\\a"``), empty when silent.
-    """
-
+    #: Accepted line text when Enter was pressed, otherwise ``None``.
     line: Optional[str] = None
+    #: ``True`` when Ctrl+D pressed on an empty line.
     eof: bool = False
+    #: ``True`` when Ctrl+C pressed.
     interrupt: bool = False
+    #: ``True`` when the display needs redrawing.
     changed: bool = False
+    #: Bell string to emit (e.g. ``"\\a"``), empty when silent.
     bell: str = ""
 
 
 @dataclass
 class DisplayState:
-    """Current visual state of the editor for rendering.
+    """Current visual state of the editor for rendering."""
 
-    When the :class:`LineEditor` has a ``max_width`` set, text and suggestion
-    are clipped to fit, ``cursor`` is adjusted for the visible window, and
-    ``clipped_left`` / ``clipped_right`` indicate overflow.
-
-    .. py:attribute:: text
-
-        Buffer text (masked with :data:`PASSWORD_CHAR` if password mode).
-        When ``max_width`` is active this is the visible slice only.
-
-    .. py:attribute:: cursor
-
-        0-indexed cursor position in display columns within the visible
-        window (already adjusted for horizontal scroll).
-
-    .. py:attribute:: suggestion
-
-        Auto-suggest suffix (to be rendered dim/grey after text).
-        Clipped to remaining space when ``max_width`` is active.
-
-    .. py:attribute:: clipped_left
-
-        ``True`` when content extends beyond the left edge of the visible
-        window (i.e. text has been scrolled right).
-
-    .. py:attribute:: clipped_right
-
-        ``True`` when content extends beyond the right edge of the visible
-        window.
-
-    .. py:attribute:: text_sgr
-
-        SGR sequence for main input text (copied from :class:`InputStyle`).
-
-    .. py:attribute:: suggestion_sgr
-
-        SGR sequence for auto-suggest suffix.
-
-    .. py:attribute:: bg_sgr
-
-        SGR sequence for the whole input line background.
-
-    .. py:attribute:: ellipsis_sgr
-
-        SGR sequence for overflow ellipsis characters.
-
-    .. py:attribute:: cursor_seq
-
-        DECSCUSR sequence for cursor shape.
-    """
-
+    #: Visible buffer text (masked in password mode, clipped when scrolling).
     text: str = ""
+    #: Cursor column within the visible window.
     cursor: int = 0
+    #: Auto-suggest suffix (rendered dim/grey after text).
     suggestion: str = ""
-    clipped_left: bool = False
-    clipped_right: bool = False
+    #: ``True`` when content extends beyond the left edge.
+    overflow_left: bool = False
+    #: ``True`` when content extends beyond the right edge.
+    overflow_right: bool = False
+    #: SGR sequence for main input text (from :class:`InputStyle`).
     text_sgr: str = ""
+    #: SGR sequence for auto-suggest suffix.
     suggestion_sgr: str = ""
+    #: SGR sequence for the whole input line background.
     bg_sgr: str = ""
+    #: SGR sequence for overflow ellipsis characters.
     ellipsis_sgr: str = ""
+    #: DECSCUSR sequence for cursor shape.
     cursor_seq: str = ""
 
 
-def _graphemes(text: str) -> List[str]:
-    """Split *text* into grapheme clusters."""
-    return list(iter_graphemes(text))
-
-
-def _display_width(text: str) -> int:
-    """Return the display column width of *text*, ignoring control codes."""
-    return wcswidth(text, control_codes="ignore")
-
-
-def _grapheme_width(grapheme: str) -> int:
-    """Return the display column width of a single grapheme cluster."""
-    w = wcswidth(grapheme, control_codes="ignore")
-    return max(0, w)
-
-
-def _is_displayable_grapheme(grapheme: str) -> bool:
-    """Return whether a grapheme cluster is displayable (not a C0/C1 control)."""
-    w = wcswidth(grapheme, control_codes="ignore")
-    if w > 0:
-        return True
-    return all(ch.isprintable() or ch == "\t" for ch in grapheme)
+def _is_control(grapheme: str) -> bool:
+    cp = ord(grapheme[0])
+    return cp < 0x20 or 0x7F <= cp < 0xA0
 
 
 class LineHistory:
-    """
-    In-memory command history with optional file persistence.
+    """In-memory command history with optional file persistence.
 
     :param max_entries: Maximum number of history entries retained.
     """
@@ -223,11 +104,7 @@ class LineHistory:
         return self._entries
 
     def add(self, line: str) -> None:
-        """
-        Append a line to history, skipping consecutive duplicates.
-
-        :param line: Line text to add.
-        """
+        """Append *line* to history, skipping empty and consecutive duplicates."""
         if not line:
             return
         if self._entries and self._entries[-1] == line:
@@ -237,12 +114,7 @@ class LineHistory:
             self._entries = self._entries[-self._max_entries:]
 
     def search_prefix(self, prefix: str) -> Optional[str]:
-        """
-        Find the most recent history entry matching *prefix*.
-
-        :param prefix: Prefix to match.
-        :returns: The matching entry, or ``None``.
-        """
+        """Return the most recent entry starting with *prefix*, or ``None``."""
         if not prefix:
             return None
         for entry in reversed(self._entries):
@@ -251,11 +123,7 @@ class LineHistory:
         return None
 
     def load_file(self, path: str) -> None:
-        """
-        Load history entries from a file (one per line).
-
-        :param path: Path to the history file.
-        """
+        """Load history entries from *path* (one per line)."""
         if not os.path.exists(path):
             return
         with open(path, "r", encoding="utf-8", errors="replace") as fh:
@@ -267,12 +135,7 @@ class LineHistory:
             self._entries = self._entries[-self._max_entries:]
 
     def save_entry(self, line: str, path: str) -> None:
-        """
-        Append a single entry to the history file.
-
-        :param line: Line text to save.
-        :param path: Path to the history file.
-        """
+        """Append *line* to the history file at *path*."""
         if not line:
             return
         os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
@@ -280,31 +143,19 @@ class LineHistory:
             fh.write(line + "\n")
 
     def nav_start(self, current_line: str) -> None:
-        """
-        Begin history navigation, saving the current line.
-
-        :param current_line: The current editor buffer to preserve.
-        """
+        """Begin history navigation, saving *current_line*."""
         self._nav_idx = len(self._entries)
         self._nav_saved = current_line
 
     def nav_up(self) -> Optional[str]:
-        """
-        Navigate to the previous (older) history entry.
-
-        :returns: The history entry text, or ``None`` if at the beginning.
-        """
+        """Navigate to the previous (older) history entry."""
         if self._nav_idx <= 0:
             return None
         self._nav_idx -= 1
         return self._entries[self._nav_idx]
 
     def nav_down(self) -> Optional[str]:
-        """
-        Navigate to the next (newer) history entry.
-
-        :returns: The history entry, the saved current line, or ``None``.
-        """
+        """Navigate to the next (newer) history entry."""
         if self._nav_idx >= len(self._entries):
             return None
         self._nav_idx += 1
@@ -313,56 +164,34 @@ class LineHistory:
         return self._entries[self._nav_idx]
 
 
-#: Alias for backward compatibility.
-History = LineHistory
-
-
 class LineEditor:
-    """
-    Headless single-line editor with grapheme-aware cursor movement.
+    """Headless single-line editor with grapheme-aware cursor movement.
 
     Feed keystrokes via :meth:`feed_key`, read display state via
-    :attr:`display`.  The editor stores its buffer as a list of grapheme
-    clusters, ensuring that cursor movement never splits a grapheme.
-
-    Accepts blessed :class:`~.Keystroke` objects directly (dispatching on
-    ``.name``), or plain strings for testing and non-blessed usage.
-
-    :param history: Optional :class:`History` for up/down and auto-suggest.
-    :param is_password: Optional callable returning ``True`` in password mode.
-    :param max_width: When set, :attr:`display` clips text to this many
-        columns with horizontal scrolling.  ``0`` means unlimited.
-    :param ellipsis: Character shown at clipped edges (default ``\u2026``).
-    :param limit: Maximum grapheme clusters allowed; ``0`` means unlimited.
-    :param limit_bell: String emitted once when the limit is reached
-        (default ``"\\a"``).  Set to ``""`` to silence.
-    :param scroll_trigger_pct: Fraction of *max_width* used as the scroll
-        trigger zone near each edge (default ``0.10``).
-    :param scroll_factor: How many trigger-zone widths to scroll at once
-        (default ``2.0``).
-    :param style: Optional :class:`InputStyle` for runtime-changeable SGR
-        styling.  Fields are copied into :class:`DisplayState` on each
-        :attr:`display` access.
+    :attr:`display`.  Accepts blessed :class:`~.Keystroke` objects
+    directly (dispatching on ``.name``), or plain strings for testing.
     """
 
     def __init__(
         self,
-        history: Optional[History] = None,
+        history: Optional[LineHistory] = None,
         is_password: Optional[Callable[[], bool]] = None,
+        password_char: str = PASSWORD_CHAR,
         max_width: int = 0,
         ellipsis: str = "\u2026",
         limit: int = 65536,
         limit_bell: str = "\a",
-        scroll_trigger_pct: float = 0.10,
-        scroll_factor: float = 2.0,
+        scroll_jump: float = 0.5,
         style: Optional[InputStyle] = None,
+        keymap: Optional[Dict[str, Callable]] = None,
     ) -> None:
-        self._buf: List[str] = []  # list of grapheme clusters
-        self._cursor: int = 0      # index into _buf (grapheme position)
-        self._history: History = history or History()
+        self._buf: List[str] = []
+        self._cursor: int = 0
+        self._history = history or LineHistory()
         self._is_password: Optional[Callable[[], bool]] = is_password
+        self.password_char: str = password_char
         self._kill_ring: List[str] = []
-        self._undo_stack: List[tuple[List[str], int]] = []
+        self._undo_stack: List[Tuple[List[str], int]] = []
         self._in_history: bool = False
         self._password_mode: bool = False
         self.max_width: int = max_width
@@ -370,13 +199,16 @@ class LineEditor:
         self.limit: int = limit
         self.limit_bell: str = limit_bell
         self._limit_bell_fired: bool = False
-        self.scroll_trigger_pct: float = scroll_trigger_pct
-        self.scroll_factor: float = scroll_factor
+        self.scroll_jump: float = scroll_jump
+        self._scroll_offset: int = 0
         self.style: InputStyle = style if style is not None else InputStyle()
+        self._keymap: Dict[str, Callable] = dict(_KEY_DISPATCH)
+        if keymap:
+            self._keymap.update(keymap)
 
     @property
-    def history(self) -> History:
-        """Return the attached :class:`History` instance."""
+    def history(self) -> LineHistory:
+        """Return the attached :class:`LineHistory` instance."""
         return self._history
 
     @property
@@ -391,108 +223,67 @@ class LineEditor:
             return self._is_password()
         return self._password_mode
 
-    def _copy_style(self, ds: DisplayState) -> DisplayState:
-        """Copy :attr:`style` fields into a :class:`DisplayState`."""
-        ds.text_sgr = self.style.text_sgr
-        ds.suggestion_sgr = self.style.suggestion_sgr
-        ds.bg_sgr = self.style.bg_sgr
-        ds.ellipsis_sgr = self.style.ellipsis_sgr
-        ds.cursor_seq = self.style.cursor_seq
-        return ds
-
-    def _needs_hscroll(self) -> bool:
-        """Return whether horizontal scrolling is needed.
-
-        When the limit is set and fits within ``max_width``, the text can
-        never exceed the window — no scrolling needed.
-        """
-        if self.max_width <= 0:
-            return False
-        if self.limit > 0 and self.limit <= self.max_width:
-            return False
-        return True
-
     @property
     def display(self) -> DisplayState:
-        """Return the current :class:`DisplayState` for rendering.
-
-        When :attr:`max_width` is set (> 0), the returned state has text
-        and suggestion clipped to fit, with ``clipped_left`` and
-        ``clipped_right`` indicating overflow.  The ``cursor`` value is
-        relative to the visible window.
-        """
+        """Return the current :class:`DisplayState` for rendering."""
         line = self.line
         cursor_col = self._cursor_display_col()
+        sf = self._style_fields()
         if self.password_mode:
-            pw_text = PASSWORD_CHAR * len(self._buf)
+            pw_text = self.password_char * len(self._buf)
             if self._needs_hscroll():
-                return self._copy_style(_apply_hscroll(
+                cw = wcswidth(pw_text)
+                offset = self._compute_scroll(cursor_col, cw)
+                ds = _apply_hscroll(
                     pw_text, "", cursor_col, self.max_width, self.ellipsis,
-                    self.scroll_trigger_pct, self.scroll_factor,
-                ))
-            return self._copy_style(
-                DisplayState(text=pw_text, cursor=cursor_col)
-            )
+                    scroll_offset=offset)
+                return DisplayState(**{**vars(ds), **sf})
+            return DisplayState(text=pw_text, cursor=cursor_col, **sf)
         suggestion = self._get_suggestion()
         if self._needs_hscroll():
-            return self._copy_style(_apply_hscroll(
+            text_w = wcswidth(line)
+            suggest_w = wcswidth(suggestion)
+            offset = self._compute_scroll(cursor_col, text_w + suggest_w)
+            ds = _apply_hscroll(
                 line, suggestion, cursor_col, self.max_width, self.ellipsis,
-                self.scroll_trigger_pct, self.scroll_factor,
-            ))
-        return self._copy_style(
-            DisplayState(text=line, cursor=cursor_col, suggestion=suggestion)
-        )
+                scroll_offset=offset)
+            return DisplayState(**{**vars(ds), **sf})
+        return DisplayState(
+            text=line, cursor=cursor_col, suggestion=suggestion, **sf)
 
-    def feed_key(self, key: Union["Keystroke", str]) -> LineEditResult:
-        """
-        Process one keystroke event.
-
-        Accepts a blessed :class:`~.Keystroke` (dispatching on its ``.name``
-        attribute) or a plain string for testing.
-
-        :param key: A :class:`~.Keystroke` or a string.
-        :returns: :class:`LineEditResult` describing what happened.
-        """
+    def feed_key(self, key: Union["Keystroke", str]) -> LineEditResult:  # noqa: F821
+        """Process one keystroke and return a :class:`LineEditResult`."""
         name = getattr(key, "name", None)
         if name:
-            handler = _KEY_DISPATCH.get(name)
+            handler = self._keymap.get(name)
             if handler is not None:
                 return handler(self)
-
+            return LineEditResult()
         key_str = str(key)
-        if key_str and _is_displayable_grapheme(key_str):
+        if key_str and key_str.isprintable():
             if self._at_limit():
                 return LineEditResult(
-                    changed=False, bell=self._fire_limit_bell(),
-                )
+                    changed=False, bell=self._fire_limit_bell())
             self._save_undo()
-            for grapheme in _graphemes(key_str):
+            for grapheme in iter_graphemes(key_str):
                 if self._at_limit():
                     break
                 self._buf.insert(self._cursor, grapheme)
                 self._cursor += 1
             self._in_history = False
             return LineEditResult(changed=True)
-
         return LineEditResult()
 
     def insert_text(self, text: str) -> LineEditResult:
-        """
-        Insert text at cursor position (for bracketed paste).
-
-        :param text: Text to insert.
-        :returns: :class:`LineEditResult` with ``changed=True``, or
-            ``changed=False`` with a bell if the limit blocks insertion.
-        """
+        """Insert *text* at cursor position (for bracketed paste)."""
         if self._at_limit():
             return LineEditResult(
-                changed=False, bell=self._fire_limit_bell(),
-            )
+                changed=False, bell=self._fire_limit_bell())
         self._save_undo()
-        for grapheme in _graphemes(text):
+        for grapheme in iter_graphemes(text):
             if self._at_limit():
                 break
-            if _is_displayable_grapheme(grapheme):
+            if not _is_control(grapheme):
                 self._buf.insert(self._cursor, grapheme)
                 self._cursor += 1
         return LineEditResult(changed=True)
@@ -501,35 +292,56 @@ class LineEditor:
         """Clear the buffer and reset cursor to start."""
         self._buf.clear()
         self._cursor = 0
+        self._scroll_offset = 0
         self._in_history = False
 
     def set_password_mode(self, enabled: bool) -> None:
-        """
-        Set password mode directly (used when no ``is_password`` callable).
-
-        :param enabled: Whether to mask input display.
-        """
+        """Set password mode directly (used when no *is_password* callable)."""
         self._password_mode = enabled
 
+    def _style_fields(self) -> dict:
+        s = self.style
+        return dict(text_sgr=s.text_sgr, suggestion_sgr=s.suggestion_sgr,
+                    bg_sgr=s.bg_sgr, ellipsis_sgr=s.ellipsis_sgr,
+                    cursor_seq=s.cursor_seq)
+
+    def _needs_hscroll(self) -> bool:
+        if self.max_width <= 0:
+            return False
+        if self.limit > 0 and self.limit <= self.max_width:
+            return False
+        return True
+
+    def _compute_scroll(self, cursor_col: int, content_width: int) -> int:
+        usable = self.max_width
+        if content_width < usable and cursor_col < usable:
+            self._scroll_offset = 0
+            return 0
+        jump = max(1, int(usable * self.scroll_jump))
+        ecw = wcswidth(self.ellipsis)
+        left_cost = ecw if self._scroll_offset > 0 else 0
+        right_edge = self._scroll_offset + usable - left_cost
+        if cursor_col >= right_edge:
+            self._scroll_offset = cursor_col - usable + jump + 1 + ecw
+        elif cursor_col <= self._scroll_offset and self._scroll_offset > 0:
+            self._scroll_offset = max(0, cursor_col - jump)
+        return self._scroll_offset
+
     def _at_limit(self) -> bool:
-        """Return ``True`` when the buffer is at or above the input limit."""
         return self.limit > 0 and len(self._buf) >= self.limit
 
     def _fire_limit_bell(self) -> str:
-        """Return the bell string if limit just reached, else empty."""
         if not self._limit_bell_fired:
             self._limit_bell_fired = True
             return self.limit_bell
         return ""
 
     def _maybe_reset_limit_bell(self) -> None:
-        """Reset the bell-fired flag if buffer has shrunk below limit."""
         if self._limit_bell_fired and not self._at_limit():
             self._limit_bell_fired = False
 
     def _cursor_display_col(self) -> int:
-        """Return the display column of the cursor (sum of widths before it)."""
-        return sum(_grapheme_width(g) for g in self._buf[:self._cursor])
+        return sum(wcswidth(g) for g in self._buf[:self._cursor])
 
     def _save_undo(self) -> None:
         self._undo_stack.append((list(self._buf), self._cursor))
@@ -586,15 +398,18 @@ class LineEditor:
             return LineEditResult(changed=True)
         return LineEditResult()
 
-    def _move_word_left(self) -> LineEditResult:
-        if self._cursor == 0:
-            return LineEditResult()
+    def _find_word_left(self) -> int:
         pos = self._cursor - 1
         while pos > 0 and not self._buf[pos - 1].isalnum():
             pos -= 1
         while pos > 0 and self._buf[pos - 1].isalnum():
             pos -= 1
-        self._cursor = pos
+        return pos
+
+    def _move_word_left(self) -> LineEditResult:
+        if self._cursor == 0:
+            return LineEditResult()
+        self._cursor = self._find_word_left()
         return LineEditResult(changed=True)
 
     def _move_word_right(self) -> LineEditResult:
@@ -652,11 +467,7 @@ class LineEditor:
             return LineEditResult()
         self._save_undo()
         end = self._cursor
-        pos = self._cursor - 1
-        while pos > 0 and not self._buf[pos - 1].isalnum():
-            pos -= 1
-        while pos > 0 and self._buf[pos - 1].isalnum():
-            pos -= 1
+        pos = self._find_word_left()
         killed = "".join(self._buf[pos:end])
         del self._buf[pos:end]
         self._cursor = pos
@@ -669,7 +480,7 @@ class LineEditor:
             return LineEditResult()
         self._save_undo()
         text = self._kill_ring[-1]
-        for grapheme in _graphemes(text):
+        for grapheme in iter_graphemes(text):
             self._buf.insert(self._cursor, grapheme)
             self._cursor += 1
         return LineEditResult(changed=True)
@@ -694,12 +505,11 @@ class LineEditor:
         return LineEditResult()
 
     def _accept_suggestion(self) -> LineEditResult:
-        """Accept auto-suggest when cursor is at end, otherwise move right."""
         if self._cursor == len(self._buf):
             suggestion = self._get_suggestion()
             if suggestion:
                 self._save_undo()
-                for grapheme in _graphemes(suggestion):
+                for grapheme in iter_graphemes(suggestion):
                     self._buf.append(grapheme)
                 self._cursor = len(self._buf)
                 return LineEditResult(changed=True)
@@ -709,7 +519,7 @@ class LineEditor:
         return LineEditResult()
 
     def _set_text(self, text: str) -> None:
-        self._buf = _graphemes(text)
+        self._buf = list(iter_graphemes(text))
         self._cursor = len(self._buf)
 
     def _get_suggestion(self) -> str:
@@ -730,55 +540,35 @@ def _apply_hscroll(
     cursor_col: int,
     max_width: int,
     ellipsis: str = "\u2026",
-    scroll_trigger_pct: float = 0.10,
-    scroll_factor: float = 2.0,
+    scroll_jump: float = 0.5,
+    scroll_offset: Optional[int] = None,
 ) -> DisplayState:
-    """
-    Clip *text* and *suggestion* to *max_width* with horizontal scrolling.
-
-    The cursor is kept visible within the window.  An ellipsis character is
-    shown at the clipped edge(s).
-
-    :param text: Full buffer text.
-    :param suggestion: Auto-suggest suffix.
-    :param cursor_col: Cursor position in display columns (full text).
-    :param max_width: Available display columns.
-    :param ellipsis: Overflow indicator character.
-    :param scroll_trigger_pct: Fraction of *max_width* for the trigger zone.
-    :param scroll_factor: Multiplier on trigger zone for scroll amount.
-    :returns: A :class:`DisplayState` with clipped text and adjusted cursor.
-    """
-    ellipsis_w = _grapheme_width(ellipsis) if ellipsis else 0
-    text_w = _display_width(text)
-    suggest_w = _display_width(suggestion) if suggestion else 0
+    ellipsis_w = wcswidth(ellipsis)
+    text_w = wcswidth(text)
+    suggest_w = wcswidth(suggestion)
     total_w = text_w + suggest_w
 
-    if total_w <= max_width:
+    if total_w < max_width and cursor_col < max_width:
         return DisplayState(
-            text=text, cursor=cursor_col, suggestion=suggestion,
-        )
+            text=text, cursor=cursor_col, suggestion=suggestion)
 
-    trigger_cols = max(1, int(max_width * scroll_trigger_pct))
-    scroll_amount = max(1, int(trigger_cols * scroll_factor))
     usable = max_width
+    if scroll_offset is None:
+        jump = max(1, int(usable * scroll_jump))
+        scroll_offset = 0
+        if cursor_col >= usable:
+            scroll_offset = cursor_col - usable + jump + 1
 
-    scroll_offset = 0
-    if cursor_col >= usable - trigger_cols:
-        scroll_offset = cursor_col - usable + scroll_amount + 1
-
-    # Adjust for left ellipsis taking up space.
-    clipped_left = scroll_offset > 0
-    if clipped_left:
+    overflow_left = scroll_offset > 0
+    if overflow_left:
         usable -= ellipsis_w
 
-    # Slice graphemes from the combined text+suggestion.
     combined = text + suggestion
     vis_parts: List[str] = []
     vis_width = 0
     col = 0
-
     for grapheme in iter_graphemes(combined):
-        g_w = _grapheme_width(grapheme)
+        g_w = wcswidth(grapheme)
         if col + g_w <= scroll_offset:
             col += g_w
             continue
@@ -788,19 +578,17 @@ def _apply_hscroll(
         vis_width += g_w
         col += g_w
 
-    clipped_right = (scroll_offset + usable) < total_w
-    if clipped_right:
-        # Make room for right ellipsis by removing last grapheme(s).
+    overflow_right = (scroll_offset + usable) < total_w
+    if overflow_right:
         while vis_parts and vis_width + ellipsis_w > usable:
             removed = vis_parts.pop()
-            vis_width -= _grapheme_width(removed)
+            vis_width -= wcswidth(removed)
 
-    # Split visible parts back into text and suggestion portions.
     vis_text_parts: List[str] = []
     vis_suggest_parts: List[str] = []
     pos = 0
     for grapheme in vis_parts:
-        g_w = _grapheme_width(grapheme)
+        g_w = wcswidth(grapheme)
         src_col = scroll_offset + pos
         if src_col < text_w:
             vis_text_parts.append(grapheme)
@@ -809,31 +597,30 @@ def _apply_hscroll(
         pos += g_w
 
     vis_cursor = cursor_col - scroll_offset
-    if clipped_left:
+    if overflow_left:
         vis_cursor += ellipsis_w
 
     return DisplayState(
         text="".join(vis_text_parts),
         cursor=vis_cursor,
         suggestion="".join(vis_suggest_parts),
-        clipped_left=clipped_left,
-        clipped_right=clipped_right,
+        overflow_left=overflow_left,
+        overflow_right=overflow_right,
     )
 
 
-# Dispatch table keyed by blessed Keystroke.name values.
-_KEY_DISPATCH = {
+_KEY_DISPATCH: Dict[str, Callable] = {
     "KEY_ENTER": LineEditor._handle_enter,
     "KEY_CTRL_C": LineEditor._handle_ctrl_c,
     "KEY_CTRL_D": LineEditor._handle_ctrl_d,
     "KEY_LEFT": LineEditor._move_left,
-    "KEY_CTRL_B": LineEditor._move_left,
     "KEY_RIGHT": LineEditor._accept_suggestion,
-    "KEY_CTRL_F": LineEditor._move_right,
     "KEY_HOME": LineEditor._move_home,
-    "KEY_CTRL_A": LineEditor._move_home,
     "KEY_END": LineEditor._move_end,
+    "KEY_CTRL_A": LineEditor._move_home,
+    "KEY_CTRL_B": LineEditor._move_left,
     "KEY_CTRL_E": LineEditor._move_end,
+    "KEY_CTRL_F": LineEditor._move_right,
     "KEY_SLEFT": LineEditor._move_word_left,
     "KEY_SRIGHT": LineEditor._move_word_right,
     "KEY_CTRL_LEFT": LineEditor._move_word_left,
@@ -845,144 +632,8 @@ _KEY_DISPATCH = {
     "KEY_CTRL_W": LineEditor._kill_word_back,
     "KEY_CTRL_Y": LineEditor._yank,
     "KEY_UP": LineEditor._history_prev,
-    "KEY_CTRL_P": LineEditor._history_prev,
     "KEY_DOWN": LineEditor._history_next,
     "KEY_CTRL_N": LineEditor._history_next,
+    "KEY_CTRL_P": LineEditor._history_prev,
     "KEY_CTRL_Z": LineEditor._undo,
 }
-
-
-# incomplete
-#
-#class LiveLineEditor:
-#    """
-#    Line editor with async rendering to a terminal region.
-#
-#    Renders the editor at a fixed ``(row, col)`` position using an asyncio
-#    writer for output and :meth:`~.Terminal.async_inkey` for input.  If *row*
-#    and *col* are not specified, renders at the current cursor position.
-#
-#    :param terminal: A :class:`~.Terminal` instance for keystroke reading.
-#    :param writer: An :class:`asyncio.StreamWriter` for terminal output.
-#        If ``None``, output is written to *terminal*'s stream.
-#    :param row: 0-indexed row for the input line (``None`` = current position).
-#    :param col: 0-indexed column for the input line (default ``0``).
-#    :param width: Maximum display width (default: terminal width minus *col*).
-#    :param history: :class:`History` instance for command recall.
-#    :param is_password: Callable returning ``True`` when in password mode.
-#    :param prompt: Prompt string displayed before the input area.
-#    :param suggestion_style: SGR escape for auto-suggest text (default: dim).
-#    """
-#
-#    def __init__(
-#        self,
-#        terminal: "Any",
-#        writer: "Any" = None,
-#        row: Optional[int] = None,
-#        col: int = 0,
-#        width: Optional[int] = None,
-#        history: Optional[History] = None,
-#        is_password: Optional[Callable[[], bool]] = None,
-#        prompt: str = "",
-#        suggestion_style: str = "\x1b[2m",
-#    ) -> None:
-#        self._term = terminal
-#        self._writer = writer
-#        self._row = row
-#        self._col = col
-#        self._width = width
-#        self._prompt = prompt
-#        self._suggestion_style = suggestion_style
-#        self._editor = LineEditor(history=history, is_password=is_password)
-#
-#    @property
-#    def editor(self) -> LineEditor:
-#        """Return the underlying :class:`LineEditor`."""
-#        return self._editor
-#
-#    def _write(self, data: bytes) -> None:
-#        """Write bytes to the output stream."""
-#        if self._writer is not None:
-#            self._writer.write(data)
-#        else:
-#            self._term.stream.write(data.decode("utf-8", errors="replace"))
-#            self._term.stream.flush()
-#
-#    def render(self) -> None:
-#        """Render the current editor state to the terminal."""
-#        state = self._editor.display
-#        prompt_width = _display_width(self._prompt) if self._prompt else 0
-#        term_width = getattr(self._term, "width", 80)
-#        width = self._width if self._width is not None else (term_width - self._col)
-#
-#        parts: List[bytes] = []
-#
-#        if self._row is not None:
-#            parts.append(f"\x1b[{self._row + 1};{self._col + 1}H".encode())
-#
-#        parts.append(b"\x1b[K")
-#
-#        if self._prompt:
-#            parts.append(self._prompt.encode("utf-8", errors="replace"))
-#
-#        available = width - prompt_width
-#        text = state.text
-#        text_width = _display_width(text)
-#        if text_width <= available:
-#            parts.append(text.encode("utf-8", errors="replace"))
-#            if state.suggestion:
-#                remaining = available - text_width
-#                suggestion = state.suggestion
-#                if _display_width(suggestion) > remaining:
-#                    suggestion = _truncate_to_width(suggestion, remaining)
-#                parts.append(self._suggestion_style.encode())
-#                parts.append(suggestion.encode("utf-8", errors="replace"))
-#                parts.append(b"\x1b[0m")
-#        else:
-#            parts.append(_truncate_to_width(text, available).encode(
-#                "utf-8", errors="replace"))
-#
-#        cursor_col = self._col + prompt_width + state.cursor
-#        if self._row is not None:
-#            parts.append(f"\x1b[{self._row + 1};{cursor_col + 1}H".encode())
-#
-#        self._write(b"".join(parts))
-#
-#    async def readline(self) -> Optional[str]:
-#        """
-#        Read a complete line of input asynchronously.
-#
-#        Reads keystrokes via :meth:`~.Terminal.async_inkey`, feeds them
-#        directly to the underlying :class:`LineEditor`, and renders after
-#        each change.
-#
-#        :returns: The accepted line, or ``None`` on EOF (Ctrl+D).
-#        :raises KeyboardInterrupt: On Ctrl+C.
-#        """
-#        self.render()
-#        while True:
-#            key = await self._term.async_inkey()
-#            result = self._editor.feed_key(key)
-#
-#            if result.eof:
-#                return None
-#            if result.interrupt:
-#                self.render()
-#                raise KeyboardInterrupt
-#            if result.line is not None:
-#                return result.line
-#            if result.changed:
-#                self.render()
-#
-#
-#def _truncate_to_width(text: str, max_width: int) -> str:
-#    """Truncate *text* to fit within *max_width* display columns."""
-#    result: List[str] = []
-#    used = 0
-#    for grapheme in iter_graphemes(text):
-#        w = _grapheme_width(grapheme)
-#        if used + w > max_width:
-#            break
-#        result.append(grapheme)
-#        used += w
-#    return "".join(result)

--- a/blessed/line_editor.py
+++ b/blessed/line_editor.py
@@ -215,14 +215,15 @@ class LineEditor:
         cursor_col = self._cursor_display_col()
         if self.password_mode:
             pw_text = self.password_char * len(self._buf)
+            pw_cursor = self._cursor * wcswidth(self.password_char)
             if self._needs_hscroll():
                 cw = wcswidth(pw_text)
-                offset = self._compute_scroll(cursor_col, cw)
+                offset = self._compute_scroll(pw_cursor, cw)
                 return self._apply_sgr(_apply_hscroll(
-                    pw_text, "", cursor_col, self.max_width, self.ellipsis,
+                    pw_text, "", pw_cursor, self.max_width, self.ellipsis,
                     scroll_offset=offset))
             return self._apply_sgr(
-                DisplayState(text=pw_text, cursor=cursor_col))
+                DisplayState(text=pw_text, cursor=pw_cursor))
         suggestion = self._get_suggestion()
         if self._needs_hscroll():
             text_w = wcswidth(line)
@@ -356,6 +357,7 @@ class LineEditor:
         if self._at_limit():
             return LineEditResult(
                 changed=False, bell=self._fire_limit_bell())
+        old_len = len(self._buf)
         self._save_undo()
         for grapheme in iter_graphemes(text):
             if self._at_limit():
@@ -363,6 +365,9 @@ class LineEditor:
             if not _is_control(grapheme):
                 self._buf.insert(self._cursor, grapheme)
                 self._cursor += 1
+        if len(self._buf) == old_len:
+            self._undo_stack.pop()
+            return LineEditResult(changed=False)
         return LineEditResult(changed=True)
 
     def clear(self) -> None:
@@ -441,9 +446,7 @@ class LineEditor:
     def _handle_ctrl_d(self) -> LineEditResult:
         if not self._buf:
             return LineEditResult(eof=True)
-        self._save_undo()
-        self._delete_at_cursor()
-        return LineEditResult(changed=True)
+        return self._delete_at_cursor()
 
     def _move_left(self) -> LineEditResult:
         if self._cursor > 0:

--- a/blessed/line_editor.py
+++ b/blessed/line_editor.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Dict, List, Deque, Tuple, Union, Callable, Opt
 from collections import deque
 from dataclasses import dataclass
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .terminal import Terminal
 
 # 3rd party
@@ -606,35 +606,17 @@ class LineEditor:  # pylint: disable=too-many-instance-attributes
         return ""
 
 
-def _apply_hscroll(  # pylint: disable=too-many-locals,too-many-branches,too-many-positional-arguments,too-complex
-    text: str,
-    suggestion: str,
-    cursor_col: int,
-    max_width: int,
-    ellipsis: str = "\u2026",
-    scroll_offset: Optional[int] = None,
-) -> DisplayState:
-    ellipsis_w = wcswidth(ellipsis)
-    text_w = wcswidth(text)
-    suggest_w = wcswidth(suggestion)
-    total_w = text_w + suggest_w
+def _clip_graphemes(
+    combined: str, scroll_offset: int, usable: int
+) -> Tuple[List[str], int]:
+    """
+    Collect visible graphemes from *combined* within a scroll window.
 
-    if total_w < max_width and cursor_col < max_width:
-        return DisplayState(
-            text=text, cursor=cursor_col, suggestion=suggestion)
-
-    usable = max_width
-    if scroll_offset is None:
-        scroll_offset = 0
-        if cursor_col >= usable:
-            jump = max(1, usable // 2)
-            scroll_offset = cursor_col - usable + jump + 1
-
-    overflow_left = scroll_offset > 0
-    if overflow_left:
-        usable -= ellipsis_w
-
-    combined = text + suggestion
+    :param combined: Full text (buffer + suggestion).
+    :param scroll_offset: Column offset of the left edge.
+    :param usable: Available display columns.
+    :returns: ``(visible_parts, visible_width)`` tuple.
+    """
     vis_parts: List[str] = []
     vis_width = 0
     col = 0
@@ -648,33 +630,100 @@ def _apply_hscroll(  # pylint: disable=too-many-locals,too-many-branches,too-man
         vis_parts.append(grapheme)
         vis_width += g_w
         col += g_w
+    return vis_parts, vis_width
 
-    overflow_right = (scroll_offset + usable) < total_w
-    if overflow_right:
-        while vis_parts and vis_width + ellipsis_w > usable:
-            removed = vis_parts.pop()
-            vis_width -= wcswidth(removed)
 
+def _split_text_suggestion(
+    vis_parts: List[str], scroll_offset: int, text_w: int
+) -> Tuple[str, str]:
+    """
+    Split visible graphemes into text and suggestion portions.
+
+    :param vis_parts: Graphemes within the visible window.
+    :param scroll_offset: Column offset of the left edge.
+    :param text_w: Display width of the buffer text (before suggestion).
+    :returns: ``(visible_text, visible_suggestion)`` tuple.
+    """
     vis_text_parts: List[str] = []
     vis_suggest_parts: List[str] = []
     pos = 0
     for grapheme in vis_parts:
         g_w = wcswidth(grapheme)
-        src_col = scroll_offset + pos
-        if src_col < text_w:
+        if scroll_offset + pos < text_w:
             vis_text_parts.append(grapheme)
         else:
             vis_suggest_parts.append(grapheme)
         pos += g_w
+    return "".join(vis_text_parts), "".join(vis_suggest_parts)
 
-    vis_cursor = cursor_col - scroll_offset
-    if overflow_left:
-        vis_cursor += ellipsis_w
+
+def _default_scroll_offset(cursor_col: int, max_width: int) -> int:
+    """
+    Compute an initial scroll offset when none is provided.
+
+    :param cursor_col: Cursor display column.
+    :param max_width: Available display columns.
+    :returns: Scroll offset in columns.
+    """
+    if cursor_col >= max_width:
+        jump = max(1, max_width // 2)
+        return cursor_col - max_width + jump + 1
+    return 0
+
+
+def _trim_right_overflow(
+    vis_parts: List[str], vis_width: int, ellipsis_w: int, usable: int
+) -> int:
+    """
+    Remove trailing graphemes to make room for a right-side ellipsis.
+
+    :param vis_parts: Visible grapheme list (mutated in place).
+    :param vis_width: Current total display width of *vis_parts*.
+    :param ellipsis_w: Display width of the ellipsis character.
+    :param usable: Available display columns.
+    :returns: Updated visible width after trimming.
+    """
+    while vis_parts and vis_width + ellipsis_w > usable:
+        vis_width -= wcswidth(vis_parts.pop())
+    return vis_width
+
+
+def _apply_hscroll(  # pylint: disable=too-many-positional-arguments
+    text: str,
+    suggestion: str,
+    cursor_col: int,
+    max_width: int,
+    ellipsis: str = "\u2026",
+    scroll_offset: Optional[int] = None,
+) -> DisplayState:
+    """Build a :class:`DisplayState` with horizontal scrolling applied."""
+    text_w = wcswidth(text)
+
+    if text_w + wcswidth(suggestion) < max_width and cursor_col < max_width:
+        return DisplayState(
+            text=text, cursor=cursor_col, suggestion=suggestion)
+
+    if scroll_offset is None:
+        scroll_offset = _default_scroll_offset(cursor_col, max_width)
+
+    overflow_left = scroll_offset > 0
+    ellipsis_w = wcswidth(ellipsis)
+    usable = max_width - (ellipsis_w if overflow_left else 0)
+
+    vis_parts, vis_width = _clip_graphemes(
+        text + suggestion, scroll_offset, usable)
+
+    overflow_right = (scroll_offset + usable) < text_w + wcswidth(suggestion)
+    if overflow_right:
+        _trim_right_overflow(vis_parts, vis_width, ellipsis_w, usable)
+
+    vis_text, vis_suggestion = _split_text_suggestion(
+        vis_parts, scroll_offset, text_w)
 
     return DisplayState(
-        text="".join(vis_text_parts),
-        cursor=vis_cursor,
-        suggestion="".join(vis_suggest_parts),
+        text=vis_text,
+        cursor=cursor_col - scroll_offset + (ellipsis_w if overflow_left else 0),
+        suggestion=vis_suggestion,
         overflow_left=overflow_left,
         overflow_right=overflow_right,
     )

--- a/blessed/line_editor.py
+++ b/blessed/line_editor.py
@@ -3,40 +3,27 @@
 This module provides :class:`LineEditor` for single-line input with readline-style
 editing and :class:`LineHistory` for command recall and file persistence.
 """
+from __future__ import annotations
 
 # std imports
-import os
-from typing import Dict, List, Tuple, Union, Callable, Optional
+from typing import TYPE_CHECKING, Dict, List, Tuple, Union, Callable, Optional
 from dataclasses import dataclass
+
+if TYPE_CHECKING:
+    from .terminal import Terminal
 
 # 3rd party
 from wcwidth import iter_graphemes, width as wcswidth
 
-PASSWORD_CHAR = "\u25cf"
+PASSWORD_CHAR = "\u273b"
 
 __all__ = (
+    "DEFAULT_KEYMAP",
     "DisplayState",
-    "InputStyle",
     "LineEditResult",
     "LineHistory",
     "LineEditor",
 )
-
-
-@dataclass
-class InputStyle:
-    """SGR styling for the input line, changeable at runtime."""
-
-    #: SGR sequence applied to main input text.
-    text_sgr: str = ""
-    #: SGR sequence applied to auto-suggest suffix.
-    suggestion_sgr: str = ""
-    #: SGR sequence for the whole input line background.
-    bg_sgr: str = ""
-    #: SGR sequence applied to overflow ellipsis characters.
-    ellipsis_sgr: str = ""
-    #: DECSCUSR sequence for cursor shape (e.g. ``"\\x1b[5 q"``).
-    cursor_seq: str = ""
 
 
 @dataclass
@@ -69,16 +56,14 @@ class DisplayState:
     overflow_left: bool = False
     #: ``True`` when content extends beyond the right edge.
     overflow_right: bool = False
-    #: SGR sequence for main input text (from :class:`InputStyle`).
+    #: SGR sequence applied to buffer text.
     text_sgr: str = ""
-    #: SGR sequence for auto-suggest suffix.
+    #: SGR sequence applied to suggestion text.
     suggestion_sgr: str = ""
-    #: SGR sequence for the whole input line background.
+    #: SGR sequence applied to fill the background.
     bg_sgr: str = ""
-    #: SGR sequence for overflow ellipsis characters.
+    #: SGR sequence applied to the ellipsis indicator.
     ellipsis_sgr: str = ""
-    #: DECSCUSR sequence for cursor shape.
-    cursor_seq: str = ""
 
 
 def _is_control(grapheme: str) -> bool:
@@ -93,58 +78,34 @@ class LineHistory:
     """
 
     def __init__(self, max_entries: int = 5000) -> None:
-        self._entries: List[str] = []
+        #: History entries list (most recent last).
+        self.entries: List[str] = []
         self._max_entries = max_entries
         self._nav_idx: int = -1
         self._nav_saved: str = ""
-
-    @property
-    def entries(self) -> List[str]:
-        """Return the history entries list (most recent last)."""
-        return self._entries
 
     def add(self, line: str) -> None:
         """Append *line* to history, skipping empty and consecutive duplicates."""
         if not line:
             return
-        if self._entries and self._entries[-1] == line:
+        if self.entries and self.entries[-1] == line:
             return
-        self._entries.append(line)
-        if len(self._entries) > self._max_entries:
-            self._entries = self._entries[-self._max_entries:]
+        self.entries.append(line)
+        if len(self.entries) > self._max_entries:
+            self.entries = self.entries[-self._max_entries:]
 
     def search_prefix(self, prefix: str) -> Optional[str]:
         """Return the most recent entry starting with *prefix*, or ``None``."""
         if not prefix:
             return None
-        for entry in reversed(self._entries):
+        for entry in reversed(self.entries):
             if entry.startswith(prefix) and entry != prefix:
                 return entry
         return None
 
-    def load_file(self, path: str) -> None:
-        """Load history entries from *path* (one per line)."""
-        if not os.path.exists(path):
-            return
-        with open(path, "r", encoding="utf-8", errors="replace") as fh:
-            for raw_line in fh:
-                line = raw_line.rstrip("\n")
-                if line:
-                    self._entries.append(line)
-        if len(self._entries) > self._max_entries:
-            self._entries = self._entries[-self._max_entries:]
-
-    def save_entry(self, line: str, path: str) -> None:
-        """Append *line* to the history file at *path*."""
-        if not line:
-            return
-        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-        with open(path, "a", encoding="utf-8") as fh:
-            fh.write(line + "\n")
-
     def nav_start(self, current_line: str) -> None:
         """Begin history navigation, saving *current_line*."""
-        self._nav_idx = len(self._entries)
+        self._nav_idx = len(self.entries)
         self._nav_saved = current_line
 
     def nav_up(self) -> Optional[str]:
@@ -152,16 +113,16 @@ class LineHistory:
         if self._nav_idx <= 0:
             return None
         self._nav_idx -= 1
-        return self._entries[self._nav_idx]
+        return self.entries[self._nav_idx]
 
     def nav_down(self) -> Optional[str]:
         """Navigate to the next (newer) history entry."""
-        if self._nav_idx >= len(self._entries):
+        if self._nav_idx >= len(self.entries):
             return None
         self._nav_idx += 1
-        if self._nav_idx >= len(self._entries):
+        if self._nav_idx >= len(self.entries):
             return self._nav_saved
-        return self._entries[self._nav_idx]
+        return self.entries[self._nav_idx]
 
 
 class LineEditor:
@@ -182,7 +143,11 @@ class LineEditor:
         limit: int = 65536,
         limit_bell: str = "\a",
         scroll_jump: float = 0.5,
-        style: Optional[InputStyle] = None,
+        text_sgr: str = "\x1b[38;2;230;225;220m",
+        suggestion_sgr: str = "\x1b[30m",
+        bg_sgr: str = "",
+        ellipsis_sgr: str = "",
+        cursor_seq: str = "",
         keymap: Optional[Dict[str, Callable]] = None,
     ) -> None:
         self._buf: List[str] = []
@@ -201,10 +166,17 @@ class LineEditor:
         self._limit_bell_fired: bool = False
         self.scroll_jump: float = scroll_jump
         self._scroll_offset: int = 0
-        self.style: InputStyle = style if style is not None else InputStyle()
-        self._keymap: Dict[str, Callable] = dict(_KEY_DISPATCH)
+        self.text_sgr: str = text_sgr
+        self.suggestion_sgr: str = suggestion_sgr
+        self.bg_sgr: str = bg_sgr
+        self.ellipsis_sgr: str = ellipsis_sgr
+        self.cursor_seq: str = cursor_seq
+        self.keymap: Dict[str, Callable] = dict(DEFAULT_KEYMAP)
         if keymap:
-            self._keymap.update(keymap)
+            self.keymap.update(keymap)
+        self._prev_cursor: int = 0
+        self._prev_content_w: int = 0
+        self._prev_overflow: Tuple[bool, bool] = (False, False)
 
     @property
     def history(self) -> LineHistory:
@@ -223,39 +195,139 @@ class LineEditor:
             return self._is_password()
         return self._password_mode
 
+    def _apply_sgr(self, state: DisplayState) -> DisplayState:
+        """Populate SGR fields on a :class:`DisplayState` from editor style."""
+        state.text_sgr = self.text_sgr
+        state.suggestion_sgr = self.suggestion_sgr
+        state.bg_sgr = self.bg_sgr
+        state.ellipsis_sgr = self.ellipsis_sgr
+        return state
+
     @property
     def display(self) -> DisplayState:
         """Return the current :class:`DisplayState` for rendering."""
         line = self.line
         cursor_col = self._cursor_display_col()
-        sf = self._style_fields()
         if self.password_mode:
             pw_text = self.password_char * len(self._buf)
             if self._needs_hscroll():
                 cw = wcswidth(pw_text)
                 offset = self._compute_scroll(cursor_col, cw)
-                ds = _apply_hscroll(
+                return self._apply_sgr(_apply_hscroll(
                     pw_text, "", cursor_col, self.max_width, self.ellipsis,
-                    scroll_offset=offset)
-                return DisplayState(**{**vars(ds), **sf})
-            return DisplayState(text=pw_text, cursor=cursor_col, **sf)
+                    scroll_offset=offset))
+            return self._apply_sgr(
+                DisplayState(text=pw_text, cursor=cursor_col))
         suggestion = self._get_suggestion()
         if self._needs_hscroll():
             text_w = wcswidth(line)
             suggest_w = wcswidth(suggestion)
             offset = self._compute_scroll(cursor_col, text_w + suggest_w)
-            ds = _apply_hscroll(
+            return self._apply_sgr(_apply_hscroll(
                 line, suggestion, cursor_col, self.max_width, self.ellipsis,
-                scroll_offset=offset)
-            return DisplayState(**{**vars(ds), **sf})
-        return DisplayState(
-            text=line, cursor=cursor_col, suggestion=suggestion, **sf)
+                scroll_offset=offset))
+        return self._apply_sgr(DisplayState(
+            text=line, cursor=cursor_col, suggestion=suggestion))
+
+    def render(self, term: Terminal, row: int, width: int) -> str:
+        """Build escape sequences to render the current display state.
+
+        :param term: Blessed :class:`~.Terminal` instance for cursor/SGR.
+        :param row: Terminal row for the input line.
+        :param width: Available columns.
+        :returns: Escape-sequence string; caller writes/encodes it.
+        """
+        cur = self.display
+        ellipsis_w = wcswidth(self.ellipsis)
+        parts: List[str] = [term.move_yx(row, 0), cur.bg_sgr]
+        rendered = 0
+
+        if cur.overflow_left:
+            parts.extend((cur.ellipsis_sgr, self.ellipsis, cur.bg_sgr))
+            rendered += ellipsis_w
+
+        if cur.text:
+            parts.extend((cur.text_sgr, cur.text))
+            rendered += wcswidth(cur.text)
+
+        if cur.suggestion:
+            parts.extend((cur.suggestion_sgr, cur.suggestion))
+            rendered += wcswidth(cur.suggestion)
+
+        if cur.overflow_right:
+            parts.extend((cur.ellipsis_sgr, self.ellipsis))
+            rendered += ellipsis_w
+
+        pad = width - rendered
+        if pad > 0:
+            parts.extend((cur.bg_sgr, " " * pad))
+
+        parts.extend((term.normal, term.move_yx(row, cur.cursor)))
+        self._prev_cursor = cur.cursor
+        self._prev_content_w = rendered
+        self._prev_overflow = (cur.overflow_left, cur.overflow_right)
+        return "".join(parts)
+
+    def render_insert(
+        self, term: Terminal, row: int, grapheme: str
+    ) -> Optional[str]:
+        """Fast-path render for a single grapheme inserted at end of buffer.
+
+        :param term: Blessed :class:`~.Terminal` instance.
+        :param row: Terminal row for the input line.
+        :param grapheme: The grapheme cluster just inserted.
+        :returns: Escape-sequence string, or ``None`` if a full redraw is needed.
+        """
+        if self._cursor != len(self._buf):
+            return None
+        cur = self.display
+        if (cur.overflow_left, cur.overflow_right) != self._prev_overflow:
+            return None
+        col = self._prev_cursor
+        parts: List[str] = [term.move_yx(row, col), cur.text_sgr, grapheme]
+        new_content_w = wcswidth(cur.text) + wcswidth(cur.suggestion)
+        if cur.suggestion:
+            parts.extend((cur.suggestion_sgr, cur.suggestion))
+        trail = self._prev_content_w - new_content_w
+        if trail > 0:
+            parts.extend((cur.bg_sgr, " " * trail))
+        parts.extend((term.normal, term.move_yx(row, cur.cursor)))
+        self._prev_cursor = cur.cursor
+        self._prev_content_w = new_content_w
+        self._prev_overflow = (cur.overflow_left, cur.overflow_right)
+        return "".join(parts)
+
+    def render_backspace(self, term: Terminal, row: int) -> Optional[str]:
+        """Fast-path render after a backspace at end of buffer.
+
+        :param term: Blessed :class:`~.Terminal` instance.
+        :param row: Terminal row for the input line.
+        :returns: Escape-sequence string, or ``None`` if a full redraw is needed.
+        """
+        if self._cursor != len(self._buf):
+            return None
+        cur = self.display
+        if (cur.overflow_left, cur.overflow_right) != self._prev_overflow:
+            return None
+        col = cur.cursor
+        new_content_w = wcswidth(cur.text) + wcswidth(cur.suggestion)
+        erase = self._prev_content_w - new_content_w
+        parts: List[str] = [term.move_yx(row, col)]
+        if cur.suggestion:
+            parts.extend((cur.suggestion_sgr, cur.suggestion))
+        if erase > 0:
+            parts.extend((cur.bg_sgr, " " * erase))
+        parts.extend((term.normal, term.move_yx(row, cur.cursor)))
+        self._prev_cursor = cur.cursor
+        self._prev_content_w = new_content_w
+        self._prev_overflow = (cur.overflow_left, cur.overflow_right)
+        return "".join(parts)
 
     def feed_key(self, key: Union["Keystroke", str]) -> LineEditResult:  # noqa: F821
         """Process one keystroke and return a :class:`LineEditResult`."""
         name = getattr(key, "name", None)
         if name:
-            handler = self._keymap.get(name)
+            handler = self.keymap.get(name)
             if handler is not None:
                 return handler(self)
             return LineEditResult()
@@ -298,12 +370,6 @@ class LineEditor:
     def set_password_mode(self, enabled: bool) -> None:
         """Set password mode directly (used when no *is_password* callable)."""
         self._password_mode = enabled
-
-    def _style_fields(self) -> dict:
-        s = self.style
-        return dict(text_sgr=s.text_sgr, suggestion_sgr=s.suggestion_sgr,
-                    bg_sgr=s.bg_sgr, ellipsis_sgr=s.ellipsis_sgr,
-                    cursor_seq=s.cursor_seq)
 
     def _needs_hscroll(self) -> bool:
         if self.max_width <= 0:
@@ -609,7 +675,7 @@ def _apply_hscroll(
     )
 
 
-_KEY_DISPATCH: Dict[str, Callable] = {
+DEFAULT_KEYMAP: Dict[str, Callable] = {
     "KEY_ENTER": LineEditor._handle_enter,
     "KEY_CTRL_C": LineEditor._handle_ctrl_c,
     "KEY_CTRL_D": LineEditor._handle_ctrl_d,

--- a/blessed/line_editor.py
+++ b/blessed/line_editor.py
@@ -43,17 +43,47 @@ from wcwidth import iter_graphemes, width as wcswidth
 PASSWORD_CHAR = "\u25cf"
 
 __all__ = (
-    "EditResult",
-    "DisplayState",
-    "History",
+    "InputStyle",
+    "LineEditResult",
+    "LineHistory",
     "LineEditor",
-    "LiveLineEditor",
-    "PASSWORD_CHAR",
 )
 
 
 @dataclass
-class EditResult:
+class InputStyle:
+    """SGR styling for the input line, changeable at runtime.
+
+    .. py:attribute:: text_sgr
+
+        SGR sequence applied to main input text.
+
+    .. py:attribute:: suggestion_sgr
+
+        SGR sequence applied to auto-suggest suffix.
+
+    .. py:attribute:: bg_sgr
+
+        SGR sequence for the whole input line background.
+
+    .. py:attribute:: ellipsis_sgr
+
+        SGR sequence applied to overflow ellipsis characters.
+
+    .. py:attribute:: cursor_seq
+
+        DECSCUSR sequence for cursor shape (e.g. ``"\\x1b[5 q"``).
+    """
+
+    text_sgr: str = ""
+    suggestion_sgr: str = ""
+    bg_sgr: str = ""
+    ellipsis_sgr: str = ""
+    cursor_seq: str = ""
+
+
+@dataclass
+class LineEditResult:
     """Result of processing a keystroke.
 
     .. py:attribute:: line
@@ -71,34 +101,83 @@ class EditResult:
     .. py:attribute:: changed
 
         ``True`` when the display needs redrawing.
+
+    .. py:attribute:: bell
+
+        Bell string to emit (e.g. ``"\\a"``), empty when silent.
     """
 
     line: Optional[str] = None
     eof: bool = False
     interrupt: bool = False
     changed: bool = False
+    bell: str = ""
 
 
 @dataclass
 class DisplayState:
     """Current visual state of the editor for rendering.
 
+    When the :class:`LineEditor` has a ``max_width`` set, text and suggestion
+    are clipped to fit, ``cursor`` is adjusted for the visible window, and
+    ``clipped_left`` / ``clipped_right`` indicate overflow.
+
     .. py:attribute:: text
 
         Buffer text (masked with :data:`PASSWORD_CHAR` if password mode).
+        When ``max_width`` is active this is the visible slice only.
 
     .. py:attribute:: cursor
 
-        0-indexed cursor position in display columns.
+        0-indexed cursor position in display columns within the visible
+        window (already adjusted for horizontal scroll).
 
     .. py:attribute:: suggestion
 
         Auto-suggest suffix (to be rendered dim/grey after text).
+        Clipped to remaining space when ``max_width`` is active.
+
+    .. py:attribute:: clipped_left
+
+        ``True`` when content extends beyond the left edge of the visible
+        window (i.e. text has been scrolled right).
+
+    .. py:attribute:: clipped_right
+
+        ``True`` when content extends beyond the right edge of the visible
+        window.
+
+    .. py:attribute:: text_sgr
+
+        SGR sequence for main input text (copied from :class:`InputStyle`).
+
+    .. py:attribute:: suggestion_sgr
+
+        SGR sequence for auto-suggest suffix.
+
+    .. py:attribute:: bg_sgr
+
+        SGR sequence for the whole input line background.
+
+    .. py:attribute:: ellipsis_sgr
+
+        SGR sequence for overflow ellipsis characters.
+
+    .. py:attribute:: cursor_seq
+
+        DECSCUSR sequence for cursor shape.
     """
 
     text: str = ""
     cursor: int = 0
     suggestion: str = ""
+    clipped_left: bool = False
+    clipped_right: bool = False
+    text_sgr: str = ""
+    suggestion_sgr: str = ""
+    bg_sgr: str = ""
+    ellipsis_sgr: str = ""
+    cursor_seq: str = ""
 
 
 def _graphemes(text: str) -> List[str]:
@@ -125,7 +204,7 @@ def _is_displayable_grapheme(grapheme: str) -> bool:
     return all(ch.isprintable() or ch == "\t" for ch in grapheme)
 
 
-class History:
+class LineHistory:
     """
     In-memory command history with optional file persistence.
 
@@ -234,6 +313,10 @@ class History:
         return self._entries[self._nav_idx]
 
 
+#: Alias for backward compatibility.
+History = LineHistory
+
+
 class LineEditor:
     """
     Headless single-line editor with grapheme-aware cursor movement.
@@ -247,12 +330,32 @@ class LineEditor:
 
     :param history: Optional :class:`History` for up/down and auto-suggest.
     :param is_password: Optional callable returning ``True`` in password mode.
+    :param max_width: When set, :attr:`display` clips text to this many
+        columns with horizontal scrolling.  ``0`` means unlimited.
+    :param ellipsis: Character shown at clipped edges (default ``\u2026``).
+    :param limit: Maximum grapheme clusters allowed; ``0`` means unlimited.
+    :param limit_bell: String emitted once when the limit is reached
+        (default ``"\\a"``).  Set to ``""`` to silence.
+    :param scroll_trigger_pct: Fraction of *max_width* used as the scroll
+        trigger zone near each edge (default ``0.10``).
+    :param scroll_factor: How many trigger-zone widths to scroll at once
+        (default ``2.0``).
+    :param style: Optional :class:`InputStyle` for runtime-changeable SGR
+        styling.  Fields are copied into :class:`DisplayState` on each
+        :attr:`display` access.
     """
 
     def __init__(
         self,
         history: Optional[History] = None,
         is_password: Optional[Callable[[], bool]] = None,
+        max_width: int = 0,
+        ellipsis: str = "\u2026",
+        limit: int = 65536,
+        limit_bell: str = "\a",
+        scroll_trigger_pct: float = 0.10,
+        scroll_factor: float = 2.0,
+        style: Optional[InputStyle] = None,
     ) -> None:
         self._buf: List[str] = []  # list of grapheme clusters
         self._cursor: int = 0      # index into _buf (grapheme position)
@@ -262,6 +365,14 @@ class LineEditor:
         self._undo_stack: List[tuple[List[str], int]] = []
         self._in_history: bool = False
         self._password_mode: bool = False
+        self.max_width: int = max_width
+        self.ellipsis: str = ellipsis
+        self.limit: int = limit
+        self.limit_bell: str = limit_bell
+        self._limit_bell_fired: bool = False
+        self.scroll_trigger_pct: float = scroll_trigger_pct
+        self.scroll_factor: float = scroll_factor
+        self.style: InputStyle = style if style is not None else InputStyle()
 
     @property
     def history(self) -> History:
@@ -280,20 +391,59 @@ class LineEditor:
             return self._is_password()
         return self._password_mode
 
+    def _copy_style(self, ds: DisplayState) -> DisplayState:
+        """Copy :attr:`style` fields into a :class:`DisplayState`."""
+        ds.text_sgr = self.style.text_sgr
+        ds.suggestion_sgr = self.style.suggestion_sgr
+        ds.bg_sgr = self.style.bg_sgr
+        ds.ellipsis_sgr = self.style.ellipsis_sgr
+        ds.cursor_seq = self.style.cursor_seq
+        return ds
+
+    def _needs_hscroll(self) -> bool:
+        """Return whether horizontal scrolling is needed.
+
+        When the limit is set and fits within ``max_width``, the text can
+        never exceed the window — no scrolling needed.
+        """
+        if self.max_width <= 0:
+            return False
+        if self.limit > 0 and self.limit <= self.max_width:
+            return False
+        return True
+
     @property
     def display(self) -> DisplayState:
-        """Return the current :class:`DisplayState` for rendering."""
+        """Return the current :class:`DisplayState` for rendering.
+
+        When :attr:`max_width` is set (> 0), the returned state has text
+        and suggestion clipped to fit, with ``clipped_left`` and
+        ``clipped_right`` indicating overflow.  The ``cursor`` value is
+        relative to the visible window.
+        """
         line = self.line
         cursor_col = self._cursor_display_col()
         if self.password_mode:
-            return DisplayState(
-                text=PASSWORD_CHAR * len(self._buf),
-                cursor=cursor_col,
+            pw_text = PASSWORD_CHAR * len(self._buf)
+            if self._needs_hscroll():
+                return self._copy_style(_apply_hscroll(
+                    pw_text, "", cursor_col, self.max_width, self.ellipsis,
+                    self.scroll_trigger_pct, self.scroll_factor,
+                ))
+            return self._copy_style(
+                DisplayState(text=pw_text, cursor=cursor_col)
             )
         suggestion = self._get_suggestion()
-        return DisplayState(text=line, cursor=cursor_col, suggestion=suggestion)
+        if self._needs_hscroll():
+            return self._copy_style(_apply_hscroll(
+                line, suggestion, cursor_col, self.max_width, self.ellipsis,
+                self.scroll_trigger_pct, self.scroll_factor,
+            ))
+        return self._copy_style(
+            DisplayState(text=line, cursor=cursor_col, suggestion=suggestion)
+        )
 
-    def feed_key(self, key: Union["Keystroke", str]) -> EditResult:
+    def feed_key(self, key: Union["Keystroke", str]) -> LineEditResult:
         """
         Process one keystroke event.
 
@@ -301,7 +451,7 @@ class LineEditor:
         attribute) or a plain string for testing.
 
         :param key: A :class:`~.Keystroke` or a string.
-        :returns: :class:`EditResult` describing what happened.
+        :returns: :class:`LineEditResult` describing what happened.
         """
         name = getattr(key, "name", None)
         if name:
@@ -311,28 +461,41 @@ class LineEditor:
 
         key_str = str(key)
         if key_str and _is_displayable_grapheme(key_str):
+            if self._at_limit():
+                return LineEditResult(
+                    changed=False, bell=self._fire_limit_bell(),
+                )
             self._save_undo()
             for grapheme in _graphemes(key_str):
+                if self._at_limit():
+                    break
                 self._buf.insert(self._cursor, grapheme)
                 self._cursor += 1
             self._in_history = False
-            return EditResult(changed=True)
+            return LineEditResult(changed=True)
 
-        return EditResult()
+        return LineEditResult()
 
-    def insert_text(self, text: str) -> EditResult:
+    def insert_text(self, text: str) -> LineEditResult:
         """
         Insert text at cursor position (for bracketed paste).
 
         :param text: Text to insert.
-        :returns: :class:`EditResult` with ``changed=True``.
+        :returns: :class:`LineEditResult` with ``changed=True``, or
+            ``changed=False`` with a bell if the limit blocks insertion.
         """
+        if self._at_limit():
+            return LineEditResult(
+                changed=False, bell=self._fire_limit_bell(),
+            )
         self._save_undo()
         for grapheme in _graphemes(text):
+            if self._at_limit():
+                break
             if _is_displayable_grapheme(grapheme):
                 self._buf.insert(self._cursor, grapheme)
                 self._cursor += 1
-        return EditResult(changed=True)
+        return LineEditResult(changed=True)
 
     def clear(self) -> None:
         """Clear the buffer and reset cursor to start."""
@@ -348,6 +511,22 @@ class LineEditor:
         """
         self._password_mode = enabled
 
+    def _at_limit(self) -> bool:
+        """Return ``True`` when the buffer is at or above the input limit."""
+        return self.limit > 0 and len(self._buf) >= self.limit
+
+    def _fire_limit_bell(self) -> str:
+        """Return the bell string if limit just reached, else empty."""
+        if not self._limit_bell_fired:
+            self._limit_bell_fired = True
+            return self.limit_bell
+        return ""
+
+    def _maybe_reset_limit_bell(self) -> None:
+        """Reset the bell-fired flag if buffer has shrunk below limit."""
+        if self._limit_bell_fired and not self._at_limit():
+            self._limit_bell_fired = False
+
     def _cursor_display_col(self) -> int:
         """Return the display column of the cursor (sum of widths before it)."""
         return sum(_grapheme_width(g) for g in self._buf[:self._cursor])
@@ -357,103 +536,106 @@ class LineEditor:
         if len(self._undo_stack) > 100:
             self._undo_stack = self._undo_stack[-100:]
 
-    def _undo(self) -> EditResult:
+    def _undo(self) -> LineEditResult:
         if not self._undo_stack:
-            return EditResult()
+            return LineEditResult()
         self._buf, self._cursor = self._undo_stack.pop()
-        return EditResult(changed=True)
+        return LineEditResult(changed=True)
 
-    def _handle_enter(self) -> EditResult:
+    def _handle_enter(self) -> LineEditResult:
         line = self.line
         if line and not self.password_mode:
             self._history.add(line)
         self.clear()
         self._undo_stack.clear()
-        return EditResult(line=line, changed=True)
+        return LineEditResult(line=line, changed=True)
 
-    def _handle_ctrl_c(self) -> EditResult:
+    def _handle_ctrl_c(self) -> LineEditResult:
         self.clear()
         self._undo_stack.clear()
-        return EditResult(interrupt=True, changed=True)
+        return LineEditResult(interrupt=True, changed=True)
 
-    def _handle_ctrl_d(self) -> EditResult:
+    def _handle_ctrl_d(self) -> LineEditResult:
         if not self._buf:
-            return EditResult(eof=True)
+            return LineEditResult(eof=True)
         self._save_undo()
         self._delete_at_cursor()
-        return EditResult(changed=True)
+        return LineEditResult(changed=True)
 
-    def _move_left(self) -> EditResult:
+    def _move_left(self) -> LineEditResult:
         if self._cursor > 0:
             self._cursor -= 1
-            return EditResult(changed=True)
-        return EditResult()
+            return LineEditResult(changed=True)
+        return LineEditResult()
 
-    def _move_right(self) -> EditResult:
+    def _move_right(self) -> LineEditResult:
         if self._cursor < len(self._buf):
             self._cursor += 1
-            return EditResult(changed=True)
-        return EditResult()
+            return LineEditResult(changed=True)
+        return LineEditResult()
 
-    def _move_home(self) -> EditResult:
+    def _move_home(self) -> LineEditResult:
         if self._cursor > 0:
             self._cursor = 0
-            return EditResult(changed=True)
-        return EditResult()
+            return LineEditResult(changed=True)
+        return LineEditResult()
 
-    def _move_end(self) -> EditResult:
+    def _move_end(self) -> LineEditResult:
         if self._cursor < len(self._buf):
             self._cursor = len(self._buf)
-            return EditResult(changed=True)
-        return EditResult()
+            return LineEditResult(changed=True)
+        return LineEditResult()
 
-    def _move_word_left(self) -> EditResult:
+    def _move_word_left(self) -> LineEditResult:
         if self._cursor == 0:
-            return EditResult()
+            return LineEditResult()
         pos = self._cursor - 1
         while pos > 0 and not self._buf[pos - 1].isalnum():
             pos -= 1
         while pos > 0 and self._buf[pos - 1].isalnum():
             pos -= 1
         self._cursor = pos
-        return EditResult(changed=True)
+        return LineEditResult(changed=True)
 
-    def _move_word_right(self) -> EditResult:
+    def _move_word_right(self) -> LineEditResult:
         n = len(self._buf)
         if self._cursor >= n:
-            return EditResult()
+            return LineEditResult()
         pos = self._cursor
         while pos < n and not self._buf[pos].isalnum():
             pos += 1
         while pos < n and self._buf[pos].isalnum():
             pos += 1
         self._cursor = pos
-        return EditResult(changed=True)
+        return LineEditResult(changed=True)
 
-    def _backspace(self) -> EditResult:
+    def _backspace(self) -> LineEditResult:
         if self._cursor > 0:
             self._save_undo()
             self._cursor -= 1
             del self._buf[self._cursor]
-            return EditResult(changed=True)
-        return EditResult()
+            self._maybe_reset_limit_bell()
+            return LineEditResult(changed=True)
+        return LineEditResult()
 
-    def _delete_at_cursor(self) -> EditResult:
+    def _delete_at_cursor(self) -> LineEditResult:
         if self._cursor < len(self._buf):
             del self._buf[self._cursor]
-            return EditResult(changed=True)
-        return EditResult()
+            self._maybe_reset_limit_bell()
+            return LineEditResult(changed=True)
+        return LineEditResult()
 
-    def _kill_to_end(self) -> EditResult:
+    def _kill_to_end(self) -> LineEditResult:
         if self._cursor < len(self._buf):
             self._save_undo()
             killed = "".join(self._buf[self._cursor:])
             del self._buf[self._cursor:]
             self._kill_ring.append(killed)
-            return EditResult(changed=True)
-        return EditResult()
+            self._maybe_reset_limit_bell()
+            return LineEditResult(changed=True)
+        return LineEditResult()
 
-    def _kill_line(self) -> EditResult:
+    def _kill_line(self) -> LineEditResult:
         if self._buf:
             self._save_undo()
             killed = "".join(self._buf[:self._cursor])
@@ -461,12 +643,13 @@ class LineEditor:
             self._cursor = 0
             if killed:
                 self._kill_ring.append(killed)
-            return EditResult(changed=True)
-        return EditResult()
+            self._maybe_reset_limit_bell()
+            return LineEditResult(changed=True)
+        return LineEditResult()
 
-    def _kill_word_back(self) -> EditResult:
+    def _kill_word_back(self) -> LineEditResult:
         if self._cursor == 0:
-            return EditResult()
+            return LineEditResult()
         self._save_undo()
         end = self._cursor
         pos = self._cursor - 1
@@ -478,38 +661,39 @@ class LineEditor:
         del self._buf[pos:end]
         self._cursor = pos
         self._kill_ring.append(killed)
-        return EditResult(changed=True)
+        self._maybe_reset_limit_bell()
+        return LineEditResult(changed=True)
 
-    def _yank(self) -> EditResult:
+    def _yank(self) -> LineEditResult:
         if not self._kill_ring:
-            return EditResult()
+            return LineEditResult()
         self._save_undo()
         text = self._kill_ring[-1]
         for grapheme in _graphemes(text):
             self._buf.insert(self._cursor, grapheme)
             self._cursor += 1
-        return EditResult(changed=True)
+        return LineEditResult(changed=True)
 
-    def _history_prev(self) -> EditResult:
+    def _history_prev(self) -> LineEditResult:
         if not self._in_history:
             self._history.nav_start(self.line)
             self._in_history = True
         entry = self._history.nav_up()
         if entry is not None:
             self._set_text(entry)
-            return EditResult(changed=True)
-        return EditResult()
+            return LineEditResult(changed=True)
+        return LineEditResult()
 
-    def _history_next(self) -> EditResult:
+    def _history_next(self) -> LineEditResult:
         if not self._in_history:
-            return EditResult()
+            return LineEditResult()
         entry = self._history.nav_down()
         if entry is not None:
             self._set_text(entry)
-            return EditResult(changed=True)
-        return EditResult()
+            return LineEditResult(changed=True)
+        return LineEditResult()
 
-    def _accept_suggestion(self) -> EditResult:
+    def _accept_suggestion(self) -> LineEditResult:
         """Accept auto-suggest when cursor is at end, otherwise move right."""
         if self._cursor == len(self._buf):
             suggestion = self._get_suggestion()
@@ -518,11 +702,11 @@ class LineEditor:
                 for grapheme in _graphemes(suggestion):
                     self._buf.append(grapheme)
                 self._cursor = len(self._buf)
-                return EditResult(changed=True)
+                return LineEditResult(changed=True)
         if self._cursor < len(self._buf):
             self._cursor += 1
-            return EditResult(changed=True)
-        return EditResult()
+            return LineEditResult(changed=True)
+        return LineEditResult()
 
     def _set_text(self, text: str) -> None:
         self._buf = _graphemes(text)
@@ -538,6 +722,103 @@ class LineEditor:
         if match is not None:
             return match[len(line):]
         return ""
+
+
+def _apply_hscroll(
+    text: str,
+    suggestion: str,
+    cursor_col: int,
+    max_width: int,
+    ellipsis: str = "\u2026",
+    scroll_trigger_pct: float = 0.10,
+    scroll_factor: float = 2.0,
+) -> DisplayState:
+    """
+    Clip *text* and *suggestion* to *max_width* with horizontal scrolling.
+
+    The cursor is kept visible within the window.  An ellipsis character is
+    shown at the clipped edge(s).
+
+    :param text: Full buffer text.
+    :param suggestion: Auto-suggest suffix.
+    :param cursor_col: Cursor position in display columns (full text).
+    :param max_width: Available display columns.
+    :param ellipsis: Overflow indicator character.
+    :param scroll_trigger_pct: Fraction of *max_width* for the trigger zone.
+    :param scroll_factor: Multiplier on trigger zone for scroll amount.
+    :returns: A :class:`DisplayState` with clipped text and adjusted cursor.
+    """
+    ellipsis_w = _grapheme_width(ellipsis) if ellipsis else 0
+    text_w = _display_width(text)
+    suggest_w = _display_width(suggestion) if suggestion else 0
+    total_w = text_w + suggest_w
+
+    if total_w <= max_width:
+        return DisplayState(
+            text=text, cursor=cursor_col, suggestion=suggestion,
+        )
+
+    trigger_cols = max(1, int(max_width * scroll_trigger_pct))
+    scroll_amount = max(1, int(trigger_cols * scroll_factor))
+    usable = max_width
+
+    scroll_offset = 0
+    if cursor_col >= usable - trigger_cols:
+        scroll_offset = cursor_col - usable + scroll_amount + 1
+
+    # Adjust for left ellipsis taking up space.
+    clipped_left = scroll_offset > 0
+    if clipped_left:
+        usable -= ellipsis_w
+
+    # Slice graphemes from the combined text+suggestion.
+    combined = text + suggestion
+    vis_parts: List[str] = []
+    vis_width = 0
+    col = 0
+
+    for grapheme in iter_graphemes(combined):
+        g_w = _grapheme_width(grapheme)
+        if col + g_w <= scroll_offset:
+            col += g_w
+            continue
+        if vis_width + g_w > usable:
+            break
+        vis_parts.append(grapheme)
+        vis_width += g_w
+        col += g_w
+
+    clipped_right = (scroll_offset + usable) < total_w
+    if clipped_right:
+        # Make room for right ellipsis by removing last grapheme(s).
+        while vis_parts and vis_width + ellipsis_w > usable:
+            removed = vis_parts.pop()
+            vis_width -= _grapheme_width(removed)
+
+    # Split visible parts back into text and suggestion portions.
+    vis_text_parts: List[str] = []
+    vis_suggest_parts: List[str] = []
+    pos = 0
+    for grapheme in vis_parts:
+        g_w = _grapheme_width(grapheme)
+        src_col = scroll_offset + pos
+        if src_col < text_w:
+            vis_text_parts.append(grapheme)
+        else:
+            vis_suggest_parts.append(grapheme)
+        pos += g_w
+
+    vis_cursor = cursor_col - scroll_offset
+    if clipped_left:
+        vis_cursor += ellipsis_w
+
+    return DisplayState(
+        text="".join(vis_text_parts),
+        cursor=vis_cursor,
+        suggestion="".join(vis_suggest_parts),
+        clipped_left=clipped_left,
+        clipped_right=clipped_right,
+    )
 
 
 # Dispatch table keyed by blessed Keystroke.name values.
@@ -571,135 +852,137 @@ _KEY_DISPATCH = {
 }
 
 
-class LiveLineEditor:
-    """
-    Line editor with async rendering to a terminal region.
-
-    Renders the editor at a fixed ``(row, col)`` position using an asyncio
-    writer for output and :meth:`~.Terminal.async_inkey` for input.  If *row*
-    and *col* are not specified, renders at the current cursor position.
-
-    :param terminal: A :class:`~.Terminal` instance for keystroke reading.
-    :param writer: An :class:`asyncio.StreamWriter` for terminal output.
-        If ``None``, output is written to *terminal*'s stream.
-    :param row: 0-indexed row for the input line (``None`` = current position).
-    :param col: 0-indexed column for the input line (default ``0``).
-    :param width: Maximum display width (default: terminal width minus *col*).
-    :param history: :class:`History` instance for command recall.
-    :param is_password: Callable returning ``True`` when in password mode.
-    :param prompt: Prompt string displayed before the input area.
-    :param suggestion_style: SGR escape for auto-suggest text (default: dim).
-    """
-
-    def __init__(
-        self,
-        terminal: "Any",
-        writer: "Any" = None,
-        row: Optional[int] = None,
-        col: int = 0,
-        width: Optional[int] = None,
-        history: Optional[History] = None,
-        is_password: Optional[Callable[[], bool]] = None,
-        prompt: str = "",
-        suggestion_style: str = "\x1b[2m",
-    ) -> None:
-        self._term = terminal
-        self._writer = writer
-        self._row = row
-        self._col = col
-        self._width = width
-        self._prompt = prompt
-        self._suggestion_style = suggestion_style
-        self._editor = LineEditor(history=history, is_password=is_password)
-
-    @property
-    def editor(self) -> LineEditor:
-        """Return the underlying :class:`LineEditor`."""
-        return self._editor
-
-    def _write(self, data: bytes) -> None:
-        """Write bytes to the output stream."""
-        if self._writer is not None:
-            self._writer.write(data)
-        else:
-            self._term.stream.write(data.decode("utf-8", errors="replace"))
-            self._term.stream.flush()
-
-    def render(self) -> None:
-        """Render the current editor state to the terminal."""
-        state = self._editor.display
-        prompt_width = _display_width(self._prompt) if self._prompt else 0
-        term_width = getattr(self._term, "width", 80)
-        width = self._width if self._width is not None else (term_width - self._col)
-
-        parts: List[bytes] = []
-
-        if self._row is not None:
-            parts.append(f"\x1b[{self._row + 1};{self._col + 1}H".encode())
-
-        parts.append(b"\x1b[K")
-
-        if self._prompt:
-            parts.append(self._prompt.encode("utf-8", errors="replace"))
-
-        available = width - prompt_width
-        text = state.text
-        text_width = _display_width(text)
-        if text_width <= available:
-            parts.append(text.encode("utf-8", errors="replace"))
-            if state.suggestion:
-                remaining = available - text_width
-                suggestion = state.suggestion
-                if _display_width(suggestion) > remaining:
-                    suggestion = _truncate_to_width(suggestion, remaining)
-                parts.append(self._suggestion_style.encode())
-                parts.append(suggestion.encode("utf-8", errors="replace"))
-                parts.append(b"\x1b[0m")
-        else:
-            parts.append(_truncate_to_width(text, available).encode(
-                "utf-8", errors="replace"))
-
-        cursor_col = self._col + prompt_width + state.cursor
-        if self._row is not None:
-            parts.append(f"\x1b[{self._row + 1};{cursor_col + 1}H".encode())
-
-        self._write(b"".join(parts))
-
-    async def readline(self) -> Optional[str]:
-        """
-        Read a complete line of input asynchronously.
-
-        Reads keystrokes via :meth:`~.Terminal.async_inkey`, feeds them
-        directly to the underlying :class:`LineEditor`, and renders after
-        each change.
-
-        :returns: The accepted line, or ``None`` on EOF (Ctrl+D).
-        :raises KeyboardInterrupt: On Ctrl+C.
-        """
-        self.render()
-        while True:
-            key = await self._term.async_inkey()
-            result = self._editor.feed_key(key)
-
-            if result.eof:
-                return None
-            if result.interrupt:
-                self.render()
-                raise KeyboardInterrupt
-            if result.line is not None:
-                return result.line
-            if result.changed:
-                self.render()
-
-
-def _truncate_to_width(text: str, max_width: int) -> str:
-    """Truncate *text* to fit within *max_width* display columns."""
-    result: List[str] = []
-    used = 0
-    for grapheme in iter_graphemes(text):
-        w = _grapheme_width(grapheme)
-        if used + w > max_width:
-            break
-        result.append(grapheme)
-        used += w
-    return "".join(result)
+# incomplete
+#
+#class LiveLineEditor:
+#    """
+#    Line editor with async rendering to a terminal region.
+#
+#    Renders the editor at a fixed ``(row, col)`` position using an asyncio
+#    writer for output and :meth:`~.Terminal.async_inkey` for input.  If *row*
+#    and *col* are not specified, renders at the current cursor position.
+#
+#    :param terminal: A :class:`~.Terminal` instance for keystroke reading.
+#    :param writer: An :class:`asyncio.StreamWriter` for terminal output.
+#        If ``None``, output is written to *terminal*'s stream.
+#    :param row: 0-indexed row for the input line (``None`` = current position).
+#    :param col: 0-indexed column for the input line (default ``0``).
+#    :param width: Maximum display width (default: terminal width minus *col*).
+#    :param history: :class:`History` instance for command recall.
+#    :param is_password: Callable returning ``True`` when in password mode.
+#    :param prompt: Prompt string displayed before the input area.
+#    :param suggestion_style: SGR escape for auto-suggest text (default: dim).
+#    """
+#
+#    def __init__(
+#        self,
+#        terminal: "Any",
+#        writer: "Any" = None,
+#        row: Optional[int] = None,
+#        col: int = 0,
+#        width: Optional[int] = None,
+#        history: Optional[History] = None,
+#        is_password: Optional[Callable[[], bool]] = None,
+#        prompt: str = "",
+#        suggestion_style: str = "\x1b[2m",
+#    ) -> None:
+#        self._term = terminal
+#        self._writer = writer
+#        self._row = row
+#        self._col = col
+#        self._width = width
+#        self._prompt = prompt
+#        self._suggestion_style = suggestion_style
+#        self._editor = LineEditor(history=history, is_password=is_password)
+#
+#    @property
+#    def editor(self) -> LineEditor:
+#        """Return the underlying :class:`LineEditor`."""
+#        return self._editor
+#
+#    def _write(self, data: bytes) -> None:
+#        """Write bytes to the output stream."""
+#        if self._writer is not None:
+#            self._writer.write(data)
+#        else:
+#            self._term.stream.write(data.decode("utf-8", errors="replace"))
+#            self._term.stream.flush()
+#
+#    def render(self) -> None:
+#        """Render the current editor state to the terminal."""
+#        state = self._editor.display
+#        prompt_width = _display_width(self._prompt) if self._prompt else 0
+#        term_width = getattr(self._term, "width", 80)
+#        width = self._width if self._width is not None else (term_width - self._col)
+#
+#        parts: List[bytes] = []
+#
+#        if self._row is not None:
+#            parts.append(f"\x1b[{self._row + 1};{self._col + 1}H".encode())
+#
+#        parts.append(b"\x1b[K")
+#
+#        if self._prompt:
+#            parts.append(self._prompt.encode("utf-8", errors="replace"))
+#
+#        available = width - prompt_width
+#        text = state.text
+#        text_width = _display_width(text)
+#        if text_width <= available:
+#            parts.append(text.encode("utf-8", errors="replace"))
+#            if state.suggestion:
+#                remaining = available - text_width
+#                suggestion = state.suggestion
+#                if _display_width(suggestion) > remaining:
+#                    suggestion = _truncate_to_width(suggestion, remaining)
+#                parts.append(self._suggestion_style.encode())
+#                parts.append(suggestion.encode("utf-8", errors="replace"))
+#                parts.append(b"\x1b[0m")
+#        else:
+#            parts.append(_truncate_to_width(text, available).encode(
+#                "utf-8", errors="replace"))
+#
+#        cursor_col = self._col + prompt_width + state.cursor
+#        if self._row is not None:
+#            parts.append(f"\x1b[{self._row + 1};{cursor_col + 1}H".encode())
+#
+#        self._write(b"".join(parts))
+#
+#    async def readline(self) -> Optional[str]:
+#        """
+#        Read a complete line of input asynchronously.
+#
+#        Reads keystrokes via :meth:`~.Terminal.async_inkey`, feeds them
+#        directly to the underlying :class:`LineEditor`, and renders after
+#        each change.
+#
+#        :returns: The accepted line, or ``None`` on EOF (Ctrl+D).
+#        :raises KeyboardInterrupt: On Ctrl+C.
+#        """
+#        self.render()
+#        while True:
+#            key = await self._term.async_inkey()
+#            result = self._editor.feed_key(key)
+#
+#            if result.eof:
+#                return None
+#            if result.interrupt:
+#                self.render()
+#                raise KeyboardInterrupt
+#            if result.line is not None:
+#                return result.line
+#            if result.changed:
+#                self.render()
+#
+#
+#def _truncate_to_width(text: str, max_width: int) -> str:
+#    """Truncate *text* to fit within *max_width* display columns."""
+#    result: List[str] = []
+#    used = 0
+#    for grapheme in iter_graphemes(text):
+#        w = _grapheme_width(grapheme)
+#        if used + w > max_width:
+#            break
+#        result.append(grapheme)
+#        used += w
+#    return "".join(result)

--- a/blessed/line_editor.py
+++ b/blessed/line_editor.py
@@ -1,0 +1,705 @@
+"""
+Headless line editor with history, auto-suggest, and grapheme-aware editing.
+
+This module provides :class:`LineEditor` for single-line input with readline-style
+editing, :class:`History` for command recall and file persistence, and
+:class:`LiveLineEditor` for rendering the editor at a fixed terminal position using
+an asyncio ``(reader, writer)`` pair or a :class:`~.Terminal` instance.
+
+Grapheme cluster boundaries are used for all cursor movement and display width
+calculations via :func:`wcwidth.iter_graphemes` and :func:`wcwidth.width`.
+
+Example usage with blessed Terminal::
+
+    import asyncio
+    from blessed import Terminal
+    from blessed.line_editor import LineEditor, History
+
+    async def main():
+        term = Terminal()
+        history = History()
+        editor = LineEditor(history=history)
+        with term.cbreak():
+            while True:
+                key = await term.async_inkey()
+                result = editor.feed_key(key)
+                if result.line is not None:
+                    print(f"\\nYou typed: {result.line}")
+                    break
+
+Example usage with asyncio reader/writer::
+
+    editor = LiveLineEditor(reader=stdin_reader, writer=stdout_writer,
+                            row=23, col=0, width=80, history=history)
+    line = await editor.readline()
+"""
+
+import os
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Union
+
+from wcwidth import iter_graphemes, width as wcswidth
+
+PASSWORD_CHAR = "\u25cf"
+
+__all__ = (
+    "EditResult",
+    "DisplayState",
+    "History",
+    "LineEditor",
+    "LiveLineEditor",
+    "PASSWORD_CHAR",
+)
+
+
+@dataclass
+class EditResult:
+    """Result of processing a keystroke.
+
+    .. py:attribute:: line
+
+        The accepted line text when Enter was pressed, otherwise ``None``.
+
+    .. py:attribute:: eof
+
+        ``True`` when Ctrl+D pressed on an empty line.
+
+    .. py:attribute:: interrupt
+
+        ``True`` when Ctrl+C pressed.
+
+    .. py:attribute:: changed
+
+        ``True`` when the display needs redrawing.
+    """
+
+    line: Optional[str] = None
+    eof: bool = False
+    interrupt: bool = False
+    changed: bool = False
+
+
+@dataclass
+class DisplayState:
+    """Current visual state of the editor for rendering.
+
+    .. py:attribute:: text
+
+        Buffer text (masked with :data:`PASSWORD_CHAR` if password mode).
+
+    .. py:attribute:: cursor
+
+        0-indexed cursor position in display columns.
+
+    .. py:attribute:: suggestion
+
+        Auto-suggest suffix (to be rendered dim/grey after text).
+    """
+
+    text: str = ""
+    cursor: int = 0
+    suggestion: str = ""
+
+
+def _graphemes(text: str) -> List[str]:
+    """Split *text* into grapheme clusters."""
+    return list(iter_graphemes(text))
+
+
+def _display_width(text: str) -> int:
+    """Return the display column width of *text*, ignoring control codes."""
+    return wcswidth(text, control_codes="ignore")
+
+
+def _grapheme_width(grapheme: str) -> int:
+    """Return the display column width of a single grapheme cluster."""
+    w = wcswidth(grapheme, control_codes="ignore")
+    return max(0, w)
+
+
+def _is_displayable_grapheme(grapheme: str) -> bool:
+    """Return whether a grapheme cluster is displayable (not a C0/C1 control)."""
+    w = wcswidth(grapheme, control_codes="ignore")
+    if w > 0:
+        return True
+    return all(ch.isprintable() or ch == "\t" for ch in grapheme)
+
+
+class History:
+    """
+    In-memory command history with optional file persistence.
+
+    :param max_entries: Maximum number of history entries retained.
+    """
+
+    def __init__(self, max_entries: int = 5000) -> None:
+        self._entries: List[str] = []
+        self._max_entries = max_entries
+        self._nav_idx: int = -1
+        self._nav_saved: str = ""
+
+    @property
+    def entries(self) -> List[str]:
+        """Return the history entries list (most recent last)."""
+        return self._entries
+
+    def add(self, line: str) -> None:
+        """
+        Append a line to history, skipping consecutive duplicates.
+
+        :param line: Line text to add.
+        """
+        if not line:
+            return
+        if self._entries and self._entries[-1] == line:
+            return
+        self._entries.append(line)
+        if len(self._entries) > self._max_entries:
+            self._entries = self._entries[-self._max_entries:]
+
+    def search_prefix(self, prefix: str) -> Optional[str]:
+        """
+        Find the most recent history entry matching *prefix*.
+
+        :param prefix: Prefix to match.
+        :returns: The matching entry, or ``None``.
+        """
+        if not prefix:
+            return None
+        for entry in reversed(self._entries):
+            if entry.startswith(prefix) and entry != prefix:
+                return entry
+        return None
+
+    def load_file(self, path: str) -> None:
+        """
+        Load history entries from a file (one per line).
+
+        :param path: Path to the history file.
+        """
+        if not os.path.exists(path):
+            return
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            for raw_line in fh:
+                line = raw_line.rstrip("\n")
+                if line:
+                    self._entries.append(line)
+        if len(self._entries) > self._max_entries:
+            self._entries = self._entries[-self._max_entries:]
+
+    def save_entry(self, line: str, path: str) -> None:
+        """
+        Append a single entry to the history file.
+
+        :param line: Line text to save.
+        :param path: Path to the history file.
+        """
+        if not line:
+            return
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+
+    def nav_start(self, current_line: str) -> None:
+        """
+        Begin history navigation, saving the current line.
+
+        :param current_line: The current editor buffer to preserve.
+        """
+        self._nav_idx = len(self._entries)
+        self._nav_saved = current_line
+
+    def nav_up(self) -> Optional[str]:
+        """
+        Navigate to the previous (older) history entry.
+
+        :returns: The history entry text, or ``None`` if at the beginning.
+        """
+        if self._nav_idx <= 0:
+            return None
+        self._nav_idx -= 1
+        return self._entries[self._nav_idx]
+
+    def nav_down(self) -> Optional[str]:
+        """
+        Navigate to the next (newer) history entry.
+
+        :returns: The history entry, the saved current line, or ``None``.
+        """
+        if self._nav_idx >= len(self._entries):
+            return None
+        self._nav_idx += 1
+        if self._nav_idx >= len(self._entries):
+            return self._nav_saved
+        return self._entries[self._nav_idx]
+
+
+class LineEditor:
+    """
+    Headless single-line editor with grapheme-aware cursor movement.
+
+    Feed keystrokes via :meth:`feed_key`, read display state via
+    :attr:`display`.  The editor stores its buffer as a list of grapheme
+    clusters, ensuring that cursor movement never splits a grapheme.
+
+    Accepts blessed :class:`~.Keystroke` objects directly (dispatching on
+    ``.name``), or plain strings for testing and non-blessed usage.
+
+    :param history: Optional :class:`History` for up/down and auto-suggest.
+    :param is_password: Optional callable returning ``True`` in password mode.
+    """
+
+    def __init__(
+        self,
+        history: Optional[History] = None,
+        is_password: Optional[Callable[[], bool]] = None,
+    ) -> None:
+        self._buf: List[str] = []  # list of grapheme clusters
+        self._cursor: int = 0      # index into _buf (grapheme position)
+        self._history: History = history or History()
+        self._is_password: Optional[Callable[[], bool]] = is_password
+        self._kill_ring: List[str] = []
+        self._undo_stack: List[tuple[List[str], int]] = []
+        self._in_history: bool = False
+        self._password_mode: bool = False
+
+    @property
+    def history(self) -> History:
+        """Return the attached :class:`History` instance."""
+        return self._history
+
+    @property
+    def line(self) -> str:
+        """Return the current buffer contents as a string."""
+        return "".join(self._buf)
+
+    @property
+    def password_mode(self) -> bool:
+        """Return whether password mode is currently active."""
+        if self._is_password is not None:
+            return self._is_password()
+        return self._password_mode
+
+    @property
+    def display(self) -> DisplayState:
+        """Return the current :class:`DisplayState` for rendering."""
+        line = self.line
+        cursor_col = self._cursor_display_col()
+        if self.password_mode:
+            return DisplayState(
+                text=PASSWORD_CHAR * len(self._buf),
+                cursor=cursor_col,
+            )
+        suggestion = self._get_suggestion()
+        return DisplayState(text=line, cursor=cursor_col, suggestion=suggestion)
+
+    def feed_key(self, key: Union["Keystroke", str]) -> EditResult:
+        """
+        Process one keystroke event.
+
+        Accepts a blessed :class:`~.Keystroke` (dispatching on its ``.name``
+        attribute) or a plain string for testing.
+
+        :param key: A :class:`~.Keystroke` or a string.
+        :returns: :class:`EditResult` describing what happened.
+        """
+        name = getattr(key, "name", None)
+        if name:
+            handler = _KEY_DISPATCH.get(name)
+            if handler is not None:
+                return handler(self)
+
+        key_str = str(key)
+        if key_str and _is_displayable_grapheme(key_str):
+            self._save_undo()
+            for grapheme in _graphemes(key_str):
+                self._buf.insert(self._cursor, grapheme)
+                self._cursor += 1
+            self._in_history = False
+            return EditResult(changed=True)
+
+        return EditResult()
+
+    def insert_text(self, text: str) -> EditResult:
+        """
+        Insert text at cursor position (for bracketed paste).
+
+        :param text: Text to insert.
+        :returns: :class:`EditResult` with ``changed=True``.
+        """
+        self._save_undo()
+        for grapheme in _graphemes(text):
+            if _is_displayable_grapheme(grapheme):
+                self._buf.insert(self._cursor, grapheme)
+                self._cursor += 1
+        return EditResult(changed=True)
+
+    def clear(self) -> None:
+        """Clear the buffer and reset cursor to start."""
+        self._buf.clear()
+        self._cursor = 0
+        self._in_history = False
+
+    def set_password_mode(self, enabled: bool) -> None:
+        """
+        Set password mode directly (used when no ``is_password`` callable).
+
+        :param enabled: Whether to mask input display.
+        """
+        self._password_mode = enabled
+
+    def _cursor_display_col(self) -> int:
+        """Return the display column of the cursor (sum of widths before it)."""
+        return sum(_grapheme_width(g) for g in self._buf[:self._cursor])
+
+    def _save_undo(self) -> None:
+        self._undo_stack.append((list(self._buf), self._cursor))
+        if len(self._undo_stack) > 100:
+            self._undo_stack = self._undo_stack[-100:]
+
+    def _undo(self) -> EditResult:
+        if not self._undo_stack:
+            return EditResult()
+        self._buf, self._cursor = self._undo_stack.pop()
+        return EditResult(changed=True)
+
+    def _handle_enter(self) -> EditResult:
+        line = self.line
+        if line and not self.password_mode:
+            self._history.add(line)
+        self.clear()
+        self._undo_stack.clear()
+        return EditResult(line=line, changed=True)
+
+    def _handle_ctrl_c(self) -> EditResult:
+        self.clear()
+        self._undo_stack.clear()
+        return EditResult(interrupt=True, changed=True)
+
+    def _handle_ctrl_d(self) -> EditResult:
+        if not self._buf:
+            return EditResult(eof=True)
+        self._save_undo()
+        self._delete_at_cursor()
+        return EditResult(changed=True)
+
+    def _move_left(self) -> EditResult:
+        if self._cursor > 0:
+            self._cursor -= 1
+            return EditResult(changed=True)
+        return EditResult()
+
+    def _move_right(self) -> EditResult:
+        if self._cursor < len(self._buf):
+            self._cursor += 1
+            return EditResult(changed=True)
+        return EditResult()
+
+    def _move_home(self) -> EditResult:
+        if self._cursor > 0:
+            self._cursor = 0
+            return EditResult(changed=True)
+        return EditResult()
+
+    def _move_end(self) -> EditResult:
+        if self._cursor < len(self._buf):
+            self._cursor = len(self._buf)
+            return EditResult(changed=True)
+        return EditResult()
+
+    def _move_word_left(self) -> EditResult:
+        if self._cursor == 0:
+            return EditResult()
+        pos = self._cursor - 1
+        while pos > 0 and not self._buf[pos - 1].isalnum():
+            pos -= 1
+        while pos > 0 and self._buf[pos - 1].isalnum():
+            pos -= 1
+        self._cursor = pos
+        return EditResult(changed=True)
+
+    def _move_word_right(self) -> EditResult:
+        n = len(self._buf)
+        if self._cursor >= n:
+            return EditResult()
+        pos = self._cursor
+        while pos < n and not self._buf[pos].isalnum():
+            pos += 1
+        while pos < n and self._buf[pos].isalnum():
+            pos += 1
+        self._cursor = pos
+        return EditResult(changed=True)
+
+    def _backspace(self) -> EditResult:
+        if self._cursor > 0:
+            self._save_undo()
+            self._cursor -= 1
+            del self._buf[self._cursor]
+            return EditResult(changed=True)
+        return EditResult()
+
+    def _delete_at_cursor(self) -> EditResult:
+        if self._cursor < len(self._buf):
+            del self._buf[self._cursor]
+            return EditResult(changed=True)
+        return EditResult()
+
+    def _kill_to_end(self) -> EditResult:
+        if self._cursor < len(self._buf):
+            self._save_undo()
+            killed = "".join(self._buf[self._cursor:])
+            del self._buf[self._cursor:]
+            self._kill_ring.append(killed)
+            return EditResult(changed=True)
+        return EditResult()
+
+    def _kill_line(self) -> EditResult:
+        if self._buf:
+            self._save_undo()
+            killed = "".join(self._buf[:self._cursor])
+            del self._buf[:self._cursor]
+            self._cursor = 0
+            if killed:
+                self._kill_ring.append(killed)
+            return EditResult(changed=True)
+        return EditResult()
+
+    def _kill_word_back(self) -> EditResult:
+        if self._cursor == 0:
+            return EditResult()
+        self._save_undo()
+        end = self._cursor
+        pos = self._cursor - 1
+        while pos > 0 and not self._buf[pos - 1].isalnum():
+            pos -= 1
+        while pos > 0 and self._buf[pos - 1].isalnum():
+            pos -= 1
+        killed = "".join(self._buf[pos:end])
+        del self._buf[pos:end]
+        self._cursor = pos
+        self._kill_ring.append(killed)
+        return EditResult(changed=True)
+
+    def _yank(self) -> EditResult:
+        if not self._kill_ring:
+            return EditResult()
+        self._save_undo()
+        text = self._kill_ring[-1]
+        for grapheme in _graphemes(text):
+            self._buf.insert(self._cursor, grapheme)
+            self._cursor += 1
+        return EditResult(changed=True)
+
+    def _history_prev(self) -> EditResult:
+        if not self._in_history:
+            self._history.nav_start(self.line)
+            self._in_history = True
+        entry = self._history.nav_up()
+        if entry is not None:
+            self._set_text(entry)
+            return EditResult(changed=True)
+        return EditResult()
+
+    def _history_next(self) -> EditResult:
+        if not self._in_history:
+            return EditResult()
+        entry = self._history.nav_down()
+        if entry is not None:
+            self._set_text(entry)
+            return EditResult(changed=True)
+        return EditResult()
+
+    def _accept_suggestion(self) -> EditResult:
+        """Accept auto-suggest when cursor is at end, otherwise move right."""
+        if self._cursor == len(self._buf):
+            suggestion = self._get_suggestion()
+            if suggestion:
+                self._save_undo()
+                for grapheme in _graphemes(suggestion):
+                    self._buf.append(grapheme)
+                self._cursor = len(self._buf)
+                return EditResult(changed=True)
+        if self._cursor < len(self._buf):
+            self._cursor += 1
+            return EditResult(changed=True)
+        return EditResult()
+
+    def _set_text(self, text: str) -> None:
+        self._buf = _graphemes(text)
+        self._cursor = len(self._buf)
+
+    def _get_suggestion(self) -> str:
+        if self.password_mode:
+            return ""
+        line = self.line
+        if not line or self._cursor != len(self._buf):
+            return ""
+        match = self._history.search_prefix(line)
+        if match is not None:
+            return match[len(line):]
+        return ""
+
+
+# Dispatch table keyed by blessed Keystroke.name values.
+_KEY_DISPATCH = {
+    "KEY_ENTER": LineEditor._handle_enter,
+    "KEY_CTRL_C": LineEditor._handle_ctrl_c,
+    "KEY_CTRL_D": LineEditor._handle_ctrl_d,
+    "KEY_LEFT": LineEditor._move_left,
+    "KEY_CTRL_B": LineEditor._move_left,
+    "KEY_RIGHT": LineEditor._accept_suggestion,
+    "KEY_CTRL_F": LineEditor._move_right,
+    "KEY_HOME": LineEditor._move_home,
+    "KEY_CTRL_A": LineEditor._move_home,
+    "KEY_END": LineEditor._move_end,
+    "KEY_CTRL_E": LineEditor._move_end,
+    "KEY_SLEFT": LineEditor._move_word_left,
+    "KEY_SRIGHT": LineEditor._move_word_right,
+    "KEY_CTRL_LEFT": LineEditor._move_word_left,
+    "KEY_CTRL_RIGHT": LineEditor._move_word_right,
+    "KEY_BACKSPACE": LineEditor._backspace,
+    "KEY_DELETE": LineEditor._delete_at_cursor,
+    "KEY_CTRL_K": LineEditor._kill_to_end,
+    "KEY_CTRL_U": LineEditor._kill_line,
+    "KEY_CTRL_W": LineEditor._kill_word_back,
+    "KEY_CTRL_Y": LineEditor._yank,
+    "KEY_UP": LineEditor._history_prev,
+    "KEY_CTRL_P": LineEditor._history_prev,
+    "KEY_DOWN": LineEditor._history_next,
+    "KEY_CTRL_N": LineEditor._history_next,
+    "KEY_CTRL_Z": LineEditor._undo,
+}
+
+
+class LiveLineEditor:
+    """
+    Line editor with async rendering to a terminal region.
+
+    Renders the editor at a fixed ``(row, col)`` position using an asyncio
+    writer for output and :meth:`~.Terminal.async_inkey` for input.  If *row*
+    and *col* are not specified, renders at the current cursor position.
+
+    :param terminal: A :class:`~.Terminal` instance for keystroke reading.
+    :param writer: An :class:`asyncio.StreamWriter` for terminal output.
+        If ``None``, output is written to *terminal*'s stream.
+    :param row: 0-indexed row for the input line (``None`` = current position).
+    :param col: 0-indexed column for the input line (default ``0``).
+    :param width: Maximum display width (default: terminal width minus *col*).
+    :param history: :class:`History` instance for command recall.
+    :param is_password: Callable returning ``True`` when in password mode.
+    :param prompt: Prompt string displayed before the input area.
+    :param suggestion_style: SGR escape for auto-suggest text (default: dim).
+    """
+
+    def __init__(
+        self,
+        terminal: "Any",
+        writer: "Any" = None,
+        row: Optional[int] = None,
+        col: int = 0,
+        width: Optional[int] = None,
+        history: Optional[History] = None,
+        is_password: Optional[Callable[[], bool]] = None,
+        prompt: str = "",
+        suggestion_style: str = "\x1b[2m",
+    ) -> None:
+        self._term = terminal
+        self._writer = writer
+        self._row = row
+        self._col = col
+        self._width = width
+        self._prompt = prompt
+        self._suggestion_style = suggestion_style
+        self._editor = LineEditor(history=history, is_password=is_password)
+
+    @property
+    def editor(self) -> LineEditor:
+        """Return the underlying :class:`LineEditor`."""
+        return self._editor
+
+    def _write(self, data: bytes) -> None:
+        """Write bytes to the output stream."""
+        if self._writer is not None:
+            self._writer.write(data)
+        else:
+            self._term.stream.write(data.decode("utf-8", errors="replace"))
+            self._term.stream.flush()
+
+    def render(self) -> None:
+        """Render the current editor state to the terminal."""
+        state = self._editor.display
+        prompt_width = _display_width(self._prompt) if self._prompt else 0
+        term_width = getattr(self._term, "width", 80)
+        width = self._width if self._width is not None else (term_width - self._col)
+
+        parts: List[bytes] = []
+
+        if self._row is not None:
+            parts.append(f"\x1b[{self._row + 1};{self._col + 1}H".encode())
+
+        parts.append(b"\x1b[K")
+
+        if self._prompt:
+            parts.append(self._prompt.encode("utf-8", errors="replace"))
+
+        available = width - prompt_width
+        text = state.text
+        text_width = _display_width(text)
+        if text_width <= available:
+            parts.append(text.encode("utf-8", errors="replace"))
+            if state.suggestion:
+                remaining = available - text_width
+                suggestion = state.suggestion
+                if _display_width(suggestion) > remaining:
+                    suggestion = _truncate_to_width(suggestion, remaining)
+                parts.append(self._suggestion_style.encode())
+                parts.append(suggestion.encode("utf-8", errors="replace"))
+                parts.append(b"\x1b[0m")
+        else:
+            parts.append(_truncate_to_width(text, available).encode(
+                "utf-8", errors="replace"))
+
+        cursor_col = self._col + prompt_width + state.cursor
+        if self._row is not None:
+            parts.append(f"\x1b[{self._row + 1};{cursor_col + 1}H".encode())
+
+        self._write(b"".join(parts))
+
+    async def readline(self) -> Optional[str]:
+        """
+        Read a complete line of input asynchronously.
+
+        Reads keystrokes via :meth:`~.Terminal.async_inkey`, feeds them
+        directly to the underlying :class:`LineEditor`, and renders after
+        each change.
+
+        :returns: The accepted line, or ``None`` on EOF (Ctrl+D).
+        :raises KeyboardInterrupt: On Ctrl+C.
+        """
+        self.render()
+        while True:
+            key = await self._term.async_inkey()
+            result = self._editor.feed_key(key)
+
+            if result.eof:
+                return None
+            if result.interrupt:
+                self.render()
+                raise KeyboardInterrupt
+            if result.line is not None:
+                return result.line
+            if result.changed:
+                self.render()
+
+
+def _truncate_to_width(text: str, max_width: int) -> str:
+    """Truncate *text* to fit within *max_width* display columns."""
+    result: List[str] = []
+    used = 0
+    for grapheme in iter_graphemes(text):
+        w = _grapheme_width(grapheme)
+        if used + w > max_width:
+            break
+        result.append(grapheme)
+        used += w
+    return "".join(result)

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -8,7 +8,6 @@ import time
 import codecs
 import locale
 import asyncio
-import logging
 import select
 import struct
 import platform
@@ -2967,7 +2966,6 @@ class Terminal():
         :returns: :class:`~.Keystroke`, which may be empty (``''``) if
             ``timeout`` is specified and keystroke is not received.
         """
-        # pylint: disable=too-many-locals,too-many-branches,too-complex
         loop = asyncio.get_running_loop()
 
         # drain keyboard buffer (non-blocking)

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -2959,7 +2959,7 @@ class Terminal():
         """
         import asyncio  # pylint: disable=import-outside-toplevel
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         # drain keyboard buffer (non-blocking)
         ucs = self.flushinp()

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -3029,7 +3029,7 @@ class Terminal():
 
     async def _async_read_byte(
         self,
-        loop: "asyncio.AbstractEventLoop",
+        loop: "asyncio.AbstractEventLoop",  # noqa: F821
         timeout: Optional[float],
     ) -> Optional[bytes]:
         """
@@ -3041,7 +3041,9 @@ class Terminal():
         """
         import asyncio  # pylint: disable=import-outside-toplevel
 
-        assert self._keyboard_fd is not None
+        if self._keyboard_fd is None:
+            raise RuntimeError(
+                "async_inkey requires a keyboard file descriptor")
         fut: asyncio.Future[bytes] = loop.create_future()
 
         def _on_readable() -> None:

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -26,6 +26,7 @@ from wcwidth import center as wcwidth_center
 from .color import COLOR_DISTANCE_ALGORITHMS, xterm256gray_from_rgb, xterm256color_from_rgb
 from .keyboard import (DEFAULT_ESCDELAY,
                        Keystroke,
+                       ResizeEvent,
                        DeviceAttribute,
                        SoftwareVersion,
                        KittyKeyboardProtocol,
@@ -2727,9 +2728,11 @@ class Terminal():
                 self._line_buffered = False
                 yield
             finally:
-                # Restore prior mode:
+                # Restore prior mode.  TCSADRAIN (not TCSAFLUSH) so that
+                # keystrokes buffered during the mode switch are preserved;
+                # TCSAFLUSH discards unread input, dropping user keystrokes.
                 termios.tcsetattr(self._keyboard_fd,
-                                  termios.TCSAFLUSH,
+                                  termios.TCSADRAIN,
                                   save_mode)
                 self._line_buffered = save_line_buffered
         else:
@@ -2764,9 +2767,11 @@ class Terminal():
                 self._line_buffered = False
                 yield
             finally:
-                # Restore prior mode:
+                # Restore prior mode.  TCSADRAIN (not TCSAFLUSH) so that
+                # keystrokes buffered during the mode switch are preserved;
+                # TCSAFLUSH discards unread input, dropping user keystrokes.
                 termios.tcsetattr(self._keyboard_fd,
-                                  termios.TCSAFLUSH,
+                                  termios.TCSADRAIN,
                                   save_mode)
                 self._line_buffered = save_line_buffered
         else:
@@ -2924,11 +2929,12 @@ class Terminal():
         # Update preferred size cache if this is a resize event
         if ks._mode == _DecPrivateMode.IN_BAND_WINDOW_RESIZE:  # pylint: disable=protected-access
             event_vals = ks._mode_values  # pylint: disable=protected-access
+            assert isinstance(event_vals, ResizeEvent)
             self._preferred_size_cache = WINSZ(
-                ws_row=event_vals.height_chars,  # type: ignore[union-attr]
-                ws_col=event_vals.width_chars,  # type: ignore[union-attr]
-                ws_xpixel=event_vals.width_pixels,  # type: ignore[union-attr]
-                ws_ypixel=event_vals.height_pixels)  # type: ignore[union-attr]
+                ws_row=event_vals.height_chars,
+                ws_col=event_vals.width_chars,
+                ws_xpixel=event_vals.width_pixels,
+                ws_ypixel=event_vals.height_pixels)
 
         return ks
 
@@ -3017,8 +3023,9 @@ class Terminal():
         self.ungetch(ucs[len(ks):])
 
         # update preferred size cache if this is a resize event
-        if ks._mode == _DecPrivateMode.IN_BAND_WINDOW_RESIZE:
-            event_vals = ks._mode_values
+        if ks._mode == _DecPrivateMode.IN_BAND_WINDOW_RESIZE:  # pylint: disable=protected-access
+            event_vals = ks._mode_values  # pylint: disable=protected-access
+            assert isinstance(event_vals, ResizeEvent)
             self._preferred_size_cache = WINSZ(
                 ws_row=event_vals.height_chars,
                 ws_col=event_vals.width_chars,

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -7,9 +7,9 @@ import sys
 import time
 import codecs
 import locale
-import asyncio
 import select
 import struct
+import asyncio
 import platform
 import warnings
 import contextlib
@@ -2966,6 +2966,7 @@ class Terminal():
         :returns: :class:`~.Keystroke`, which may be empty (``''``) if
             ``timeout`` is specified and keystroke is not received.
         """
+        # pylint: disable=too-complex,too-many-branches
         loop = asyncio.get_running_loop()
 
         # drain keyboard buffer (non-blocking)
@@ -3003,7 +3004,11 @@ class Terminal():
                 byte = await self._async_read_byte(loop, esc_delay)
                 if byte is None:
                     break
-                ucs += self.getch(decode_latin1=ucs.startswith('\x1b[M'))
+                decode_latin1 = ucs.startswith('\x1b[M')
+                if decode_latin1:
+                    ucs += chr(byte[0])
+                else:
+                    ucs += self._keyboard_decoder.decode(byte, final=False)
                 # drain remaining immediately available bytes
                 while self.kbhit(timeout=0):
                     ucs += self.getch(

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -7,6 +7,8 @@ import sys
 import time
 import codecs
 import locale
+import asyncio
+import logging
 import select
 import struct
 import platform
@@ -2938,8 +2940,10 @@ class Terminal():
 
         return ks
 
-    async def async_inkey(self, timeout: Optional[float] = None,
-                          esc_delay: float = DEFAULT_ESCDELAY) -> Keystroke:
+    async def async_inkey(
+        self, timeout: Optional[float] = None,
+        esc_delay: float = DEFAULT_ESCDELAY,
+    ) -> Keystroke:
         r"""
         Asynchronous version of :meth:`inkey` for use with :mod:`asyncio`.
 
@@ -2963,8 +2967,7 @@ class Terminal():
         :returns: :class:`~.Keystroke`, which may be empty (``''``) if
             ``timeout`` is specified and keystroke is not received.
         """
-        import asyncio  # pylint: disable=import-outside-toplevel
-
+        # pylint: disable=too-many-locals,too-many-branches,too-complex
         loop = asyncio.get_running_loop()
 
         # drain keyboard buffer (non-blocking)
@@ -3046,8 +3049,6 @@ class Terminal():
         :arg timeout: Seconds to wait, or None for indefinite.
         :returns: A single byte, or None on timeout.
         """
-        import asyncio  # pylint: disable=import-outside-toplevel
-
         if self._keyboard_fd is None:
             raise RuntimeError(
                 "async_inkey requires a keyboard file descriptor")

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -2932,6 +2932,137 @@ class Terminal():
 
         return ks
 
+    async def async_inkey(self, timeout: Optional[float] = None,
+                          esc_delay: float = DEFAULT_ESCDELAY) -> Keystroke:
+        r"""
+        Asynchronous version of :meth:`inkey` for use with :mod:`asyncio`.
+
+        Read and return the next keyboard event within given timeout, yielding
+        control to the asyncio event loop while waiting for input rather than
+        blocking the thread.
+
+        Uses :meth:`asyncio.AbstractEventLoop.add_reader` on the keyboard file
+        descriptor, reusing the same :func:`~.resolve_sequence`, keymap, and
+        :class:`~.Keystroke` internals as the synchronous :meth:`inkey`.
+
+        Must be called within a :meth:`cbreak` or :meth:`raw` context, just
+        like :meth:`inkey`.
+
+        :arg float timeout: Number of seconds to wait for a keystroke before
+            returning.  When ``None`` (default), this method may block
+            indefinitely.
+        :arg float esc_delay: Time in seconds to wait after Escape key
+            is received to disambiguate bare Escape from escape sequences.
+        :rtype: :class:`~.Keystroke`
+        :returns: :class:`~.Keystroke`, which may be empty (``''``) if
+            ``timeout`` is specified and keystroke is not received.
+        """
+        import asyncio  # pylint: disable=import-outside-toplevel
+
+        loop = asyncio.get_event_loop()
+
+        # drain keyboard buffer (non-blocking)
+        ucs = self.flushinp()
+
+        # resolve any buffered keystroke
+        ks = resolve_sequence(ucs, self._keymap, self._keycodes,
+                              self._keymap_prefixes, final=False,
+                              dec_mode_cache=self._dec_mode_cache)
+
+        # read bytes until a complete keystroke is resolved
+        while not ks:
+            byte = await self._async_read_byte(loop, timeout)
+            if byte is None:
+                # timeout expired with no input
+                return Keystroke()
+            decode_latin1 = ucs.startswith('\x1b[M')
+            if decode_latin1:
+                ucs += chr(byte[0])
+            else:
+                ucs += self._keyboard_decoder.decode(byte, final=False)
+
+            # drain all immediately available bytes (non-blocking)
+            while self.kbhit(timeout=0):
+                ucs += self.getch(decode_latin1=ucs.startswith('\x1b[M'))
+
+            ks = resolve_sequence(ucs, self._keymap, self._keycodes,
+                                  self._keymap_prefixes, final=False,
+                                  dec_mode_cache=self._dec_mode_cache)
+
+        # escape key disambiguation: wait esc_delay for more bytes
+        if ks.code == self.KEY_ESCAPE and len(ks) == 1:
+            while (ks.code == self.KEY_ESCAPE
+                   and self._is_incomplete_keystroke(ucs)):
+                byte = await self._async_read_byte(loop, esc_delay)
+                if byte is None:
+                    break
+                ucs += self.getch(decode_latin1=ucs.startswith('\x1b[M'))
+                # drain remaining immediately available bytes
+                while self.kbhit(timeout=0):
+                    ucs += self.getch(
+                        decode_latin1=ucs.startswith('\x1b[M'))
+                final = bool(ucs) and not self._is_incomplete_keystroke(ucs)
+                ks = resolve_sequence(
+                    ucs, self._keymap, self._keycodes,
+                    self._keymap_prefixes, final=final,
+                    dec_mode_cache=self._dec_mode_cache)
+
+            if ks.code == self.KEY_ESCAPE and self._is_incomplete_keystroke(ucs):
+                ks = resolve_sequence(
+                    ucs, self._keymap, self._keycodes,
+                    self._keymap_prefixes, final=True,
+                    dec_mode_cache=self._dec_mode_cache)
+
+        # buffer any remaining text
+        self.ungetch(ucs[len(ks):])
+
+        # update preferred size cache if this is a resize event
+        if ks._mode == _DecPrivateMode.IN_BAND_WINDOW_RESIZE:
+            event_vals = ks._mode_values
+            self._preferred_size_cache = WINSZ(
+                ws_row=event_vals.height_chars,
+                ws_col=event_vals.width_chars,
+                ws_xpixel=event_vals.width_pixels,
+                ws_ypixel=event_vals.height_pixels)
+
+        return ks
+
+    async def _async_read_byte(
+        self,
+        loop: "asyncio.AbstractEventLoop",
+        timeout: Optional[float],
+    ) -> Optional[bytes]:
+        """
+        Read one byte from keyboard fd using asyncio, with optional timeout.
+
+        :arg loop: The asyncio event loop.
+        :arg timeout: Seconds to wait, or None for indefinite.
+        :returns: A single byte, or None on timeout.
+        """
+        import asyncio  # pylint: disable=import-outside-toplevel
+
+        assert self._keyboard_fd is not None
+        fut: asyncio.Future[bytes] = loop.create_future()
+
+        def _on_readable() -> None:
+            if not fut.done():
+                try:
+                    data = os.read(self._keyboard_fd, 1)
+                    fut.set_result(data)
+                except OSError as exc:
+                    fut.set_exception(exc)
+
+        loop.add_reader(self._keyboard_fd, _on_readable)
+        try:
+            if timeout is not None:
+                try:
+                    return await asyncio.wait_for(fut, timeout=timeout)
+                except asyncio.TimeoutError:
+                    return None
+            return await fut
+        finally:
+            loop.remove_reader(self._keyboard_fd)
+
 
 class WINSZ(collections.namedtuple('WINSZ', (
         'ws_row', 'ws_col', 'ws_xpixel', 'ws_ypixel'))):

--- a/docs/api/line_editor.rst
+++ b/docs/api/line_editor.rst
@@ -1,0 +1,6 @@
+line_editor.py
+--------------
+
+.. automodule:: blessed.line_editor
+   :members:
+   :undoc-members:

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,9 @@
 Version History
 ===============
 1.31
+  * bugfix: :meth:`~.cbreak` and :meth:`~.raw` should use ``TCSADRAIN`` to preserve keystrokes
+    buffered during mode switches, previously ``TCSAFLUSH`` was used which discarded unread input,
+    dropping keystrokes.
   * introduced: :mod:`blessed.line_editor` - "headless" single-line editor
   * introduced: :meth:`~.Terminal.async_inkey` — asyncio-compatible version of
     :meth:`~.Terminal.inkey` using event loop readers.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,6 +2,13 @@
 
 Version History
 ===============
+1.31
+  * introduced: :mod:`blessed.line_editor` — headless single-line editor with readline-style
+    keybindings, grapheme-aware cursor, kill ring, undo, auto-suggest, password mode,
+    horizontal scrolling, and custom keymap support.
+  * introduced: :meth:`~.Terminal.async_inkey` — asyncio-compatible version of
+    :meth:`~.Terminal.inkey` using event loop readers.
+
 1.30
   * bugfix: Terminal.wrap drops color escape sequences, :ghpull:`352`.
   * bugfix: Prevent rare feedback loops in automatic responses, :ghpull:`350`.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,9 +3,7 @@
 Version History
 ===============
 1.31
-  * introduced: :mod:`blessed.line_editor` — headless single-line editor with readline-style
-    keybindings, grapheme-aware cursor, kill ring, undo, auto-suggest, password mode,
-    horizontal scrolling, and custom keymap support.
+  * introduced: :mod:`blessed.line_editor` - "headless" single-line editor
   * introduced: :meth:`~.Terminal.async_inkey` — asyncio-compatible version of
     :meth:`~.Terminal.inkey` using event loop readers.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Welcome to Blessed documentation!
    colors
    keyboard
    keyboard_kitty
+   line_editor
    mouse
    dec_modes
    location

--- a/docs/keyboard.rst
+++ b/docs/keyboard.rst
@@ -208,3 +208,35 @@ those found in :linuxman:`curses(3)`, or those `constants
 <https://docs.python.org/3/library/curses.html#constants>`_ in :mod:`curses`
 beginning with phrase *KEY_*. These have numeric values that can be used for
 all basic application keys.
+
+.. _async_input:
+
+Async Input
+-----------
+
+The :meth:`~.Terminal.async_inkey` method is an asyncio-compatible version of
+:meth:`~.Terminal.inkey`.  It yields control to the event loop while waiting for
+input, making it suitable for use with ``async``/``await``.
+
+.. code-block:: python
+
+    import asyncio
+    from blessed import Terminal
+
+    async def main():
+        term = Terminal()
+        with term.cbreak():
+            key = await term.async_inkey(timeout=5.0)
+            if key:
+                print(f"You pressed: {key!r}")
+            else:
+                print("Timed out")
+
+    asyncio.run(main())
+
+The method accepts the same ``timeout`` and ``esc_delay`` parameters as
+:meth:`~.Terminal.inkey`.  It must be called within a :meth:`~.Terminal.cbreak`
+or :meth:`~.Terminal.raw` context.
+
+For a complete example using ``async_inkey`` with the :doc:`line_editor`, see
+:ref:`line_editor`.

--- a/docs/line_editor.rst
+++ b/docs/line_editor.rst
@@ -9,19 +9,25 @@ movement, auto-suggest from history, password masking, and horizontal scrolling.
 
 .. note::
 
-   The editor is entirely headless — it does not write to the terminal.
+   The editor never writes to the terminal directly — your application
+   controls when and where output appears.
 
-   Your application must read :attr:`~blessed.line_editor.LineEditor.display`
-   and render the text, cursor, and suggestion itself, as shown in the
-   example below.
+   Use the built-in :ref:`render methods <line_editor_render>` to produce
+   ready-to-print escape sequences, or read
+   :attr:`~blessed.line_editor.LineEditor.display` for raw display state
+   if you need fully custom rendering.
 
 Overview
 --------
 
 Feed keystrokes (from :meth:`~.Terminal.inkey` or :meth:`~.Terminal.async_inkey`) into
 :meth:`~blessed.line_editor.LineEditor.feed_key`.  It returns a
-:class:`~blessed.line_editor.LineEditResult` telling you whether the line was accepted,
-an interrupt or EOF occurred, or the display changed.
+:class:`~blessed.line_editor.LineEditResult` with these fields:
+
+- ``line`` — the accepted string when Enter is pressed, otherwise ``None``
+- ``interrupt`` / ``eof`` — ``True`` on Ctrl+C / Ctrl+D respectively
+- ``changed`` — ``True`` when the display needs redrawing
+- ``bell`` — a bell string to emit (empty when silent)
 
 For bracketed paste, feed the pasted text through
 :meth:`~blessed.line_editor.LineEditor.insert_text` instead of
@@ -48,7 +54,8 @@ History
 History navigation (Up/Down) and auto-suggest (type a prefix, press Right to accept)
 are enabled automatically when a history instance is attached to the editor.
 
-For on-disk persistence, read/write the ``entries`` list directly.
+For on-disk persistence, read/write the ``entries`` list directly (most recent
+entry last).
 
 .. _line_editor_display:
 
@@ -59,8 +66,8 @@ Each call to :attr:`~blessed.line_editor.LineEditor.display` returns a
 :class:`~blessed.line_editor.DisplayState` with the visible text, cursor position,
 suggestion suffix, and clipping indicators.
 
-Override the default SGR styling with ``text_sgr``, ``suggestion_sgr``, ``bg_sgr``, or
-``ellipsis_sgr``::
+The editor ships with default SGR styling (light cream text, dark suggestion).
+Override with ``text_sgr``, ``suggestion_sgr``, ``bg_sgr``, or ``ellipsis_sgr``::
 
     editor = LineEditor(bg_sgr=term.on_brown, max_width=term.width)
 
@@ -90,6 +97,41 @@ build complete escape-sequence strings from the current display state:
 Try the fast-path first and fall back to ``render()`` when it returns
 ``None``.  See the :ref:`example above <line_editor>` for the complete
 pattern.
+
+.. _line_editor_other:
+
+Other Methods
+-------------
+
+:meth:`~blessed.line_editor.LineEditor.clear`
+   Reset the buffer, cursor, and undo history.
+
+:meth:`~blessed.line_editor.LineEditor.set_password_mode`
+   Toggle password masking on or off mid-session.
+
+.. _line_editor_constructor:
+
+Constructor Options
+-------------------
+
+Beyond the styling and keybinding options shown above, :class:`~blessed.line_editor.LineEditor`
+accepts:
+
+``password``
+   If ``True``, start in password mode (characters are masked).  Toggle at
+   runtime with :meth:`~blessed.line_editor.LineEditor.set_password_mode`.
+
+``password_char``
+   Replacement character shown in password mode (default ``"⚻"``).
+
+``limit``
+   Maximum buffer length in characters (default 65536).
+
+``limit_bell``
+   Bell string emitted when the limit is reached (default ``"\\a"``).
+
+``scroll_jump``
+   Fraction of ``max_width`` to scroll when the cursor overflows (default 0.5).
 
 .. _line_editor_keybindings:
 

--- a/docs/line_editor.rst
+++ b/docs/line_editor.rst
@@ -1,0 +1,173 @@
+.. _line_editor:
+
+Line Editor
+===========
+
+The :mod:`blessed.line_editor` module provides :class:`~blessed.line_editor.LineEditor`,
+a headless single-line editor with readline-style keybindings, grapheme-aware cursor
+movement, auto-suggest from history, password masking, and horizontal scrolling.
+
+.. note::
+
+   The editor is entirely headless — it does not write to the terminal.
+
+   Your application must read :attr:`~blessed.line_editor.LineEditor.display`
+   and render the text, cursor, and suggestion itself, as shown in the
+   example below.
+
+Overview
+--------
+
+Feed keystrokes (from :meth:`~.Terminal.inkey` or :meth:`~.Terminal.async_inkey`) into
+:meth:`~blessed.line_editor.LineEditor.feed_key`.  It returns a
+:class:`~blessed.line_editor.LineEditResult` telling you whether the line was accepted,
+an interrupt or EOF occurred, or the display changed.
+
+For bracketed paste, feed the pasted text through
+:meth:`~blessed.line_editor.LineEditor.insert_text` instead of
+:meth:`~blessed.line_editor.LineEditor.feed_key`.
+
+For async usage, simply replace ``term.inkey()`` with ``await term.async_inkey()``.
+See :ref:`async_input` in the keyboard documentation for more on ``async_inkey``.
+
+Example
+-------
+
+A line editor with history, auto-suggest, password mode, and styled rendering:
+
+.. literalinclude:: ../bin/line_editor_form.py
+   :language: python
+   :linenos:
+
+.. _line_editor_history:
+
+History
+-------
+
+:class:`~blessed.line_editor.LineHistory` stores command history in memory.
+History navigation (Up/Down) and auto-suggest (type a prefix, press Right to accept)
+are enabled automatically when a history instance is attached to the editor.
+
+For on-disk persistence, read/write the ``entries`` list directly.
+
+.. _line_editor_display:
+
+Display State & Styling
+-----------------------
+
+Each call to :attr:`~blessed.line_editor.LineEditor.display` returns a
+:class:`~blessed.line_editor.DisplayState` with the visible text, cursor position,
+suggestion suffix, and clipping indicators.
+
+Override the default SGR styling with ``text_sgr``, ``suggestion_sgr``, ``bg_sgr``, or
+``ellipsis_sgr``::
+
+    editor = LineEditor(bg_sgr=term.on_brown, max_width=term.width)
+
+When ``max_width`` is set and text overflows, ``overflow_left`` and
+``overflow_right`` indicate which edges are truncated.  Use
+``ellipsis_sgr`` to style the overflow indicator.
+
+.. _line_editor_render:
+
+Rendering Helpers
+-----------------
+
+:class:`~blessed.line_editor.LineEditor` provides three render methods that
+build complete escape-sequence strings from the current display state:
+
+:meth:`~blessed.line_editor.LineEditor.render`
+   Full redraw — always produces correct output.
+
+:meth:`~blessed.line_editor.LineEditor.render_insert`
+   Fast-path after a character insert at end of buffer.  Returns ``None``
+   when a full redraw is needed instead.
+
+:meth:`~blessed.line_editor.LineEditor.render_backspace`
+   Fast-path after a backspace at end of buffer.  Returns ``None``
+   when a full redraw is needed instead.
+
+Try the fast-path first and fall back to ``render()`` when it returns
+``None``.  See the :ref:`example above <line_editor>` for the complete
+pattern.
+
+.. _line_editor_keybindings:
+
+Custom Keybindings
+------------------
+
+Pass a ``keymap`` dict to override or extend the default emacs/readline bindings.
+Keys are :class:`~.Keystroke` ``.name`` strings (e.g. ``"KEY_CTRL_K"``), values are
+callables accepting a :class:`~blessed.line_editor.LineEditor` and returning a
+:class:`~blessed.line_editor.LineEditResult`.
+
+Override an existing binding::
+
+    def my_enter(editor):
+        # custom accept logic
+        return LineEditResult(line=editor.line, changed=True)
+
+    editor = LineEditor(keymap={"KEY_ENTER": my_enter})
+
+Add a new binding::
+
+    def handle_f1(editor):
+        editor.insert_text("help!")
+        return LineEditResult(changed=True)
+
+    editor = LineEditor(keymap={"KEY_F1": handle_f1})
+
+Disable a binding by setting it to ``None``::
+
+    # Ctrl+C becomes a silent no-op instead of raising interrupt
+    editor = LineEditor(keymap={"KEY_CTRL_C": None})
+
+Default Keybindings
+-------------------
+
+These are the default emacs/readline bindings.  All can be overridden via ``keymap``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Key
+     - Action
+   * - Enter
+     - Accept line
+   * - Ctrl+C
+     - Cancel (interrupt)
+   * - Ctrl+D
+     - EOF on empty line, delete at cursor otherwise
+   * - Left, Ctrl+B
+     - Move cursor left
+   * - Right
+     - Accept auto-suggest at end, otherwise move right
+   * - Ctrl+F
+     - Move cursor right
+   * - Home, Ctrl+A
+     - Move to start of line
+   * - End, Ctrl+E
+     - Move to end of line
+   * - Shift+Left, Ctrl+Left
+     - Move word left
+   * - Shift+Right, Ctrl+Right
+     - Move word right
+   * - Backspace
+     - Delete character before cursor
+   * - Delete
+     - Delete character at cursor
+   * - Ctrl+K
+     - Kill to end of line
+   * - Ctrl+U
+     - Kill to start of line
+   * - Ctrl+W
+     - Kill word backward
+   * - Ctrl+Y
+     - Yank (paste from kill ring)
+   * - Up, Ctrl+P
+     - Previous history entry
+   * - Down, Ctrl+N
+     - Next history entry
+   * - Ctrl+Z
+     - Undo

--- a/tests/test_async_inkey.py
+++ b/tests/test_async_inkey.py
@@ -1,0 +1,295 @@
+"""Tests for async_inkey() and _async_read_byte()."""
+
+# std imports
+import os
+import sys
+import time
+import asyncio
+from unittest import mock
+
+# 3rd party
+import pytest
+
+# local
+from .conftest import IS_WINDOWS
+from .accessories import SEMAPHORE, TestTerminal, pty_test, as_subprocess, read_until_semaphore
+
+pytestmark = pytest.mark.skipif(IS_WINDOWS, reason="no pty on Windows")
+
+
+def test_async_read_byte_returns_data():
+    """_async_read_byte returns data written to pty."""
+    def child(term):
+        os.write(sys.__stdout__.fileno(), SEMAPHORE)
+        with term.cbreak():
+            loop = asyncio.new_event_loop()
+            try:
+                result = loop.run_until_complete(
+                    term._async_read_byte(loop, timeout=1.0))
+            finally:
+                loop.close()
+            assert result == b'x'
+            return b'OK'
+
+    def parent(master_fd):
+        read_until_semaphore(master_fd)
+        os.write(master_fd, b'x')
+
+    output = pty_test(child, parent, 'test_async_read_byte_returns_data')
+    assert output == 'OK'
+
+
+def test_async_read_byte_timeout_returns_none():
+    """_async_read_byte returns None on timeout."""
+    def child(term):
+        with term.cbreak():
+            loop = asyncio.new_event_loop()
+            try:
+                result = loop.run_until_complete(
+                    term._async_read_byte(loop, timeout=0.05))
+            finally:
+                loop.close()
+            assert result is None
+            return b'OK'
+
+    output = pty_test(child, test_name='test_async_read_byte_timeout_returns_none')
+    assert output == 'OK'
+
+
+def test_async_inkey_simple_keystroke():
+    """async_inkey resolves a simple keystroke."""
+    def child(term):
+        os.write(sys.__stdout__.fileno(), SEMAPHORE)
+        with term.cbreak():
+            loop = asyncio.new_event_loop()
+            try:
+                ks = loop.run_until_complete(
+                    term.async_inkey(timeout=1.0))
+            finally:
+                loop.close()
+            assert str(ks) == 'x'
+            assert not ks.is_sequence
+            return b'OK'
+
+    def parent(master_fd):
+        read_until_semaphore(master_fd)
+        os.write(master_fd, b'x')
+
+    output = pty_test(child, parent, 'test_async_inkey_simple_keystroke')
+    assert output == 'OK'
+
+
+def test_async_inkey_timeout_returns_empty():
+    """async_inkey returns empty Keystroke on timeout."""
+    def child(term):
+        with term.cbreak():
+            loop = asyncio.new_event_loop()
+            try:
+                ks = loop.run_until_complete(
+                    term.async_inkey(timeout=0.05))
+            finally:
+                loop.close()
+            assert str(ks) == ''
+            assert ks.code is None
+            assert ks.name is None
+            return b'OK'
+
+    output = pty_test(child, test_name='test_async_inkey_timeout_returns_empty')
+    assert output == 'OK'
+
+
+def test_async_inkey_mouse_x10():
+    """async_inkey decodes X10 mouse event with all bytes at once."""
+    def child(term):
+        os.write(sys.__stdout__.fileno(), SEMAPHORE)
+        with term.cbreak():
+            loop = asyncio.new_event_loop()
+            try:
+                ks = loop.run_until_complete(
+                    term.async_inkey(timeout=2.0))
+            finally:
+                loop.close()
+            assert ks.is_mouse
+            return b'OK'
+
+    def parent(master_fd):
+        read_until_semaphore(master_fd)
+        # X10 mouse: ESC [ M button_byte x_byte y_byte
+        os.write(master_fd, b'\x1b[M \x21\x21')
+
+    output = pty_test(child, parent, 'test_async_inkey_mouse_x10')
+    assert output == 'OK'
+
+
+def test_async_inkey_resize_event():
+    """async_inkey updates preferred_size_cache on in-band resize."""
+    def child(term):
+        os.write(sys.__stdout__.fileno(), SEMAPHORE)
+        # Enable in-band resize in the DEC mode cache
+        from blessed.terminal import _DecPrivateMode
+        term._dec_mode_cache[_DecPrivateMode.IN_BAND_WINDOW_RESIZE] = True
+        with term.cbreak():
+            loop = asyncio.new_event_loop()
+            try:
+                ks = loop.run_until_complete(
+                    term.async_inkey(timeout=2.0))
+            finally:
+                loop.close()
+            assert ks.name == 'RESIZE_EVENT'
+            assert term._preferred_size_cache.ws_row == 24
+            assert term._preferred_size_cache.ws_col == 80
+            return b'OK'
+
+    def parent(master_fd):
+        read_until_semaphore(master_fd)
+        # DEC mode 2048: in-band resize: ESC[48;rows;cols;hpix;wpixt
+        os.write(master_fd, b'\x1b[48;24;80;480;1600t')
+
+    output = pty_test(child, parent, 'test_async_inkey_resize_event')
+    assert output == 'OK'
+
+
+def test_async_read_byte_oserror_propagates():
+    """OSError from os.read propagates through the future."""
+    @as_subprocess
+    def child():
+        term = TestTerminal()
+        term._keyboard_fd = 0
+
+        loop = asyncio.new_event_loop()
+        try:
+            original_add_reader = loop.add_reader
+
+            def mock_add_reader(fd, callback):
+                original_add_reader(fd, callback)
+                loop.call_soon(callback)
+
+            with mock.patch.object(loop, 'add_reader', side_effect=mock_add_reader):
+                with mock.patch('os.read', side_effect=OSError("mock read error")):
+                    with pytest.raises(OSError, match="mock read error"):
+                        loop.run_until_complete(
+                            term._async_read_byte(loop, timeout=1.0))
+        finally:
+            loop.close()
+
+    child()
+
+
+def test_async_read_byte_no_timeout():
+    """_async_read_byte with timeout=None waits indefinitely."""
+    def child(term):
+        os.write(sys.__stdout__.fileno(), SEMAPHORE)
+        with term.cbreak():
+            loop = asyncio.new_event_loop()
+            try:
+                result = loop.run_until_complete(
+                    term._async_read_byte(loop, timeout=None))
+            finally:
+                loop.close()
+            assert result == b'z'
+            return b'OK'
+
+    def parent(master_fd):
+        read_until_semaphore(master_fd)
+        time.sleep(0.05)
+        os.write(master_fd, b'z')
+
+    output = pty_test(child, parent, 'test_async_read_byte_no_timeout')
+    assert output == 'OK'
+
+
+def test_async_inkey_escape_key():
+    """async_inkey resolves bare escape after esc_delay."""
+    def child(term):
+        os.write(sys.__stdout__.fileno(), SEMAPHORE)
+        with term.cbreak():
+            loop = asyncio.new_event_loop()
+            try:
+                ks = loop.run_until_complete(
+                    term.async_inkey(timeout=2.0, esc_delay=0.05))
+            finally:
+                loop.close()
+            assert ks.name == 'KEY_ESCAPE'
+            assert len(ks) == 1
+            return b'OK'
+
+    def parent(master_fd):
+        read_until_semaphore(master_fd)
+        os.write(master_fd, b'\x1b')
+
+    output = pty_test(child, parent, 'test_async_inkey_escape_key')
+    assert output == 'OK'
+
+
+def test_async_inkey_arrow_key():
+    """async_inkey resolves multi-byte arrow key sequence."""
+    def child(term):
+        os.write(sys.__stdout__.fileno(), SEMAPHORE)
+        with term.cbreak():
+            loop = asyncio.new_event_loop()
+            try:
+                ks = loop.run_until_complete(
+                    term.async_inkey(timeout=2.0))
+            finally:
+                loop.close()
+            assert ks.name == 'KEY_UP'
+            assert ks.is_sequence
+            return b'OK'
+
+    def parent(master_fd):
+        read_until_semaphore(master_fd)
+        os.write(master_fd, b'\x1b[A')
+
+    output = pty_test(child, parent, 'test_async_inkey_arrow_key')
+    assert output == 'OK'
+
+
+def test_async_inkey_buffered_multi_byte():
+    """async_inkey resolves when multiple bytes arrive at once (kbhit drain)."""
+    def child(term):
+        os.write(sys.__stdout__.fileno(), SEMAPHORE)
+        with term.cbreak():
+            loop = asyncio.new_event_loop()
+            try:
+                ks = loop.run_until_complete(
+                    term.async_inkey(timeout=2.0))
+                assert str(ks) == 'x'
+                ks2 = loop.run_until_complete(
+                    term.async_inkey(timeout=0.5))
+                assert str(ks2) == 'y'
+            finally:
+                loop.close()
+            return b'OK'
+
+    def parent(master_fd):
+        read_until_semaphore(master_fd)
+        os.write(master_fd, b'xy')
+
+    output = pty_test(child, parent, 'test_async_inkey_buffered_multi_byte')
+    assert output == 'OK'
+
+
+def test_async_inkey_incomplete_csi_timeout():
+    """async_inkey times out mid-loop when CSI prefix arrives but no final byte."""
+    def child(term):
+        os.write(sys.__stdout__.fileno(), SEMAPHORE)
+        with term.cbreak():
+            loop = asyncio.new_event_loop()
+            try:
+                ks = loop.run_until_complete(
+                    term.async_inkey(timeout=0.3, esc_delay=0.05))
+            finally:
+                loop.close()
+            # partial CSI \x1b[ arrives, loop iterates reading bytes,
+            # then times out on next read — returns empty Keystroke
+            assert str(ks) == '' or ks.name is not None
+            return b'OK'
+
+    def parent(master_fd):
+        read_until_semaphore(master_fd)
+        time.sleep(0.05)
+        # Send CSI prefix without a final byte
+        os.write(master_fd, b'\x1b[')
+
+    output = pty_test(child, parent, 'test_async_inkey_incomplete_csi_timeout')
+    assert output == 'OK'

--- a/tests/test_async_inkey.py
+++ b/tests/test_async_inkey.py
@@ -293,3 +293,45 @@ def test_async_inkey_incomplete_csi_timeout():
 
     output = pty_test(child, parent, 'test_async_inkey_incomplete_csi_timeout')
     assert output == 'OK'
+
+
+def test_async_inkey_escape_then_arrow():
+    """async_inkey resolves escape + CSI sequence arriving byte-by-byte."""
+    def child(term):
+        os.write(sys.__stdout__.fileno(), SEMAPHORE)
+        with term.cbreak():
+            loop = asyncio.new_event_loop()
+            try:
+                ks = loop.run_until_complete(
+                    term.async_inkey(timeout=2.0, esc_delay=0.5))
+            finally:
+                loop.close()
+            assert ks.name == 'KEY_UP'
+            assert ks.is_sequence
+            return b'OK'
+
+    def parent(master_fd):
+        read_until_semaphore(master_fd)
+        os.write(master_fd, b'\x1b')
+        time.sleep(0.05)
+        os.write(master_fd, b'[A')
+
+    output = pty_test(child, parent, 'test_async_inkey_escape_then_arrow')
+    assert output == 'OK'
+
+
+def test_async_inkey_no_keyboard_fd():
+    """_async_read_byte raises RuntimeError without keyboard fd."""
+    @as_subprocess
+    def child():
+        term = TestTerminal()
+        term._keyboard_fd = None
+        loop = asyncio.new_event_loop()
+        try:
+            with pytest.raises(RuntimeError, match="keyboard file descriptor"):
+                loop.run_until_complete(
+                    term._async_read_byte(loop, timeout=1.0))
+        finally:
+            loop.close()
+
+    child()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -21,10 +21,10 @@ from .accessories import TestTerminal, unicode_cap, as_subprocess, pty_test
 
 
 def test_export_only_Terminal():
-    "Ensure only Terminal instance is exported for import * statements."
+    "Ensure only expected names are exported for import * statements."
     # local
     import blessed
-    assert blessed.__all__ == ('Terminal',)
+    assert blessed.__all__ == ('Terminal', 'LineEditor', 'LineHistory')
 
 
 def test_null_location(all_terms):

--- a/tests/test_line_editor.py
+++ b/tests/test_line_editor.py
@@ -1,32 +1,36 @@
 """Tests for blessed.line_editor."""
 
+# 3rd party
+import pytest
+from wcwidth import iter_graphemes, width as wcswidth
+
 # local
 from blessed.line_editor import PASSWORD_CHAR, LineEditor
 from blessed.line_editor import LineHistory as History
 from blessed.line_editor import (DisplayState,
                                  LineEditResult,
                                  _apply_hscroll)
-from wcwidth import iter_graphemes, width as wcswidth
 
 
-class MockTerminal:
+class MockTerminal:  # pylint: disable=too-few-public-methods
     """Minimal terminal stub for render method tests."""
 
     normal = "<NORMAL>"
 
     @staticmethod
     def move_yx(row: int, col: int) -> str:
+        """Return a position marker string."""
         return f"<MV:{row},{col}>"
 
 
 def _key(name: str) -> str:
     """Create a fake Keystroke-like object with a .name attribute."""
 
-    class FakeKey(str):
+    class FakeKey(str):  # pylint: disable=missing-class-docstring
         pass
 
     k = FakeKey("")
-    k.name = name  # type: ignore[attr-defined]
+    k.name = name  # type: ignore[attr-defined]  # pylint: disable=attribute-defined-outside-init
     return k  # type: ignore[return-value]
 
 
@@ -54,25 +58,32 @@ _CTRL_Z = _key("KEY_CTRL_Z")
 
 
 class TestGraphemeHelpers:
+    """Test grapheme splitting and display width helpers."""
+
     def test_graphemes_ascii(self) -> None:
+        """Test grapheme splitting of ASCII text."""
         assert list(iter_graphemes("hello")) == ["h", "e", "l", "l", "o"]
 
     def test_graphemes_emoji(self) -> None:
+        """Test grapheme splitting of emoji with ZWJ sequence."""
         result = list(iter_graphemes("\U0001f468\u200d\U0001f33e"))
         assert len(result) == 1
 
-    def test_display_width_ascii(self) -> None:
-        assert wcswidth("hello") == 5
-
-    def test_display_width_cjk(self) -> None:
-        assert wcswidth("\u4e16\u754c") == 4
-
-    def test_display_width_empty(self) -> None:
-        assert wcswidth("") == 0
+    @pytest.mark.parametrize("text,expected", [
+        ("hello", 5),
+        ("\u4e16\u754c", 4),
+        ("", 0),
+    ])
+    def test_display_width(self, text: str, expected: int) -> None:
+        """Test display width of various text inputs."""
+        assert wcswidth(text) == expected
 
 
 class TestLineEditResult:
+    """Test LineEditResult and DisplayState dataclasses."""
+
     def test_defaults(self) -> None:
+        """Test LineEditResult default field values."""
         r = LineEditResult()
         assert r.line is None
         assert r.eof is False
@@ -80,11 +91,13 @@ class TestLineEditResult:
         assert r.changed is False
 
     def test_accept(self) -> None:
+        """Test LineEditResult with accepted line and changed flag."""
         r = LineEditResult(line="hello", changed=True)
         assert r.line == "hello"
         assert r.changed is True
 
     def test_display_state_defaults(self) -> None:
+        """Test DisplayState default field values."""
         d = DisplayState()
         assert d.text == ""
         assert d.cursor == 0
@@ -92,18 +105,23 @@ class TestLineEditResult:
 
 
 class TestHistory:
+    """Test LineHistory add, search, and navigation."""
+
     def test_add_and_entries(self) -> None:
+        """Test adding entries to history."""
         h = History()
         h.add("alpha")
         h.add("bravo")
         assert h.entries == ["alpha", "bravo"]
 
     def test_add_skips_empty(self) -> None:
+        """Test that empty strings are not added to history."""
         h = History()
         h.add("")
-        assert h.entries == []
+        assert not h.entries
 
     def test_add_deduplicates_consecutive(self) -> None:
+        """Test that consecutive duplicate entries are deduplicated."""
         h = History()
         h.add("x")
         h.add("x")
@@ -112,12 +130,14 @@ class TestHistory:
         assert h.entries == ["x", "y"]
 
     def test_max_entries(self) -> None:
+        """Test that history respects max_entries limit."""
         h = History(max_entries=3)
         for i in range(5):
             h.add(str(i))
         assert h.entries == ["2", "3", "4"]
 
     def test_search_prefix(self) -> None:
+        """Test prefix search returns most recent match."""
         h = History()
         h.add("east")
         h.add("enter cave")
@@ -128,11 +148,13 @@ class TestHistory:
         assert h.search_prefix("") is None
 
     def test_search_prefix_skips_exact_match(self) -> None:
+        """Test prefix search skips exact match of query."""
         h = History()
         h.add("hello")
         assert h.search_prefix("hello") is None
 
     def test_nav_up_down(self) -> None:
+        """Test history navigation up and down through entries."""
         h = History()
         h.add("first")
         h.add("second")
@@ -145,13 +167,17 @@ class TestHistory:
         assert h.nav_down() is None
 
     def test_nav_empty_history(self) -> None:
+        """Test navigation returns None with empty history."""
         h = History()
         h.nav_start("")
         assert h.nav_up() is None
 
 
 class TestLineEditorBasicEditing:
+    """Test basic character insertion, deletion, and line submission."""
+
     def test_insert_chars(self) -> None:
+        """Test inserting characters into the buffer."""
         ed = LineEditor()
         ed.feed_key("h")
         ed.feed_key("i")
@@ -159,6 +185,7 @@ class TestLineEditorBasicEditing:
         assert ed.display.cursor == 2
 
     def test_enter_returns_line(self) -> None:
+        """Test enter key returns the current line."""
         ed = LineEditor()
         ed.feed_key("a")
         ed.feed_key("b")
@@ -168,11 +195,13 @@ class TestLineEditorBasicEditing:
         assert ed.line == ""
 
     def test_enter_empty_line(self) -> None:
+        """Test enter on empty buffer returns empty string."""
         ed = LineEditor()
         r = ed.feed_key(_ENTER)
         assert r.line == ""
 
     def test_backspace(self) -> None:
+        """Test backspace removes last character."""
         ed = LineEditor()
         ed.feed_key("a")
         ed.feed_key("b")
@@ -181,12 +210,8 @@ class TestLineEditorBasicEditing:
         assert r.changed is True
         assert ed.line == "ab"
 
-    def test_backspace_at_start(self) -> None:
-        ed = LineEditor()
-        r = ed.feed_key(_BACKSPACE)
-        assert r.changed is False
-
     def test_delete(self) -> None:
+        """Test delete removes character at cursor."""
         ed = LineEditor()
         ed.feed_key("a")
         ed.feed_key("b")
@@ -195,13 +220,8 @@ class TestLineEditorBasicEditing:
         assert r.changed is True
         assert ed.line == "b"
 
-    def test_delete_at_end(self) -> None:
-        ed = LineEditor()
-        ed.feed_key("x")
-        r = ed.feed_key(_DELETE)
-        assert r.changed is False
-
     def test_insert_text(self) -> None:
+        """Test bulk text insertion via insert_text."""
         ed = LineEditor()
         ed.feed_key("a")
         ed.insert_text("bcd")
@@ -209,6 +229,7 @@ class TestLineEditorBasicEditing:
         assert ed.display.cursor == 4
 
     def test_clear(self) -> None:
+        """Test clear resets buffer and cursor."""
         ed = LineEditor()
         ed.feed_key("h")
         ed.feed_key("i")
@@ -217,12 +238,14 @@ class TestLineEditorBasicEditing:
         assert ed.display.cursor == 0
 
     def test_unknown_key_unchanged(self) -> None:
+        """Test unrecognized key reports no change."""
         ed = LineEditor()
         r = ed.feed_key("\x00")
         assert r.changed is False
         assert r.line is None
 
     def test_ctrl_c_clears_and_interrupts(self) -> None:
+        """Test Ctrl-C clears buffer and sets interrupt flag."""
         ed = LineEditor()
         ed.feed_key("a")
         ed.feed_key("b")
@@ -232,11 +255,13 @@ class TestLineEditorBasicEditing:
         assert ed.line == ""
 
     def test_ctrl_d_eof_on_empty(self) -> None:
+        """Test Ctrl-D on empty buffer sets EOF flag."""
         ed = LineEditor()
         r = ed.feed_key(_CTRL_D)
         assert r.eof is True
 
     def test_ctrl_d_deletes_on_nonempty(self) -> None:
+        """Test Ctrl-D on non-empty buffer deletes character at cursor."""
         ed = LineEditor()
         ed.feed_key("a")
         ed.feed_key("b")
@@ -247,6 +272,7 @@ class TestLineEditorBasicEditing:
         assert ed.line == "b"
 
     def test_ctrl_d_single_undo(self) -> None:
+        """Test Ctrl-D delete pushes exactly one undo entry."""
         ed = LineEditor()
         ed.feed_key("a")
         ed.feed_key("b")
@@ -255,17 +281,20 @@ class TestLineEditorBasicEditing:
         ed.feed_key(_CTRL_D)
         assert len(ed._undo_stack) - before == 1
 
-    def test_feed_key_multi_grapheme_hits_limit_mid_insertion(self) -> None:
+    def test_feed_key_multi_grapheme_hits_limit(self) -> None:
+        """Test feed_key with multi-char string stops at limit."""
         ed = LineEditor(limit=2)
         ed.feed_key("abc")
         assert ed.line == "ab"
 
-    def test_insert_text_hits_limit_mid_insertion(self) -> None:
+    def test_insert_text_hits_limit(self) -> None:
+        """Test insert_text stops at character limit."""
         ed = LineEditor(limit=2)
         ed.insert_text("abc")
         assert ed.line == "ab"
 
     def test_insert_text_already_at_limit(self) -> None:
+        """Test insert_text when buffer is already at limit."""
         ed = LineEditor(limit=2)
         ed.feed_key("a")
         ed.feed_key("b")
@@ -273,28 +302,44 @@ class TestLineEditorBasicEditing:
         assert r.changed is False
         assert ed.line == "ab"
 
-    def test_insert_text_filters_control_chars(self) -> None:
+    @pytest.mark.parametrize("text,expected", [
+        ("a\x01b", "ab"),
+        ("", ""),
+        ("\x01\x02", ""),
+    ])
+    def test_insert_text_filtering(self, text: str, expected: str) -> None:
+        """Test insert_text filters control characters."""
         ed = LineEditor()
-        ed.insert_text("a\x01b")
-        assert ed.line == "ab"
+        ed.insert_text(text)
+        assert ed.line == expected
 
-    def test_insert_text_empty_string(self) -> None:
-        ed = LineEditor()
-        ed.feed_key("a")
-        r = ed.insert_text("")
-        assert r.changed is False
-        assert ed.line == "a"
 
-    def test_insert_text_only_control_chars(self) -> None:
-        ed = LineEditor()
-        ed.feed_key("a")
-        r = ed.insert_text("\x01\x02")
-        assert r.changed is False
-        assert ed.line == "a"
+@pytest.mark.parametrize("setup_text,key", [
+    ("", _BACKSPACE),
+    ("x", _DELETE),
+    ("", _LEFT),
+    ("", _WORD_LEFT),
+    ("x", _WORD_RIGHT),
+    ("", _HOME),
+    ("a", _END),
+    ("", _CTRL_Y),
+    ("", _CTRL_Z),
+    ("", _DOWN),
+])
+def test_no_change_boundary(setup_text: str, key: str) -> None:
+    """Test key at boundary reports changed=False."""
+    ed = LineEditor()
+    for ch in setup_text:
+        ed.feed_key(ch)
+    r = ed.feed_key(key)
+    assert r.changed is False
 
 
 class TestLineEditorCursorMovement:
+    """Test cursor movement keys and word navigation."""
+
     def test_left_right(self) -> None:
+        """Test left and right arrow cursor movement."""
         ed = LineEditor()
         ed.feed_key("a")
         ed.feed_key("b")
@@ -303,22 +348,27 @@ class TestLineEditorCursorMovement:
         ed.feed_key(_RIGHT)
         assert ed.display.cursor == 2
 
-    def test_left_at_start(self) -> None:
+    @pytest.mark.parametrize("key", [_HOME, _CTRL_A])
+    def test_home_keys(self, key: str) -> None:
+        """Test Home/Ctrl-A moves cursor to start."""
         ed = LineEditor()
-        r = ed.feed_key(_LEFT)
-        assert r.changed is False
-
-    def test_home_end(self) -> None:
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key("b")
-        ed.feed_key("c")
-        ed.feed_key(_HOME)
+        for ch in "abc":
+            ed.feed_key(ch)
+        ed.feed_key(key)
         assert ed.display.cursor == 0
-        ed.feed_key(_END)
+
+    @pytest.mark.parametrize("key", [_END, _CTRL_E])
+    def test_end_keys(self, key: str) -> None:
+        """Test End/Ctrl-E moves cursor to end."""
+        ed = LineEditor()
+        for ch in "abc":
+            ed.feed_key(ch)
+        ed.feed_key(_HOME)
+        ed.feed_key(key)
         assert ed.display.cursor == 3
 
     def test_word_left(self) -> None:
+        """Test word-left jumps to previous word boundary."""
         ed = LineEditor()
         for ch in "hello world":
             ed.feed_key(ch)
@@ -328,6 +378,7 @@ class TestLineEditorCursorMovement:
         assert ed._cursor == 0
 
     def test_word_right(self) -> None:
+        """Test word-right jumps to next word boundary."""
         ed = LineEditor()
         for ch in "hello world":
             ed.feed_key(ch)
@@ -337,18 +388,8 @@ class TestLineEditorCursorMovement:
         ed.feed_key(_WORD_RIGHT)
         assert ed._cursor == 11
 
-    def test_word_left_at_start(self) -> None:
-        ed = LineEditor()
-        r = ed.feed_key(_WORD_LEFT)
-        assert r.changed is False
-
-    def test_word_right_at_end(self) -> None:
-        ed = LineEditor()
-        ed.feed_key("x")
-        r = ed.feed_key(_WORD_RIGHT)
-        assert r.changed is False
-
     def test_insert_at_cursor(self) -> None:
+        """Test inserting a character at mid-buffer cursor position."""
         ed = LineEditor()
         for ch in "ac":
             ed.feed_key(ch)
@@ -357,42 +398,20 @@ class TestLineEditorCursorMovement:
         assert ed.line == "abc"
         assert ed.display.cursor == 2
 
-    def test_ctrl_a_moves_home(self) -> None:
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key("b")
-        ed.feed_key(_CTRL_A)
-        assert ed.display.cursor == 0
-
-    def test_ctrl_e_moves_end(self) -> None:
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key("b")
-        ed.feed_key(_HOME)
-        ed.feed_key(_CTRL_E)
-        assert ed.display.cursor == 2
-
-    def test_move_right_at_end(self) -> None:
+    def test_ctrl_f_at_end(self) -> None:
+        """Test Ctrl-F at end reports no change."""
         ed = LineEditor()
         ed.feed_key("a")
         ed.feed_key(_key("KEY_CTRL_F"))
         r = ed.feed_key(_key("KEY_CTRL_F"))
         assert r.changed is False
 
-    def test_home_already_at_start(self) -> None:
-        ed = LineEditor()
-        r = ed.feed_key(_HOME)
-        assert r.changed is False
-
-    def test_end_already_at_end(self) -> None:
-        ed = LineEditor()
-        ed.feed_key("a")
-        r = ed.feed_key(_END)
-        assert r.changed is False
-
 
 class TestLineEditorGraphemeEditing:
+    """Test editing operations on multi-codepoint grapheme clusters."""
+
     def test_backspace_emoji_with_skin_tone(self) -> None:
+        """Test backspace removes entire emoji with skin tone modifier."""
         ed = LineEditor()
         ed.feed_key("a")
         ed.feed_key("\U0001f44b\U0001f3fb")
@@ -402,18 +421,21 @@ class TestLineEditorGraphemeEditing:
         assert len(ed._buf) == 1
 
     def test_backspace_flag_emoji(self) -> None:
+        """Test backspace removes entire flag emoji."""
         ed = LineEditor()
         ed.feed_key("\U0001f1fa\U0001f1f8")
         ed.feed_key(_BACKSPACE)
         assert ed.line == ""
 
     def test_insert_text_grapheme_clusters(self) -> None:
+        """Test insert_text splits ZWJ sequences into grapheme clusters."""
         ed = LineEditor()
         ed.insert_text("a\U0001f468\u200d\U0001f33eb")
         assert len(ed._buf) == 3
         assert ed._buf[1] == "\U0001f468\u200d\U0001f33e"
 
     def test_cursor_movement_over_grapheme_clusters(self) -> None:
+        """Test cursor moves over grapheme clusters as single units."""
         ed = LineEditor()
         ed.feed_key("x")
         ed.feed_key("\U0001f44b\U0001f3fb")
@@ -425,6 +447,7 @@ class TestLineEditorGraphemeEditing:
         assert ed._cursor == 2
 
     def test_cjk_display_width(self) -> None:
+        """Test display width accounts for double-width CJK characters."""
         ed = LineEditor()
         ed.feed_key("\u4e16")
         ed.feed_key("\u754c")
@@ -432,6 +455,7 @@ class TestLineEditorGraphemeEditing:
         assert ed.display.text == "\u4e16\u754c"
 
     def test_cjk_cursor_after_left(self) -> None:
+        """Test cursor position after left over CJK character."""
         ed = LineEditor()
         ed.feed_key("\u4e16")
         ed.feed_key("\u754c")
@@ -439,6 +463,7 @@ class TestLineEditorGraphemeEditing:
         assert ed.display.cursor == 2
 
     def test_backspace_cjk(self) -> None:
+        """Test backspace removes a CJK character."""
         ed = LineEditor()
         ed.feed_key("\u4e16")
         ed.feed_key("\u754c")
@@ -448,7 +473,10 @@ class TestLineEditorGraphemeEditing:
 
 
 class TestLineEditorKillRing:
+    """Test kill, yank, and kill ring operations."""
+
     def test_kill_to_end(self) -> None:
+        """Test Ctrl-K removes text from cursor to end."""
         ed = LineEditor()
         for ch in "hello":
             ed.feed_key(ch)
@@ -460,6 +488,7 @@ class TestLineEditorKillRing:
         assert ed.line == "he"
 
     def test_kill_line(self) -> None:
+        """Test Ctrl-U removes text from start to cursor."""
         ed = LineEditor()
         for ch in "hello":
             ed.feed_key(ch)
@@ -471,6 +500,7 @@ class TestLineEditorKillRing:
         assert ed.display.cursor == 0
 
     def test_kill_word_back(self) -> None:
+        """Test Ctrl-W removes previous word."""
         ed = LineEditor()
         for ch in "hello world":
             ed.feed_key(ch)
@@ -479,6 +509,7 @@ class TestLineEditorKillRing:
         assert ed.line == "hello "
 
     def test_yank(self) -> None:
+        """Test Ctrl-Y yanks last killed text back."""
         ed = LineEditor()
         for ch in "hello world":
             ed.feed_key(ch)
@@ -486,18 +517,15 @@ class TestLineEditorKillRing:
         ed.feed_key(_CTRL_Y)
         assert ed.line == "hello world"
 
-    def test_yank_empty_ring(self) -> None:
-        ed = LineEditor()
-        r = ed.feed_key(_CTRL_Y)
-        assert r.changed is False
-
-    def test_kill_to_end_empty(self) -> None:
+    def test_kill_to_end_at_end(self) -> None:
+        """Test Ctrl-K at end of buffer reports no change."""
         ed = LineEditor()
         ed.feed_key("a")
         r = ed.feed_key(_CTRL_K)
         assert r.changed is False
 
     def test_kill_line_at_position_zero(self) -> None:
+        """Test Ctrl-U at position zero reports no change."""
         ed = LineEditor()
         ed.feed_key("a")
         ed.feed_key("b")
@@ -508,11 +536,13 @@ class TestLineEditorKillRing:
         assert len(ed._kill_ring) == 0
 
     def test_kill_line_empty_buffer(self) -> None:
+        """Test Ctrl-U on empty buffer reports no change."""
         ed = LineEditor()
         r = ed.feed_key(_CTRL_U)
         assert r.changed is False
 
     def test_kill_ring_capped_at_64(self) -> None:
+        """Test kill ring is capped at 64 entries."""
         ed = LineEditor()
         for i in range(70):
             ed.feed_key(str(i % 10))
@@ -521,6 +551,7 @@ class TestLineEditorKillRing:
         assert len(ed._kill_ring) == 64
 
     def test_kill_word_back_at_start(self) -> None:
+        """Test Ctrl-W at start reports no change."""
         ed = LineEditor()
         ed.feed_key("a")
         ed.feed_key(_HOME)
@@ -529,7 +560,10 @@ class TestLineEditorKillRing:
 
 
 class TestLineEditorUndo:
+    """Test undo for insert, backspace, delete, and kill operations."""
+
     def test_undo_insert(self) -> None:
+        """Test undo reverses character insertion."""
         ed = LineEditor()
         ed.feed_key("a")
         ed.feed_key("b")
@@ -538,42 +572,34 @@ class TestLineEditorUndo:
         ed.feed_key(_CTRL_Z)
         assert ed.line == ""
 
-    def test_undo_backspace(self) -> None:
+    @pytest.mark.parametrize("action_keys,mid_line,restored_line", [
+        (["a", "b", _BACKSPACE], "a", "ab"),
+        (list("hello") + [_CTRL_U], "", "hello"),
+        (["a", "b", _HOME, _DELETE], "b", "ab"),
+    ])
+    def test_undo_action(
+        self, action_keys: list, mid_line: str, restored_line: str
+    ) -> None:
+        """Test undo reverses backspace, kill, and delete operations."""
         ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key("b")
-        ed.feed_key(_BACKSPACE)
-        assert ed.line == "a"
+        for k in action_keys:
+            ed.feed_key(k)
+        assert ed.line == mid_line
         ed.feed_key(_CTRL_Z)
-        assert ed.line == "ab"
-
-    def test_undo_kill(self) -> None:
-        ed = LineEditor()
-        for ch in "hello":
-            ed.feed_key(ch)
-        ed.feed_key(_CTRL_U)
-        assert ed.line == ""
-        ed.feed_key(_CTRL_Z)
-        assert ed.line == "hello"
-
-    def test_undo_delete(self) -> None:
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key("b")
-        ed.feed_key(_HOME)
-        ed.feed_key(_DELETE)
-        assert ed.line == "b"
-        ed.feed_key(_CTRL_Z)
-        assert ed.line == "ab"
+        assert ed.line == restored_line
 
     def test_undo_empty_stack(self) -> None:
+        """Test undo with empty stack reports no change."""
         ed = LineEditor()
         r = ed.feed_key(_CTRL_Z)
         assert r.changed is False
 
 
 class TestLineEditorHistory:
+    """Test history navigation and submission within the editor."""
+
     def test_up_down(self) -> None:
+        """Test up and down keys navigate history entries."""
         h = History()
         h.add("alpha")
         h.add("bravo")
@@ -589,6 +615,7 @@ class TestLineEditorHistory:
         assert ed.line == "c"
 
     def test_up_at_top(self) -> None:
+        """Test up key at oldest entry reports no change."""
         h = History()
         h.add("only")
         ed = LineEditor(history=h)
@@ -597,12 +624,8 @@ class TestLineEditorHistory:
         r = ed.feed_key(_UP)
         assert r.changed is False
 
-    def test_down_without_history_browsing(self) -> None:
-        ed = LineEditor()
-        r = ed.feed_key(_DOWN)
-        assert r.changed is False
-
     def test_enter_adds_to_history(self) -> None:
+        """Test enter adds submitted line to history."""
         h = History()
         ed = LineEditor(history=h)
         ed.feed_key("x")
@@ -610,17 +633,21 @@ class TestLineEditorHistory:
         assert h.entries == ["x"]
 
     def test_enter_password_mode_skips_history(self) -> None:
+        """Test enter in password mode does not add to history."""
         h = History()
         ed = LineEditor(history=h, password=True)
         ed.feed_key("s")
         ed.feed_key("e")
         ed.feed_key("c")
         ed.feed_key(_ENTER)
-        assert h.entries == []
+        assert not h.entries
 
 
 class TestLineEditorAutoSuggest:
+    """Test auto-suggestion from history prefix matching."""
+
     def test_suggestion_from_history(self) -> None:
+        """Test suggestion shows completion from history match."""
         h = History()
         h.add("hello world")
         ed = LineEditor(history=h)
@@ -630,6 +657,7 @@ class TestLineEditorAutoSuggest:
         assert ds.suggestion == "llo world"
 
     def test_no_suggestion_mid_line(self) -> None:
+        """Test no suggestion when cursor is not at end."""
         h = History()
         h.add("hello world")
         ed = LineEditor(history=h)
@@ -639,6 +667,7 @@ class TestLineEditorAutoSuggest:
         assert ed.display.suggestion == ""
 
     def test_no_suggestion_password_mode(self) -> None:
+        """Test no suggestion in password mode."""
         h = History()
         h.add("secret123")
         ed = LineEditor(history=h, password=True)
@@ -646,6 +675,7 @@ class TestLineEditorAutoSuggest:
         assert ed.display.suggestion == ""
 
     def test_accept_suggestion_via_right(self) -> None:
+        """Test right arrow accepts the current suggestion."""
         h = History()
         h.add("hello world")
         ed = LineEditor(history=h)
@@ -655,6 +685,7 @@ class TestLineEditorAutoSuggest:
         assert ed.line == "hello world"
 
     def test_accept_suggestion_at_end_no_match(self) -> None:
+        """Test right arrow at end with no suggestion reports no change."""
         ed = LineEditor()
         for ch in "hello":
             ed.feed_key(ch)
@@ -663,6 +694,7 @@ class TestLineEditorAutoSuggest:
         assert ed.line == "hello"
 
     def test_accept_suggestion_mid_line(self) -> None:
+        """Test right arrow mid-line moves cursor without accepting."""
         h = History()
         h.add("hello world")
         ed = LineEditor(history=h)
@@ -676,7 +708,10 @@ class TestLineEditorAutoSuggest:
 
 
 class TestLineEditorPasswordMode:
+    """Test password mode display masking and behavior."""
+
     def test_masked_display(self) -> None:
+        """Test display text is masked with password character."""
         ed = LineEditor(password=True)
         ed.feed_key("a")
         ed.feed_key("b")
@@ -685,12 +720,14 @@ class TestLineEditorPasswordMode:
         assert ds.text == PASSWORD_CHAR * 3
 
     def test_set_password_mode(self) -> None:
+        """Test enabling password mode dynamically."""
         ed = LineEditor()
         ed.set_password_mode(True)
         ed.feed_key("x")
         assert ed.display.text == PASSWORD_CHAR
 
     def test_password_cursor_with_wide_char(self) -> None:
+        """Test cursor position with wide password character."""
         ed = LineEditor(password=True, password_char="\u4e16")
         ed.feed_key("a")
         ed.feed_key("b")
@@ -699,6 +736,7 @@ class TestLineEditorPasswordMode:
         assert wcswidth(ds.text) == 4
 
     def test_password_cursor_after_left(self) -> None:
+        """Test cursor position after left in password mode."""
         ed = LineEditor(password=True, password_char="\u4e16")
         ed.feed_key("a")
         ed.feed_key("b")
@@ -708,6 +746,7 @@ class TestLineEditorPasswordMode:
         assert ds.cursor == 4
 
     def test_password_enter_not_saved(self) -> None:
+        """Test enter in set_password_mode does not save to history."""
         h = History()
         ed = LineEditor(history=h)
         ed.set_password_mode(True)
@@ -715,11 +754,14 @@ class TestLineEditorPasswordMode:
         ed.feed_key("w")
         r = ed.feed_key(_ENTER)
         assert r.line == "pw"
-        assert h.entries == []
+        assert not h.entries
 
 
 class TestLineEditorKeymap:
+    """Test custom keymap bindings and overrides."""
+
     def test_custom_keymap_override(self) -> None:
+        """Test custom keymap overrides default key binding."""
         called = []
 
         def custom_handler(editor):
@@ -733,18 +775,20 @@ class TestLineEditorKeymap:
         assert ed.line == "a"
 
     def test_custom_keymap_adds_binding(self) -> None:
+        """Test custom keymap adds a new key binding."""
         called = []
 
         def custom_handler(editor):
             called.append(True)
             return LineEditResult()
 
-        _F1 = _key("KEY_F1")
+        f1 = _key("KEY_F1")
         ed = LineEditor(keymap={"KEY_F1": custom_handler})
-        ed.feed_key(_F1)
+        ed.feed_key(f1)
         assert called == [True]
 
     def test_custom_keymap_disable_binding(self) -> None:
+        """Test custom keymap disables a binding with None."""
         ed = LineEditor(keymap={"KEY_CTRL_C": None})
         ed.feed_key("a")
         r = ed.feed_key(_CTRL_C)
@@ -754,7 +798,10 @@ class TestLineEditorKeymap:
 
 
 class TestApplyHscroll:
+    """Test _apply_hscroll horizontal scrolling and clipping."""
+
     def test_no_scroll_needed(self) -> None:
+        """Test no scrolling when text fits within width."""
         ds = _apply_hscroll("hello", "", 5, 20)
         assert ds.text == "hello"
         assert ds.cursor == 5
@@ -763,6 +810,7 @@ class TestApplyHscroll:
         assert ds.overflow_right is False
 
     def test_text_with_suggestion_fits(self) -> None:
+        """Test text with suggestion fits within width."""
         ds = _apply_hscroll("he", "llo world", 2, 20)
         assert ds.text == "he"
         assert ds.suggestion == "llo world"
@@ -770,44 +818,63 @@ class TestApplyHscroll:
         assert ds.overflow_right is False
 
     def test_text_overflows_right(self) -> None:
+        """Test text exceeding width sets overflow_right flag."""
         ds = _apply_hscroll("abcdefghij", "", 3, 5)
         assert ds.overflow_right is True
         assert len(ds.text) <= 5
 
     def test_cursor_at_end_scrolls(self) -> None:
-        text = "a" * 30
-        ds = _apply_hscroll(text, "", 30, 10)
+        """Test cursor at end of long text sets overflow_left flag."""
+        ds = _apply_hscroll("a" * 30, "", 30, 10)
         assert ds.overflow_left is True
-        assert ds.cursor >= 0
-        assert ds.cursor <= 10
+        assert 0 <= ds.cursor <= 10
 
     def test_cursor_at_start_no_left_clip(self) -> None:
-        text = "a" * 30
-        ds = _apply_hscroll(text, "", 0, 10)
+        """Test cursor at start does not clip left side."""
+        ds = _apply_hscroll("a" * 30, "", 0, 10)
         assert ds.overflow_left is False
         assert ds.overflow_right is True
         assert ds.cursor == 0
 
     def test_suggestion_clipped(self) -> None:
+        """Test suggestion is clipped to fit within width."""
         ds = _apply_hscroll("ab", "cdefghijklmnop", 2, 8)
         assert ds.overflow_right is True
         total = wcswidth(ds.text) + wcswidth(ds.suggestion)
         assert total <= 8
 
     def test_custom_ellipsis(self) -> None:
+        """Test hscroll with custom ellipsis string."""
         ds = _apply_hscroll("a" * 20, "", 20, 10, ellipsis="...")
         assert ds.overflow_left is True
 
     def test_empty_text(self) -> None:
+        """Test hscroll with empty text string."""
         ds = _apply_hscroll("", "", 0, 10)
         assert ds.text == ""
         assert ds.cursor == 0
         assert ds.overflow_left is False
         assert ds.overflow_right is False
 
+    def test_explicit_scroll_offset(self) -> None:
+        """Test _apply_hscroll with explicit non-zero scroll offset."""
+        ds = _apply_hscroll("a" * 30, "", 25, 10, scroll_offset=20)
+        assert ds.overflow_left is True
+        assert ds.cursor == 25 - 20 + wcswidth("\u2026")
+
+    def test_scroll_offset_zero(self) -> None:
+        """Test _apply_hscroll with zero scroll offset."""
+        ds = _apply_hscroll("a" * 30, "", 3, 10, scroll_offset=0)
+        assert ds.overflow_left is False
+        assert ds.overflow_right is True
+        assert ds.cursor == 3
+
 
 class TestLineEditorMaxWidth:
+    """Test max_width field clipping and limit bell behavior."""
+
     def test_no_max_width_no_clipping(self) -> None:
+        """Test no clipping when max_width is not set."""
         ed = LineEditor()
         for ch in "hello world this is a long line":
             ed.feed_key(ch)
@@ -816,6 +883,7 @@ class TestLineEditorMaxWidth:
         assert ds.overflow_right is False
 
     def test_max_width_clips(self) -> None:
+        """Test display is clipped to max_width."""
         ed = LineEditor(max_width=10)
         for ch in "abcdefghijklmnop":
             ed.feed_key(ch)
@@ -825,6 +893,7 @@ class TestLineEditorMaxWidth:
         assert total <= 10
 
     def test_max_width_short_text_no_clip(self) -> None:
+        """Test short text within max_width is not clipped."""
         ed = LineEditor(max_width=20)
         for ch in "hi":
             ed.feed_key(ch)
@@ -834,6 +903,7 @@ class TestLineEditorMaxWidth:
         assert ds.text == "hi"
 
     def test_max_width_cursor_stays_visible(self) -> None:
+        """Test cursor stays within visible max_width region."""
         ed = LineEditor(max_width=10)
         for ch in "a" * 50:
             ed.feed_key(ch)
@@ -841,6 +911,7 @@ class TestLineEditorMaxWidth:
         assert 0 <= ds.cursor <= 10
 
     def test_max_width_home_shows_start(self) -> None:
+        """Test Home key scrolls view to show buffer start."""
         ed = LineEditor(max_width=10)
         for ch in "abcdefghijklmnop":
             ed.feed_key(ch)
@@ -850,6 +921,7 @@ class TestLineEditorMaxWidth:
         assert ds.cursor == 0
 
     def test_max_width_updated_dynamically(self) -> None:
+        """Test changing max_width dynamically updates display."""
         ed = LineEditor(max_width=5)
         for ch in "abcdefghij":
             ed.feed_key(ch)
@@ -859,6 +931,7 @@ class TestLineEditorMaxWidth:
         assert ds.overflow_left is False
 
     def test_max_width_password_mode(self) -> None:
+        """Test max_width clipping works in password mode."""
         ed = LineEditor(max_width=5, password=True)
         for ch in "abcdefghij":
             ed.feed_key(ch)
@@ -867,6 +940,7 @@ class TestLineEditorMaxWidth:
         assert wcswidth(ds.text) <= 5
 
     def test_limit_bell_fires_once_then_resets(self) -> None:
+        """Test bell fires once at limit and resets after backspace."""
         ed = LineEditor(limit=2)
         ed.feed_key("a")
         ed.feed_key("b")
@@ -880,6 +954,7 @@ class TestLineEditorMaxWidth:
         assert r.bell == "\a"
 
     def test_needs_hscroll_false_when_limit_fits(self) -> None:
+        """Test hscroll is disabled when limit fits within max_width."""
         ed = LineEditor(max_width=10, limit=5)
         assert ed._needs_hscroll() is False
         ds = ed.display
@@ -888,7 +963,10 @@ class TestLineEditorMaxWidth:
 
 
 class TestStatefulHScroll:
+    """Test stateful horizontal scroll offset tracking."""
+
     def test_no_scroll_while_inside_window(self) -> None:
+        """Test no scroll offset while text fits in window."""
         ed = LineEditor(max_width=20)
         for ch in "abcdef":
             ed.feed_key(ch)
@@ -898,6 +976,7 @@ class TestStatefulHScroll:
         assert ds.overflow_left is False
 
     def test_first_scroll_at_field_boundary(self) -> None:
+        """Test first scroll triggers at field width boundary."""
         ed = LineEditor(max_width=20)
         for ch in "a" * 19:
             ed.feed_key(ch)
@@ -909,7 +988,8 @@ class TestStatefulHScroll:
         assert ed._scroll_offset > 0
         assert ds.cursor < 15
 
-    def test_typing_across_full_width_then_jump(self) -> None:
+    def test_typing_across_full_width(self) -> None:
+        """Test cursor stays visible while typing past full width."""
         ed = LineEditor(max_width=40)
         for i in range(50):
             ed.feed_key(chr(ord("a") + (i % 26)))
@@ -918,6 +998,7 @@ class TestStatefulHScroll:
         assert 0 <= ds.cursor <= 40
 
     def test_scroll_left_on_home(self) -> None:
+        """Test Home key resets scroll offset to zero."""
         ed = LineEditor(max_width=20)
         for ch in "a" * 40:
             ed.feed_key(ch)
@@ -929,8 +1010,15 @@ class TestStatefulHScroll:
         assert ds.cursor == 0
         assert ds.overflow_left is False
 
-    def test_large_jump_fewer_scrolls(self) -> None:
-        ed = LineEditor(max_width=40, scroll_jump=0.75)
+    @pytest.mark.parametrize("jump,expect_fewer", [
+        (0.75, True),
+        (0.1, False),
+    ])
+    def test_scroll_jump_frequency(
+        self, jump: float, expect_fewer: bool
+    ) -> None:
+        """Test scroll_jump controls scroll event frequency."""
+        ed = LineEditor(max_width=40, scroll_jump=jump)
         scrolls = 0
         for ch in "a" * 80:
             old = ed._scroll_offset
@@ -938,20 +1026,13 @@ class TestStatefulHScroll:
             _ = ed.display
             if ed._scroll_offset != old:
                 scrolls += 1
-        assert scrolls < 5
-
-    def test_small_jump_more_scrolls(self) -> None:
-        ed = LineEditor(max_width=40, scroll_jump=0.1)
-        scrolls = 0
-        for ch in "a" * 80:
-            old = ed._scroll_offset
-            ed.feed_key(ch)
-            _ = ed.display
-            if ed._scroll_offset != old:
-                scrolls += 1
-        assert scrolls > 5
+        if expect_fewer:
+            assert scrolls < 5
+        else:
+            assert scrolls > 5
 
     def test_default_jump_makes_room(self) -> None:
+        """Test default scroll_jump places cursor away from edge."""
         ed = LineEditor(max_width=40)
         for ch in "a" * 40:
             ed.feed_key(ch)
@@ -960,6 +1041,7 @@ class TestStatefulHScroll:
         assert ds.cursor < 25
 
     def test_scroll_left_near_left_edge(self) -> None:
+        """Test scrolling left when cursor approaches left edge."""
         ed = LineEditor(max_width=20)
         for ch in "a" * 30:
             ed.feed_key(ch)
@@ -970,52 +1052,19 @@ class TestStatefulHScroll:
         _ = ed.display
         assert ed._scroll_offset < right_offset
 
-    def test_apply_hscroll_with_explicit_scroll_offset(self) -> None:
-        ds = _apply_hscroll("a" * 30, "", 25, 10, scroll_offset=20)
-        assert ds.overflow_left is True
-        assert ds.cursor == 25 - 20 + wcswidth("\u2026")
-
-    def test_apply_hscroll_scroll_offset_zero(self) -> None:
-        ds = _apply_hscroll("a" * 30, "", 3, 10, scroll_offset=0)
-        assert ds.overflow_left is False
-        assert ds.overflow_right is True
-        assert ds.cursor == 3
-
-    def test_enter_resets_scroll_offset(self) -> None:
+    @pytest.mark.parametrize("reset_key", [_ENTER, _CTRL_C])
+    def test_key_resets_scroll_offset(self, reset_key: str) -> None:
+        """Test Enter/Ctrl-C resets scroll offset to zero."""
         ed = LineEditor(max_width=10)
         for ch in "a" * 20:
             ed.feed_key(ch)
         _ = ed.display
         assert ed._scroll_offset > 0
-        ed.feed_key(_ENTER)
+        ed.feed_key(reset_key)
         assert ed._scroll_offset == 0
-
-    def test_ctrl_c_resets_scroll_offset(self) -> None:
-        ed = LineEditor(max_width=10)
-        for ch in "a" * 20:
-            ed.feed_key(ch)
-        _ = ed.display
-        assert ed._scroll_offset > 0
-        ed.feed_key(_CTRL_C)
-        assert ed._scroll_offset == 0
-
-    def test_small_field_width_10(self) -> None:
-        ed = LineEditor(max_width=10)
-        for ch in "a" * 15:
-            ed.feed_key(ch)
-        ds = ed.display
-        assert 0 <= ds.cursor <= 10
-        assert ed._scroll_offset > 0
-
-    def test_password_mode_stateful_scroll(self) -> None:
-        ed = LineEditor(max_width=10, password=True)
-        for ch in "a" * 20:
-            ed.feed_key(ch)
-        ds = ed.display
-        assert ed._scroll_offset > 0
-        assert 0 <= ds.cursor <= 10
 
     def test_clear_resets_scroll_offset(self) -> None:
+        """Test clear resets scroll offset to zero."""
         ed = LineEditor(max_width=10)
         for ch in "a" * 30:
             ed.feed_key(ch)
@@ -1024,9 +1073,22 @@ class TestStatefulHScroll:
         ed.clear()
         assert ed._scroll_offset == 0
 
+    @pytest.mark.parametrize("password", [False, True])
+    def test_small_field_scrolls(self, password: bool) -> None:
+        """Test scrolling in a small 10-column field."""
+        ed = LineEditor(max_width=10, password=password)
+        for ch in "a" * 15:
+            ed.feed_key(ch)
+        ds = ed.display
+        assert 0 <= ds.cursor <= 10
+        assert ed._scroll_offset > 0
+
 
 class TestRender:
+    """Test render method output sequences."""
+
     def test_render_basic(self) -> None:
+        """Test render produces move, text, and normal sequences."""
         mt = MockTerminal()
         ed = LineEditor()
         for ch in "hello":
@@ -1038,6 +1100,7 @@ class TestRender:
         assert "<NORMAL>" in out
 
     def test_render_with_suggestion(self) -> None:
+        """Test render includes suggestion text with SGR styling."""
         mt = MockTerminal()
         h = History()
         h.add("hello world")
@@ -1050,6 +1113,7 @@ class TestRender:
         assert ed.suggestion_sgr in out
 
     def test_render_overflow_left_right(self) -> None:
+        """Test render shows ellipsis indicators on overflow."""
         mt = MockTerminal()
         ed = LineEditor(max_width=10)
         for ch in "abcdefghijklmnop":
@@ -1066,6 +1130,7 @@ class TestRender:
             assert ed.ellipsis in out
 
     def test_render_updates_prev_state(self) -> None:
+        """Test render updates previous state tracking fields."""
         mt = MockTerminal()
         ed = LineEditor()
         for ch in "abc":
@@ -1076,6 +1141,7 @@ class TestRender:
         assert ed._prev_overflow == (False, False)
 
     def test_render_padding(self) -> None:
+        """Test render pads remaining width with spaces."""
         mt = MockTerminal()
         ed = LineEditor()
         ed.feed_key("a")
@@ -1083,6 +1149,7 @@ class TestRender:
         assert " " * 9 in out
 
     def test_render_empty_text(self) -> None:
+        """Test render with empty buffer produces blank padding."""
         mt = MockTerminal()
         ed = LineEditor()
         out = ed.render(mt, 0, 10)
@@ -1091,7 +1158,10 @@ class TestRender:
 
 
 class TestRenderInsert:
+    """Test render_insert incremental rendering optimization."""
+
     def test_render_insert_at_end(self) -> None:
+        """Test render_insert produces output for append at end."""
         mt = MockTerminal()
         ed = LineEditor()
         for ch in "hel":
@@ -1103,6 +1173,7 @@ class TestRenderInsert:
         assert "l" in result
 
     def test_render_insert_mid_buffer_returns_none(self) -> None:
+        """Test render_insert returns None for mid-buffer insert."""
         mt = MockTerminal()
         ed = LineEditor()
         for ch in "abc":
@@ -1114,6 +1185,7 @@ class TestRenderInsert:
         assert result is None
 
     def test_render_insert_overflow_change_returns_none(self) -> None:
+        """Test render_insert returns None when overflow state changes."""
         mt = MockTerminal()
         ed = LineEditor(max_width=5)
         for ch in "abcd":
@@ -1124,7 +1196,8 @@ class TestRenderInsert:
         result = ed.render_insert(mt, 0, "f")
         assert result is None
 
-    def test_render_insert_returns_none_when_scroll_changes(self) -> None:
+    def test_render_insert_scroll_change_returns_none(self) -> None:
+        """Test render_insert returns None when scroll offset changes."""
         mt = MockTerminal()
         ed = LineEditor(max_width=10)
         for ch in "a" * 9:
@@ -1139,6 +1212,7 @@ class TestRenderInsert:
         assert result is None
 
     def test_render_insert_clears_stale_suggestion(self) -> None:
+        """Test render_insert clears previous suggestion text."""
         mt = MockTerminal()
         h = History()
         h.add("hello world")
@@ -1151,6 +1225,7 @@ class TestRenderInsert:
         assert result is not None
 
     def test_render_insert_updates_prev_state(self) -> None:
+        """Test render_insert updates previous state tracking fields."""
         mt = MockTerminal()
         ed = LineEditor()
         for ch in "ab":
@@ -1164,7 +1239,10 @@ class TestRenderInsert:
 
 
 class TestRenderBackspace:
+    """Test render_backspace incremental rendering optimization."""
+
     def test_render_backspace_at_end(self) -> None:
+        """Test render_backspace produces output for deletion at end."""
         mt = MockTerminal()
         ed = LineEditor()
         for ch in "abc":
@@ -1175,6 +1253,7 @@ class TestRenderBackspace:
         assert result is not None
 
     def test_render_backspace_mid_buffer_returns_none(self) -> None:
+        """Test render_backspace returns None for mid-buffer deletion."""
         mt = MockTerminal()
         ed = LineEditor()
         for ch in "abc":
@@ -1186,6 +1265,7 @@ class TestRenderBackspace:
         assert result is None
 
     def test_render_backspace_overflow_change_returns_none(self) -> None:
+        """Test render_backspace returns None on overflow state change."""
         mt = MockTerminal()
         ed = LineEditor(max_width=5)
         for ch in "abcdef":
@@ -1196,7 +1276,8 @@ class TestRenderBackspace:
         result = ed.render_backspace(mt, 0)
         assert result is None
 
-    def test_render_backspace_returns_none_when_scroll_changes(self) -> None:
+    def test_render_backspace_scroll_change_returns_none(self) -> None:
+        """Test render_backspace returns None when scroll changes."""
         mt = MockTerminal()
         ed = LineEditor(max_width=10)
         for ch in "a" * 20:
@@ -1211,6 +1292,7 @@ class TestRenderBackspace:
         assert result is None
 
     def test_render_backspace_erases_trailing(self) -> None:
+        """Test render_backspace erases trailing character with space."""
         mt = MockTerminal()
         ed = LineEditor()
         for ch in "abc":
@@ -1222,6 +1304,7 @@ class TestRenderBackspace:
         assert " " in result
 
     def test_render_backspace_updates_prev_state(self) -> None:
+        """Test render_backspace updates previous state tracking."""
         mt = MockTerminal()
         ed = LineEditor()
         for ch in "abc":
@@ -1234,6 +1317,7 @@ class TestRenderBackspace:
         assert ed._prev_overflow == (False, False)
 
     def test_render_backspace_with_suggestion(self) -> None:
+        """Test render_backspace redraws updated suggestion."""
         mt = MockTerminal()
         h = History()
         h.add("hello world")

--- a/tests/test_line_editor.py
+++ b/tests/test_line_editor.py
@@ -1237,6 +1237,22 @@ class TestRenderInsert:
         assert ed._prev_content_w == 3
         assert ed._prev_overflow == (False, False)
 
+    def test_render_insert_trailing_space_cleanup(self) -> None:
+        """render_insert pads with spaces when new content is narrower."""
+        mt = MockTerminal()
+        h = History()
+        h.add("hello")
+        ed = LineEditor(history=h)
+        for ch in "hel":
+            ed.feed_key(ch)
+        ed.render(mt, 0, 40)
+        prev_w = ed._prev_content_w
+        assert prev_w == 5
+        ed.feed_key("x")
+        result = ed.render_insert(mt, 0, "x")
+        assert result is not None
+        assert "x " in result
+
 
 class TestRenderBackspace:
     """Test render_backspace incremental rendering optimization."""

--- a/tests/test_line_editor.py
+++ b/tests/test_line_editor.py
@@ -1,4 +1,5 @@
 """Tests for blessed.line_editor."""
+# pylint: disable=too-many-positional-arguments
 
 # 3rd party
 import pytest

--- a/tests/test_line_editor.py
+++ b/tests/test_line_editor.py
@@ -1,10 +1,5 @@
 """Tests for blessed.line_editor."""
 
-# std imports
-import math
-import os
-import tempfile
-
 # local
 from blessed.line_editor import PASSWORD_CHAR, LineEditor
 from blessed.line_editor import LineHistory as History
@@ -12,6 +7,16 @@ from blessed.line_editor import (DisplayState,
                                  LineEditResult,
                                  _apply_hscroll)
 from wcwidth import iter_graphemes, width as wcswidth
+
+
+class MockTerminal:
+    """Minimal terminal stub for render method tests."""
+
+    normal = "<NORMAL>"
+
+    @staticmethod
+    def move_yx(row: int, col: int) -> str:
+        return f"<MV:{row},{col}>"
 
 
 def _key(name: str) -> str:
@@ -79,9 +84,7 @@ class TestLineEditResult:
         assert r.line == "hello"
         assert r.changed is True
 
-
-class TestDisplayState:
-    def test_defaults(self) -> None:
+    def test_display_state_defaults(self) -> None:
         d = DisplayState()
         assert d.text == ""
         assert d.cursor == 0
@@ -145,39 +148,6 @@ class TestHistory:
         h = History()
         h.nav_start("")
         assert h.nav_up() is None
-
-    def test_load_file(self) -> None:
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
-            f.write("alpha\nbravo\ncharlie\n")
-            f.flush()
-            path = f.name
-        try:
-            h = History()
-            h.load_file(path)
-            assert h.entries == ["alpha", "bravo", "charlie"]
-        finally:
-            os.unlink(path)
-
-    def test_load_file_missing(self) -> None:
-        h = History()
-        h.load_file("/nonexistent/path")
-        assert h.entries == []
-
-    def test_save_entry(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            path = os.path.join(tmpdir, "sub", "history.txt")
-            h = History()
-            h.save_entry("hello", path)
-            h.save_entry("world", path)
-            with open(path, "r") as f:
-                assert f.read() == "hello\nworld\n"
-
-    def test_save_entry_empty(self) -> None:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            path = os.path.join(tmpdir, "history.txt")
-            h = History()
-            h.save_entry("", path)
-            assert not os.path.exists(path)
 
 
 class TestLineEditorBasicEditing:
@@ -252,6 +222,53 @@ class TestLineEditorBasicEditing:
         assert r.changed is False
         assert r.line is None
 
+    def test_ctrl_c_clears_and_interrupts(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key("b")
+        r = ed.feed_key(_CTRL_C)
+        assert r.interrupt is True
+        assert r.changed is True
+        assert ed.line == ""
+
+    def test_ctrl_d_eof_on_empty(self) -> None:
+        ed = LineEditor()
+        r = ed.feed_key(_CTRL_D)
+        assert r.eof is True
+
+    def test_ctrl_d_deletes_on_nonempty(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ed.feed_key(_HOME)
+        r = ed.feed_key(_CTRL_D)
+        assert r.eof is False
+        assert r.changed is True
+        assert ed.line == "b"
+
+    def test_feed_key_multi_grapheme_hits_limit_mid_insertion(self) -> None:
+        ed = LineEditor(limit=2)
+        ed.feed_key("abc")
+        assert ed.line == "ab"
+
+    def test_insert_text_hits_limit_mid_insertion(self) -> None:
+        ed = LineEditor(limit=2)
+        ed.insert_text("abc")
+        assert ed.line == "ab"
+
+    def test_insert_text_already_at_limit(self) -> None:
+        ed = LineEditor(limit=2)
+        ed.feed_key("a")
+        ed.feed_key("b")
+        r = ed.insert_text("x")
+        assert r.changed is False
+        assert ed.line == "ab"
+
+    def test_insert_text_filters_control_chars(self) -> None:
+        ed = LineEditor()
+        ed.insert_text("a\x01b")
+        assert ed.line == "ab"
+
 
 class TestLineEditorCursorMovement:
     def test_left_right(self) -> None:
@@ -317,29 +334,38 @@ class TestLineEditorCursorMovement:
         assert ed.line == "abc"
         assert ed.display.cursor == 2
 
-
-class TestLineEditorCJK:
-    def test_cjkwcswidth(self) -> None:
+    def test_ctrl_a_moves_home(self) -> None:
         ed = LineEditor()
-        ed.feed_key("\u4e16")
-        ed.feed_key("\u754c")
-        assert ed.display.cursor == 4
-        assert ed.display.text == "\u4e16\u754c"
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ed.feed_key(_CTRL_A)
+        assert ed.display.cursor == 0
 
-    def test_cjk_cursor_after_left(self) -> None:
+    def test_ctrl_e_moves_end(self) -> None:
         ed = LineEditor()
-        ed.feed_key("\u4e16")
-        ed.feed_key("\u754c")
-        ed.feed_key(_LEFT)
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ed.feed_key(_HOME)
+        ed.feed_key(_CTRL_E)
         assert ed.display.cursor == 2
 
-    def test_backspace_cjk(self) -> None:
+    def test_move_right_at_end(self) -> None:
         ed = LineEditor()
-        ed.feed_key("\u4e16")
-        ed.feed_key("\u754c")
-        ed.feed_key(_BACKSPACE)
-        assert ed.line == "\u4e16"
-        assert ed.display.cursor == 2
+        ed.feed_key("a")
+        ed.feed_key(_key("KEY_CTRL_F"))
+        r = ed.feed_key(_key("KEY_CTRL_F"))
+        assert r.changed is False
+
+    def test_home_already_at_start(self) -> None:
+        ed = LineEditor()
+        r = ed.feed_key(_HOME)
+        assert r.changed is False
+
+    def test_end_already_at_end(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        r = ed.feed_key(_END)
+        assert r.changed is False
 
 
 class TestLineEditorGraphemeEditing:
@@ -374,6 +400,28 @@ class TestLineEditorGraphemeEditing:
         assert ed._cursor == 1
         ed.feed_key(_RIGHT)
         assert ed._cursor == 2
+
+    def test_cjk_display_width(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("\u4e16")
+        ed.feed_key("\u754c")
+        assert ed.display.cursor == 4
+        assert ed.display.text == "\u4e16\u754c"
+
+    def test_cjk_cursor_after_left(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("\u4e16")
+        ed.feed_key("\u754c")
+        ed.feed_key(_LEFT)
+        assert ed.display.cursor == 2
+
+    def test_backspace_cjk(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("\u4e16")
+        ed.feed_key("\u754c")
+        ed.feed_key(_BACKSPACE)
+        assert ed.line == "\u4e16"
+        assert ed.display.cursor == 2
 
 
 class TestLineEditorKillRing:
@@ -424,6 +472,27 @@ class TestLineEditorKillRing:
         ed = LineEditor()
         ed.feed_key("a")
         r = ed.feed_key(_CTRL_K)
+        assert r.changed is False
+
+    def test_kill_line_at_position_zero(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ed.feed_key(_HOME)
+        ed.feed_key(_CTRL_U)
+        assert ed.line == "ab"
+        assert ed._kill_ring == []
+
+    def test_kill_line_empty_buffer(self) -> None:
+        ed = LineEditor()
+        r = ed.feed_key(_CTRL_U)
+        assert r.changed is False
+
+    def test_kill_word_back_at_start(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key(_HOME)
+        r = ed.feed_key(_CTRL_W)
         assert r.changed is False
 
 
@@ -543,6 +612,26 @@ class TestLineEditorAutoSuggest:
         ed.feed_key(_RIGHT)
         assert ed.line == "hello world"
 
+    def test_accept_suggestion_at_end_no_match(self) -> None:
+        ed = LineEditor()
+        for ch in "hello":
+            ed.feed_key(ch)
+        r = ed.feed_key(_RIGHT)
+        assert r.changed is False
+        assert ed.line == "hello"
+
+    def test_accept_suggestion_mid_line(self) -> None:
+        h = History()
+        h.add("hello world")
+        ed = LineEditor(history=h)
+        for ch in "hello":
+            ed.feed_key(ch)
+        ed.feed_key(_LEFT)
+        r = ed.feed_key(_RIGHT)
+        assert r.changed is True
+        assert ed._cursor == 5
+        assert ed.line == "hello"
+
 
 class TestLineEditorPasswordMode:
     def test_masked_display(self) -> None:
@@ -570,47 +659,39 @@ class TestLineEditorPasswordMode:
         assert h.entries == []
 
 
-class TestLineEditorCtrlCD:
-    def test_ctrl_c_clears_and_interrupts(self) -> None:
-        ed = LineEditor()
+class TestLineEditorKeymap:
+    def test_custom_keymap_override(self) -> None:
+        called = []
+
+        def custom_handler(editor):
+            called.append(True)
+            return LineEditResult()
+
+        ed = LineEditor(keymap={"KEY_ENTER": custom_handler})
         ed.feed_key("a")
-        ed.feed_key("b")
+        ed.feed_key(_ENTER)
+        assert called == [True]
+        assert ed.line == "a"
+
+    def test_custom_keymap_adds_binding(self) -> None:
+        called = []
+
+        def custom_handler(editor):
+            called.append(True)
+            return LineEditResult()
+
+        _F1 = _key("KEY_F1")
+        ed = LineEditor(keymap={"KEY_F1": custom_handler})
+        ed.feed_key(_F1)
+        assert called == [True]
+
+    def test_custom_keymap_disable_binding(self) -> None:
+        ed = LineEditor(keymap={"KEY_CTRL_C": None})
+        ed.feed_key("a")
         r = ed.feed_key(_CTRL_C)
-        assert r.interrupt is True
-        assert r.changed is True
-        assert ed.line == ""
-
-    def test_ctrl_d_eof_on_empty(self) -> None:
-        ed = LineEditor()
-        r = ed.feed_key(_CTRL_D)
-        assert r.eof is True
-
-    def test_ctrl_d_deletes_on_nonempty(self) -> None:
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key("b")
-        ed.feed_key(_HOME)
-        r = ed.feed_key(_CTRL_D)
-        assert r.eof is False
-        assert r.changed is True
-        assert ed.line == "b"
-
-
-class TestLineEditorCtrlAE:
-    def test_ctrl_a_moves_home(self) -> None:
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key("b")
-        ed.feed_key(_CTRL_A)
-        assert ed.display.cursor == 0
-
-    def test_ctrl_e_moves_end(self) -> None:
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key("b")
-        ed.feed_key(_HOME)
-        ed.feed_key(_CTRL_E)
-        assert ed.display.cursor == 2
+        assert r.interrupt is False
+        assert r.changed is False
+        assert ed.line == "a"
 
 
 class TestApplyHscroll:
@@ -726,35 +807,6 @@ class TestLineEditorMaxWidth:
         assert PASSWORD_CHAR in ds.text
         assert wcswidth(ds.text) <= 5
 
-
-class TestLineEditorCoverage:
-    def test_load_file_truncates_to_max_entries(self) -> None:
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
-            f.write("one\ntwo\nthree\nfour\nfive\n")
-            f.flush()
-            path = f.name
-        try:
-            h = History(max_entries=3)
-            h.load_file(path)
-            assert h.entries == ["three", "four", "five"]
-        finally:
-            os.unlink(path)
-
-    def test_feed_key_multi_grapheme_hits_limit_mid_insertion(self) -> None:
-        ed = LineEditor(limit=2)
-        ed.feed_key("abc")
-        assert ed.line == "ab"
-
-    def test_insert_text_hits_limit_mid_insertion(self) -> None:
-        ed = LineEditor(limit=2)
-        ed.insert_text("abc")
-        assert ed.line == "ab"
-
-    def test_insert_text_filters_control_chars(self) -> None:
-        ed = LineEditor()
-        ed.insert_text("a\x01b")
-        assert ed.line == "ab"
-
     def test_limit_bell_fires_once_then_resets(self) -> None:
         ed = LineEditor(limit=2)
         ed.feed_key("a")
@@ -774,119 +826,6 @@ class TestLineEditorCoverage:
         ds = ed.display
         assert ds.overflow_left is False
         assert ds.overflow_right is False
-
-    def test_kill_line_at_position_zero(self) -> None:
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key("b")
-        ed.feed_key(_HOME)
-        ed.feed_key(_CTRL_U)
-        assert ed.line == "ab"
-        assert ed._kill_ring == []
-
-    def test_accept_suggestion_at_end_no_match(self) -> None:
-        ed = LineEditor()
-        for ch in "hello":
-            ed.feed_key(ch)
-        r = ed.feed_key(_RIGHT)
-        assert r.changed is False
-        assert ed.line == "hello"
-
-    def test_accept_suggestion_mid_line(self) -> None:
-        h = History()
-        h.add("hello world")
-        ed = LineEditor(history=h)
-        for ch in "hello":
-            ed.feed_key(ch)
-        ed.feed_key(_LEFT)
-        r = ed.feed_key(_RIGHT)
-        assert r.changed is True
-        assert ed._cursor == 5
-        assert ed.line == "hello"
-
-    def test_custom_keymap_override(self) -> None:
-        called = []
-
-        def custom_handler(editor):
-            called.append(True)
-            return LineEditResult()
-
-        ed = LineEditor(keymap={"KEY_ENTER": custom_handler})
-        ed.feed_key("a")
-        ed.feed_key(_ENTER)
-        assert called == [True]
-        assert ed.line == "a"
-
-    def test_custom_keymap_adds_binding(self) -> None:
-        called = []
-
-        def custom_handler(editor):
-            called.append(True)
-            return LineEditResult()
-
-        _F1 = _key("KEY_F1")
-        ed = LineEditor(keymap={"KEY_F1": custom_handler})
-        ed.feed_key(_F1)
-        assert called == [True]
-
-    def test_custom_keymap_disable_binding(self) -> None:
-        ed = LineEditor(keymap={"KEY_CTRL_C": None})
-        ed.feed_key("a")
-        r = ed.feed_key(_CTRL_C)
-        assert r.interrupt is False
-        assert r.changed is False
-        assert ed.line == "a"
-
-    def test_load_file_skips_blank_lines(self) -> None:
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
-            f.write("alpha\n\nbravo\n")
-            f.flush()
-            path = f.name
-        try:
-            h = History()
-            h.load_file(path)
-            assert h.entries == ["alpha", "bravo"]
-        finally:
-            os.unlink(path)
-
-    def test_clear_resets_scroll_offset(self) -> None:
-        ed = LineEditor(max_width=10)
-        for ch in "a" * 30:
-            ed.feed_key(ch)
-        _ = ed.display
-        assert ed._scroll_offset > 0
-        ed.clear()
-        assert ed._scroll_offset == 0
-
-    def test_move_right_at_end(self) -> None:
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key(_key("KEY_CTRL_F"))
-        r = ed.feed_key(_key("KEY_CTRL_F"))
-        assert r.changed is False
-
-    def test_home_already_at_start(self) -> None:
-        ed = LineEditor()
-        r = ed.feed_key(_HOME)
-        assert r.changed is False
-
-    def test_end_already_at_end(self) -> None:
-        ed = LineEditor()
-        ed.feed_key("a")
-        r = ed.feed_key(_END)
-        assert r.changed is False
-
-    def test_kill_line_empty_buffer(self) -> None:
-        ed = LineEditor()
-        r = ed.feed_key(_CTRL_U)
-        assert r.changed is False
-
-    def test_kill_word_back_at_start(self) -> None:
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key(_HOME)
-        r = ed.feed_key(_CTRL_W)
-        assert r.changed is False
 
 
 class TestStatefulHScroll:
@@ -1017,3 +956,205 @@ class TestStatefulHScroll:
         assert ed._scroll_offset > 0
         assert 0 <= ds.cursor <= 10
 
+    def test_clear_resets_scroll_offset(self) -> None:
+        ed = LineEditor(max_width=10)
+        for ch in "a" * 30:
+            ed.feed_key(ch)
+        _ = ed.display
+        assert ed._scroll_offset > 0
+        ed.clear()
+        assert ed._scroll_offset == 0
+
+
+class TestRender:
+    def test_render_basic(self) -> None:
+        mt = MockTerminal()
+        ed = LineEditor()
+        for ch in "hello":
+            ed.feed_key(ch)
+        out = ed.render(mt, 3, 40)
+        assert "<MV:3,0>" in out
+        assert "hello" in out
+        assert "<MV:3,5>" in out
+        assert "<NORMAL>" in out
+
+    def test_render_with_suggestion(self) -> None:
+        mt = MockTerminal()
+        h = History()
+        h.add("hello world")
+        ed = LineEditor(history=h)
+        for ch in "he":
+            ed.feed_key(ch)
+        out = ed.render(mt, 0, 40)
+        assert "he" in out
+        assert "llo world" in out
+        assert ed.suggestion_sgr in out
+
+    def test_render_overflow_left_right(self) -> None:
+        mt = MockTerminal()
+        ed = LineEditor(max_width=10)
+        for ch in "abcdefghijklmnop":
+            ed.feed_key(ch)
+        ed.feed_key(_HOME)
+        ed.feed_key(_RIGHT)
+        for ch in "xyz":
+            ed.feed_key(ch)
+        out = ed.render(mt, 0, 10)
+        ds = ed.display
+        if ds.overflow_left:
+            assert ed.ellipsis in out
+        if ds.overflow_right:
+            assert ed.ellipsis in out
+
+    def test_render_updates_prev_state(self) -> None:
+        mt = MockTerminal()
+        ed = LineEditor()
+        for ch in "abc":
+            ed.feed_key(ch)
+        ed.render(mt, 0, 40)
+        assert ed._prev_cursor == 3
+        assert ed._prev_content_w == 3
+        assert ed._prev_overflow == (False, False)
+
+    def test_render_padding(self) -> None:
+        mt = MockTerminal()
+        ed = LineEditor()
+        ed.feed_key("a")
+        out = ed.render(mt, 0, 10)
+        assert " " * 9 in out
+
+    def test_render_empty_text(self) -> None:
+        mt = MockTerminal()
+        ed = LineEditor()
+        out = ed.render(mt, 0, 10)
+        assert "<MV:0,0>" in out
+        assert " " * 10 in out
+
+
+class TestRenderInsert:
+    def test_render_insert_at_end(self) -> None:
+        mt = MockTerminal()
+        ed = LineEditor()
+        for ch in "hel":
+            ed.feed_key(ch)
+        ed.render(mt, 0, 40)
+        ed.feed_key("l")
+        result = ed.render_insert(mt, 0, "l")
+        assert result is not None
+        assert "l" in result
+
+    def test_render_insert_mid_buffer_returns_none(self) -> None:
+        mt = MockTerminal()
+        ed = LineEditor()
+        for ch in "abc":
+            ed.feed_key(ch)
+        ed.render(mt, 0, 40)
+        ed.feed_key(_LEFT)
+        ed.feed_key("x")
+        result = ed.render_insert(mt, 0, "x")
+        assert result is None
+
+    def test_render_insert_overflow_change_returns_none(self) -> None:
+        mt = MockTerminal()
+        ed = LineEditor(max_width=5)
+        for ch in "abcd":
+            ed.feed_key(ch)
+        ed.render(mt, 0, 5)
+        ed.feed_key("e")
+        ed.feed_key("f")
+        result = ed.render_insert(mt, 0, "f")
+        assert result is None
+
+    def test_render_insert_clears_stale_suggestion(self) -> None:
+        mt = MockTerminal()
+        h = History()
+        h.add("hello world")
+        ed = LineEditor(history=h)
+        for ch in "he":
+            ed.feed_key(ch)
+        ed.render(mt, 0, 40)
+        ed.feed_key("l")
+        result = ed.render_insert(mt, 0, "l")
+        assert result is not None
+
+    def test_render_insert_updates_prev_state(self) -> None:
+        mt = MockTerminal()
+        ed = LineEditor()
+        for ch in "ab":
+            ed.feed_key(ch)
+        ed.render(mt, 0, 40)
+        ed.feed_key("c")
+        ed.render_insert(mt, 0, "c")
+        assert ed._prev_cursor == 3
+        assert ed._prev_content_w == 3
+        assert ed._prev_overflow == (False, False)
+
+
+class TestRenderBackspace:
+    def test_render_backspace_at_end(self) -> None:
+        mt = MockTerminal()
+        ed = LineEditor()
+        for ch in "abc":
+            ed.feed_key(ch)
+        ed.render(mt, 0, 40)
+        ed.feed_key(_BACKSPACE)
+        result = ed.render_backspace(mt, 0)
+        assert result is not None
+
+    def test_render_backspace_mid_buffer_returns_none(self) -> None:
+        mt = MockTerminal()
+        ed = LineEditor()
+        for ch in "abc":
+            ed.feed_key(ch)
+        ed.render(mt, 0, 40)
+        ed.feed_key(_LEFT)
+        ed.feed_key(_BACKSPACE)
+        result = ed.render_backspace(mt, 0)
+        assert result is None
+
+    def test_render_backspace_overflow_change_returns_none(self) -> None:
+        mt = MockTerminal()
+        ed = LineEditor(max_width=5)
+        for ch in "abcdef":
+            ed.feed_key(ch)
+        ed.render(mt, 0, 5)
+        for _ in range(4):
+            ed.feed_key(_BACKSPACE)
+        result = ed.render_backspace(mt, 0)
+        assert result is None
+
+    def test_render_backspace_erases_trailing(self) -> None:
+        mt = MockTerminal()
+        ed = LineEditor()
+        for ch in "abc":
+            ed.feed_key(ch)
+        ed.render(mt, 0, 40)
+        ed.feed_key(_BACKSPACE)
+        result = ed.render_backspace(mt, 0)
+        assert result is not None
+        assert " " in result
+
+    def test_render_backspace_updates_prev_state(self) -> None:
+        mt = MockTerminal()
+        ed = LineEditor()
+        for ch in "abc":
+            ed.feed_key(ch)
+        ed.render(mt, 0, 40)
+        ed.feed_key(_BACKSPACE)
+        ed.render_backspace(mt, 0)
+        assert ed._prev_cursor == 2
+        assert ed._prev_content_w == 2
+        assert ed._prev_overflow == (False, False)
+
+    def test_render_backspace_with_suggestion(self) -> None:
+        mt = MockTerminal()
+        h = History()
+        h.add("hello world")
+        ed = LineEditor(history=h)
+        for ch in "hel":
+            ed.feed_key(ch)
+        ed.render(mt, 0, 40)
+        ed.feed_key(_BACKSPACE)
+        result = ed.render_backspace(mt, 0)
+        assert result is not None
+        assert ed.suggestion_sgr in result

--- a/tests/test_line_editor.py
+++ b/tests/test_line_editor.py
@@ -479,7 +479,8 @@ class TestLineEditorKillRing:
         ed.feed_key("a")
         ed.feed_key("b")
         ed.feed_key(_HOME)
-        ed.feed_key(_CTRL_U)
+        r = ed.feed_key(_CTRL_U)
+        assert r.changed is False
         assert ed.line == "ab"
         assert ed._kill_ring == []
 
@@ -523,6 +524,16 @@ class TestLineEditorUndo:
         assert ed.line == ""
         ed.feed_key(_CTRL_Z)
         assert ed.line == "hello"
+
+    def test_undo_delete(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ed.feed_key(_HOME)
+        ed.feed_key(_DELETE)
+        assert ed.line == "b"
+        ed.feed_key(_CTRL_Z)
+        assert ed.line == "ab"
 
     def test_undo_empty_stack(self) -> None:
         ed = LineEditor()

--- a/tests/test_line_editor.py
+++ b/tests/test_line_editor.py
@@ -1,20 +1,17 @@
 """Tests for blessed.line_editor."""
 
+# std imports
+import math
 import os
 import tempfile
 
-import pytest
-
-from blessed.line_editor import (
-    PASSWORD_CHAR,
-    DisplayState,
-    LineEditResult,
-    LineHistory as History,
-    LineEditor,
-    _apply_hscroll,
-    _display_width,
-    _graphemes,
-)
+# local
+from blessed.line_editor import PASSWORD_CHAR, LineEditor
+from blessed.line_editor import LineHistory as History
+from blessed.line_editor import (DisplayState,
+                                 LineEditResult,
+                                 _apply_hscroll)
+from wcwidth import iter_graphemes, width as wcswidth
 
 
 def _key(name: str) -> str:
@@ -53,20 +50,20 @@ _CTRL_Z = _key("KEY_CTRL_Z")
 
 class TestGraphemeHelpers:
     def test_graphemes_ascii(self) -> None:
-        assert _graphemes("hello") == ["h", "e", "l", "l", "o"]
+        assert list(iter_graphemes("hello")) == ["h", "e", "l", "l", "o"]
 
     def test_graphemes_emoji(self) -> None:
-        result = _graphemes("\U0001f468\u200d\U0001f33e")
+        result = list(iter_graphemes("\U0001f468\u200d\U0001f33e"))
         assert len(result) == 1
 
     def test_display_width_ascii(self) -> None:
-        assert _display_width("hello") == 5
+        assert wcswidth("hello") == 5
 
     def test_display_width_cjk(self) -> None:
-        assert _display_width("\u4e16\u754c") == 4
+        assert wcswidth("\u4e16\u754c") == 4
 
     def test_display_width_empty(self) -> None:
-        assert _display_width("") == 0
+        assert wcswidth("") == 0
 
 
 class TestLineEditResult:
@@ -322,7 +319,7 @@ class TestLineEditorCursorMovement:
 
 
 class TestLineEditorCJK:
-    def test_cjk_display_width(self) -> None:
+    def test_cjkwcswidth(self) -> None:
         ed = LineEditor()
         ed.feed_key("\u4e16")
         ed.feed_key("\u754c")
@@ -622,51 +619,51 @@ class TestApplyHscroll:
         assert ds.text == "hello"
         assert ds.cursor == 5
         assert ds.suggestion == ""
-        assert ds.clipped_left is False
-        assert ds.clipped_right is False
+        assert ds.overflow_left is False
+        assert ds.overflow_right is False
 
     def test_text_with_suggestion_fits(self) -> None:
         ds = _apply_hscroll("he", "llo world", 2, 20)
         assert ds.text == "he"
         assert ds.suggestion == "llo world"
-        assert ds.clipped_left is False
-        assert ds.clipped_right is False
+        assert ds.overflow_left is False
+        assert ds.overflow_right is False
 
     def test_text_overflows_right(self) -> None:
         ds = _apply_hscroll("abcdefghij", "", 3, 5)
-        assert ds.clipped_right is True
+        assert ds.overflow_right is True
         assert len(ds.text) <= 5
 
     def test_cursor_at_end_scrolls(self) -> None:
         text = "a" * 30
         ds = _apply_hscroll(text, "", 30, 10)
-        assert ds.clipped_left is True
+        assert ds.overflow_left is True
         assert ds.cursor >= 0
         assert ds.cursor <= 10
 
     def test_cursor_at_start_no_left_clip(self) -> None:
         text = "a" * 30
         ds = _apply_hscroll(text, "", 0, 10)
-        assert ds.clipped_left is False
-        assert ds.clipped_right is True
+        assert ds.overflow_left is False
+        assert ds.overflow_right is True
         assert ds.cursor == 0
 
     def test_suggestion_clipped(self) -> None:
         ds = _apply_hscroll("ab", "cdefghijklmnop", 2, 8)
-        assert ds.clipped_right is True
-        total = _display_width(ds.text) + _display_width(ds.suggestion)
+        assert ds.overflow_right is True
+        total = wcswidth(ds.text) + wcswidth(ds.suggestion)
         assert total <= 8
 
     def test_custom_ellipsis(self) -> None:
         ds = _apply_hscroll("a" * 20, "", 20, 10, ellipsis="...")
-        assert ds.clipped_left is True
+        assert ds.overflow_left is True
 
     def test_empty_text(self) -> None:
         ds = _apply_hscroll("", "", 0, 10)
         assert ds.text == ""
         assert ds.cursor == 0
-        assert ds.clipped_left is False
-        assert ds.clipped_right is False
+        assert ds.overflow_left is False
+        assert ds.overflow_right is False
 
 
 class TestLineEditorMaxWidth:
@@ -675,16 +672,16 @@ class TestLineEditorMaxWidth:
         for ch in "hello world this is a long line":
             ed.feed_key(ch)
         ds = ed.display
-        assert ds.clipped_left is False
-        assert ds.clipped_right is False
+        assert ds.overflow_left is False
+        assert ds.overflow_right is False
 
     def test_max_width_clips(self) -> None:
         ed = LineEditor(max_width=10)
         for ch in "abcdefghijklmnop":
             ed.feed_key(ch)
         ds = ed.display
-        assert ds.clipped_left is True
-        total = _display_width(ds.text) + _display_width(ds.suggestion)
+        assert ds.overflow_left is True
+        total = wcswidth(ds.text) + wcswidth(ds.suggestion)
         assert total <= 10
 
     def test_max_width_short_text_no_clip(self) -> None:
@@ -692,8 +689,8 @@ class TestLineEditorMaxWidth:
         for ch in "hi":
             ed.feed_key(ch)
         ds = ed.display
-        assert ds.clipped_left is False
-        assert ds.clipped_right is False
+        assert ds.overflow_left is False
+        assert ds.overflow_right is False
         assert ds.text == "hi"
 
     def test_max_width_cursor_stays_visible(self) -> None:
@@ -709,17 +706,17 @@ class TestLineEditorMaxWidth:
             ed.feed_key(ch)
         ed.feed_key(_HOME)
         ds = ed.display
-        assert ds.clipped_left is False
+        assert ds.overflow_left is False
         assert ds.cursor == 0
 
     def test_max_width_updated_dynamically(self) -> None:
         ed = LineEditor(max_width=5)
         for ch in "abcdefghij":
             ed.feed_key(ch)
-        assert ed.display.clipped_left is True
+        assert ed.display.overflow_left is True
         ed.max_width = 20
         ds = ed.display
-        assert ds.clipped_left is False
+        assert ds.overflow_left is False
 
     def test_max_width_password_mode(self) -> None:
         ed = LineEditor(max_width=5, is_password=lambda: True)
@@ -727,4 +724,296 @@ class TestLineEditorMaxWidth:
             ed.feed_key(ch)
         ds = ed.display
         assert PASSWORD_CHAR in ds.text
-        assert _display_width(ds.text) <= 5
+        assert wcswidth(ds.text) <= 5
+
+
+class TestLineEditorCoverage:
+    def test_load_file_truncates_to_max_entries(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("one\ntwo\nthree\nfour\nfive\n")
+            f.flush()
+            path = f.name
+        try:
+            h = History(max_entries=3)
+            h.load_file(path)
+            assert h.entries == ["three", "four", "five"]
+        finally:
+            os.unlink(path)
+
+    def test_feed_key_multi_grapheme_hits_limit_mid_insertion(self) -> None:
+        ed = LineEditor(limit=2)
+        ed.feed_key("abc")
+        assert ed.line == "ab"
+
+    def test_insert_text_hits_limit_mid_insertion(self) -> None:
+        ed = LineEditor(limit=2)
+        ed.insert_text("abc")
+        assert ed.line == "ab"
+
+    def test_insert_text_filters_control_chars(self) -> None:
+        ed = LineEditor()
+        ed.insert_text("a\x01b")
+        assert ed.line == "ab"
+
+    def test_limit_bell_fires_once_then_resets(self) -> None:
+        ed = LineEditor(limit=2)
+        ed.feed_key("a")
+        ed.feed_key("b")
+        r = ed.feed_key("c")
+        assert r.bell == "\a"
+        r = ed.feed_key("d")
+        assert r.bell == ""
+        ed.feed_key(_BACKSPACE)
+        r = ed.feed_key("x")
+        r = ed.feed_key("y")
+        assert r.bell == "\a"
+
+    def test_needs_hscroll_false_when_limit_fits(self) -> None:
+        ed = LineEditor(max_width=10, limit=5)
+        assert ed._needs_hscroll() is False
+        ds = ed.display
+        assert ds.overflow_left is False
+        assert ds.overflow_right is False
+
+    def test_kill_line_at_position_zero(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ed.feed_key(_HOME)
+        ed.feed_key(_CTRL_U)
+        assert ed.line == "ab"
+        assert ed._kill_ring == []
+
+    def test_accept_suggestion_at_end_no_match(self) -> None:
+        ed = LineEditor()
+        for ch in "hello":
+            ed.feed_key(ch)
+        r = ed.feed_key(_RIGHT)
+        assert r.changed is False
+        assert ed.line == "hello"
+
+    def test_accept_suggestion_mid_line(self) -> None:
+        h = History()
+        h.add("hello world")
+        ed = LineEditor(history=h)
+        for ch in "hello":
+            ed.feed_key(ch)
+        ed.feed_key(_LEFT)
+        r = ed.feed_key(_RIGHT)
+        assert r.changed is True
+        assert ed._cursor == 5
+        assert ed.line == "hello"
+
+    def test_custom_keymap_override(self) -> None:
+        called = []
+
+        def custom_handler(editor):
+            called.append(True)
+            return LineEditResult()
+
+        ed = LineEditor(keymap={"KEY_ENTER": custom_handler})
+        ed.feed_key("a")
+        ed.feed_key(_ENTER)
+        assert called == [True]
+        assert ed.line == "a"
+
+    def test_custom_keymap_adds_binding(self) -> None:
+        called = []
+
+        def custom_handler(editor):
+            called.append(True)
+            return LineEditResult()
+
+        _F1 = _key("KEY_F1")
+        ed = LineEditor(keymap={"KEY_F1": custom_handler})
+        ed.feed_key(_F1)
+        assert called == [True]
+
+    def test_custom_keymap_disable_binding(self) -> None:
+        ed = LineEditor(keymap={"KEY_CTRL_C": None})
+        ed.feed_key("a")
+        r = ed.feed_key(_CTRL_C)
+        assert r.interrupt is False
+        assert r.changed is False
+        assert ed.line == "a"
+
+    def test_load_file_skips_blank_lines(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("alpha\n\nbravo\n")
+            f.flush()
+            path = f.name
+        try:
+            h = History()
+            h.load_file(path)
+            assert h.entries == ["alpha", "bravo"]
+        finally:
+            os.unlink(path)
+
+    def test_clear_resets_scroll_offset(self) -> None:
+        ed = LineEditor(max_width=10)
+        for ch in "a" * 30:
+            ed.feed_key(ch)
+        _ = ed.display
+        assert ed._scroll_offset > 0
+        ed.clear()
+        assert ed._scroll_offset == 0
+
+    def test_move_right_at_end(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key(_key("KEY_CTRL_F"))
+        r = ed.feed_key(_key("KEY_CTRL_F"))
+        assert r.changed is False
+
+    def test_home_already_at_start(self) -> None:
+        ed = LineEditor()
+        r = ed.feed_key(_HOME)
+        assert r.changed is False
+
+    def test_end_already_at_end(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        r = ed.feed_key(_END)
+        assert r.changed is False
+
+    def test_kill_line_empty_buffer(self) -> None:
+        ed = LineEditor()
+        r = ed.feed_key(_CTRL_U)
+        assert r.changed is False
+
+    def test_kill_word_back_at_start(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key(_HOME)
+        r = ed.feed_key(_CTRL_W)
+        assert r.changed is False
+
+
+class TestStatefulHScroll:
+    def test_no_scroll_while_inside_window(self) -> None:
+        ed = LineEditor(max_width=20)
+        for ch in "abcdef":
+            ed.feed_key(ch)
+        ds = ed.display
+        assert ed._scroll_offset == 0
+        assert ds.cursor == 6
+        assert ds.overflow_left is False
+
+    def test_first_scroll_at_field_boundary(self) -> None:
+        ed = LineEditor(max_width=20)
+        for ch in "a" * 19:
+            ed.feed_key(ch)
+        ds = ed.display
+        assert ed._scroll_offset == 0
+        assert ds.cursor == 19
+        ed.feed_key("b")
+        ds = ed.display
+        assert ed._scroll_offset > 0
+        assert ds.cursor < 15
+
+    def test_typing_across_full_width_then_jump(self) -> None:
+        ed = LineEditor(max_width=40)
+        for i in range(50):
+            ed.feed_key(chr(ord("a") + (i % 26)))
+            ds = ed.display
+        assert ed._scroll_offset > 0
+        assert 0 <= ds.cursor <= 40
+
+    def test_scroll_left_on_home(self) -> None:
+        ed = LineEditor(max_width=20)
+        for ch in "a" * 40:
+            ed.feed_key(ch)
+        _ = ed.display
+        assert ed._scroll_offset > 0
+        ed.feed_key(_HOME)
+        ds = ed.display
+        assert ed._scroll_offset == 0
+        assert ds.cursor == 0
+        assert ds.overflow_left is False
+
+    def test_large_jump_fewer_scrolls(self) -> None:
+        ed = LineEditor(max_width=40, scroll_jump=0.75)
+        scrolls = 0
+        for ch in "a" * 80:
+            old = ed._scroll_offset
+            ed.feed_key(ch)
+            _ = ed.display
+            if ed._scroll_offset != old:
+                scrolls += 1
+        assert scrolls < 5
+
+    def test_small_jump_more_scrolls(self) -> None:
+        ed = LineEditor(max_width=40, scroll_jump=0.1)
+        scrolls = 0
+        for ch in "a" * 80:
+            old = ed._scroll_offset
+            ed.feed_key(ch)
+            _ = ed.display
+            if ed._scroll_offset != old:
+                scrolls += 1
+        assert scrolls > 5
+
+    def test_default_jump_makes_room(self) -> None:
+        ed = LineEditor(max_width=40)
+        for ch in "a" * 40:
+            ed.feed_key(ch)
+        ds = ed.display
+        assert ed._scroll_offset > 0
+        assert ds.cursor < 25
+
+    def test_scroll_left_near_left_edge(self) -> None:
+        ed = LineEditor(max_width=20)
+        for ch in "a" * 30:
+            ed.feed_key(ch)
+        _ = ed.display
+        right_offset = ed._scroll_offset
+        for _ in range(25):
+            ed.feed_key(_LEFT)
+        ds = ed.display
+        assert ed._scroll_offset < right_offset
+
+    def test_apply_hscroll_with_explicit_scroll_offset(self) -> None:
+        ds = _apply_hscroll("a" * 30, "", 25, 10, scroll_offset=20)
+        assert ds.overflow_left is True
+        assert ds.cursor == 25 - 20 + wcswidth("\u2026")
+
+    def test_apply_hscroll_scroll_offset_zero(self) -> None:
+        ds = _apply_hscroll("a" * 30, "", 3, 10, scroll_offset=0)
+        assert ds.overflow_left is False
+        assert ds.overflow_right is True
+        assert ds.cursor == 3
+
+    def test_enter_resets_scroll_offset(self) -> None:
+        ed = LineEditor(max_width=10)
+        for ch in "a" * 20:
+            ed.feed_key(ch)
+        _ = ed.display
+        assert ed._scroll_offset > 0
+        ed.feed_key(_ENTER)
+        assert ed._scroll_offset == 0
+
+    def test_ctrl_c_resets_scroll_offset(self) -> None:
+        ed = LineEditor(max_width=10)
+        for ch in "a" * 20:
+            ed.feed_key(ch)
+        _ = ed.display
+        assert ed._scroll_offset > 0
+        ed.feed_key(_CTRL_C)
+        assert ed._scroll_offset == 0
+
+    def test_small_field_width_10(self) -> None:
+        ed = LineEditor(max_width=10)
+        for ch in "a" * 15:
+            ed.feed_key(ch)
+        ds = ed.display
+        assert 0 <= ds.cursor <= 10
+        assert ed._scroll_offset > 0
+
+    def test_password_mode_stateful_scroll(self) -> None:
+        ed = LineEditor(max_width=10, is_password=lambda: True)
+        for ch in "a" * 20:
+            ed.feed_key(ch)
+        ds = ed.display
+        assert ed._scroll_offset > 0
+        assert 0 <= ds.cursor <= 10
+

--- a/tests/test_line_editor.py
+++ b/tests/test_line_editor.py
@@ -1,0 +1,615 @@
+"""Tests for blessed.line_editor."""
+
+import os
+import tempfile
+
+import pytest
+
+from blessed.line_editor import (
+    PASSWORD_CHAR,
+    DisplayState,
+    EditResult,
+    History,
+    LineEditor,
+    _display_width,
+    _graphemes,
+)
+
+
+def _key(name: str) -> str:
+    """Create a fake Keystroke-like object with a .name attribute."""
+
+    class FakeKey(str):
+        pass
+
+    k = FakeKey("")
+    k.name = name  # type: ignore[attr-defined]
+    return k  # type: ignore[return-value]
+
+
+# Shorthand aliases for common keys
+_ENTER = _key("KEY_ENTER")
+_BACKSPACE = _key("KEY_BACKSPACE")
+_DELETE = _key("KEY_DELETE")
+_LEFT = _key("KEY_LEFT")
+_RIGHT = _key("KEY_RIGHT")
+_HOME = _key("KEY_HOME")
+_END = _key("KEY_END")
+_UP = _key("KEY_UP")
+_DOWN = _key("KEY_DOWN")
+_WORD_LEFT = _key("KEY_SLEFT")
+_WORD_RIGHT = _key("KEY_SRIGHT")
+_CTRL_A = _key("KEY_CTRL_A")
+_CTRL_C = _key("KEY_CTRL_C")
+_CTRL_D = _key("KEY_CTRL_D")
+_CTRL_E = _key("KEY_CTRL_E")
+_CTRL_K = _key("KEY_CTRL_K")
+_CTRL_U = _key("KEY_CTRL_U")
+_CTRL_W = _key("KEY_CTRL_W")
+_CTRL_Y = _key("KEY_CTRL_Y")
+_CTRL_Z = _key("KEY_CTRL_Z")
+
+
+class TestGraphemeHelpers:
+    def test_graphemes_ascii(self) -> None:
+        assert _graphemes("hello") == ["h", "e", "l", "l", "o"]
+
+    def test_graphemes_emoji(self) -> None:
+        result = _graphemes("\U0001f468\u200d\U0001f33e")
+        assert len(result) == 1
+
+    def test_display_width_ascii(self) -> None:
+        assert _display_width("hello") == 5
+
+    def test_display_width_cjk(self) -> None:
+        assert _display_width("\u4e16\u754c") == 4
+
+    def test_display_width_empty(self) -> None:
+        assert _display_width("") == 0
+
+
+class TestEditResult:
+    def test_defaults(self) -> None:
+        r = EditResult()
+        assert r.line is None
+        assert r.eof is False
+        assert r.interrupt is False
+        assert r.changed is False
+
+    def test_accept(self) -> None:
+        r = EditResult(line="hello", changed=True)
+        assert r.line == "hello"
+        assert r.changed is True
+
+
+class TestDisplayState:
+    def test_defaults(self) -> None:
+        d = DisplayState()
+        assert d.text == ""
+        assert d.cursor == 0
+        assert d.suggestion == ""
+
+
+class TestHistory:
+    def test_add_and_entries(self) -> None:
+        h = History()
+        h.add("alpha")
+        h.add("bravo")
+        assert h.entries == ["alpha", "bravo"]
+
+    def test_add_skips_empty(self) -> None:
+        h = History()
+        h.add("")
+        assert h.entries == []
+
+    def test_add_deduplicates_consecutive(self) -> None:
+        h = History()
+        h.add("x")
+        h.add("x")
+        h.add("y")
+        h.add("y")
+        assert h.entries == ["x", "y"]
+
+    def test_max_entries(self) -> None:
+        h = History(max_entries=3)
+        for i in range(5):
+            h.add(str(i))
+        assert h.entries == ["2", "3", "4"]
+
+    def test_search_prefix(self) -> None:
+        h = History()
+        h.add("east")
+        h.add("enter cave")
+        h.add("eat bread")
+        assert h.search_prefix("ea") == "eat bread"
+        assert h.search_prefix("ent") == "enter cave"
+        assert h.search_prefix("xyz") is None
+        assert h.search_prefix("") is None
+
+    def test_search_prefix_skips_exact_match(self) -> None:
+        h = History()
+        h.add("hello")
+        assert h.search_prefix("hello") is None
+
+    def test_nav_up_down(self) -> None:
+        h = History()
+        h.add("first")
+        h.add("second")
+        h.nav_start("current")
+        assert h.nav_up() == "second"
+        assert h.nav_up() == "first"
+        assert h.nav_up() is None
+        assert h.nav_down() == "second"
+        assert h.nav_down() == "current"
+        assert h.nav_down() is None
+
+    def test_nav_empty_history(self) -> None:
+        h = History()
+        h.nav_start("")
+        assert h.nav_up() is None
+
+    def test_load_file(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("alpha\nbravo\ncharlie\n")
+            f.flush()
+            path = f.name
+        try:
+            h = History()
+            h.load_file(path)
+            assert h.entries == ["alpha", "bravo", "charlie"]
+        finally:
+            os.unlink(path)
+
+    def test_load_file_missing(self) -> None:
+        h = History()
+        h.load_file("/nonexistent/path")
+        assert h.entries == []
+
+    def test_save_entry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "sub", "history.txt")
+            h = History()
+            h.save_entry("hello", path)
+            h.save_entry("world", path)
+            with open(path, "r") as f:
+                assert f.read() == "hello\nworld\n"
+
+    def test_save_entry_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "history.txt")
+            h = History()
+            h.save_entry("", path)
+            assert not os.path.exists(path)
+
+
+class TestLineEditorBasicEditing:
+    def test_insert_chars(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("h")
+        ed.feed_key("i")
+        assert ed.line == "hi"
+        assert ed.display.cursor == 2
+
+    def test_enter_returns_line(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key("b")
+        r = ed.feed_key(_ENTER)
+        assert r.line == "ab"
+        assert r.changed is True
+        assert ed.line == ""
+
+    def test_enter_empty_line(self) -> None:
+        ed = LineEditor()
+        r = ed.feed_key(_ENTER)
+        assert r.line == ""
+
+    def test_backspace(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ed.feed_key("c")
+        r = ed.feed_key(_BACKSPACE)
+        assert r.changed is True
+        assert ed.line == "ab"
+
+    def test_backspace_at_start(self) -> None:
+        ed = LineEditor()
+        r = ed.feed_key(_BACKSPACE)
+        assert r.changed is False
+
+    def test_delete(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ed.feed_key(_HOME)
+        r = ed.feed_key(_DELETE)
+        assert r.changed is True
+        assert ed.line == "b"
+
+    def test_delete_at_end(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("x")
+        r = ed.feed_key(_DELETE)
+        assert r.changed is False
+
+    def test_insert_text(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.insert_text("bcd")
+        assert ed.line == "abcd"
+        assert ed.display.cursor == 4
+
+    def test_clear(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("h")
+        ed.feed_key("i")
+        ed.clear()
+        assert ed.line == ""
+        assert ed.display.cursor == 0
+
+    def test_unknown_key_unchanged(self) -> None:
+        ed = LineEditor()
+        r = ed.feed_key("\x00")
+        assert r.changed is False
+        assert r.line is None
+
+
+class TestLineEditorCursorMovement:
+    def test_left_right(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ed.feed_key(_LEFT)
+        assert ed.display.cursor == 1
+        ed.feed_key(_RIGHT)
+        assert ed.display.cursor == 2
+
+    def test_left_at_start(self) -> None:
+        ed = LineEditor()
+        r = ed.feed_key(_LEFT)
+        assert r.changed is False
+
+    def test_home_end(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ed.feed_key("c")
+        ed.feed_key(_HOME)
+        assert ed.display.cursor == 0
+        ed.feed_key(_END)
+        assert ed.display.cursor == 3
+
+    def test_word_left(self) -> None:
+        ed = LineEditor()
+        for ch in "hello world":
+            ed.feed_key(ch)
+        ed.feed_key(_WORD_LEFT)
+        assert ed.line[ed._cursor:] == "world"
+        ed.feed_key(_WORD_LEFT)
+        assert ed._cursor == 0
+
+    def test_word_right(self) -> None:
+        ed = LineEditor()
+        for ch in "hello world":
+            ed.feed_key(ch)
+        ed.feed_key(_HOME)
+        ed.feed_key(_WORD_RIGHT)
+        assert ed.line[:ed._cursor] == "hello"
+        ed.feed_key(_WORD_RIGHT)
+        assert ed._cursor == 11
+
+    def test_word_left_at_start(self) -> None:
+        ed = LineEditor()
+        r = ed.feed_key(_WORD_LEFT)
+        assert r.changed is False
+
+    def test_word_right_at_end(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("x")
+        r = ed.feed_key(_WORD_RIGHT)
+        assert r.changed is False
+
+    def test_insert_at_cursor(self) -> None:
+        ed = LineEditor()
+        for ch in "ac":
+            ed.feed_key(ch)
+        ed.feed_key(_LEFT)
+        ed.feed_key("b")
+        assert ed.line == "abc"
+        assert ed.display.cursor == 2
+
+
+class TestLineEditorCJK:
+    def test_cjk_display_width(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("\u4e16")
+        ed.feed_key("\u754c")
+        assert ed.display.cursor == 4
+        assert ed.display.text == "\u4e16\u754c"
+
+    def test_cjk_cursor_after_left(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("\u4e16")
+        ed.feed_key("\u754c")
+        ed.feed_key(_LEFT)
+        assert ed.display.cursor == 2
+
+    def test_backspace_cjk(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("\u4e16")
+        ed.feed_key("\u754c")
+        ed.feed_key(_BACKSPACE)
+        assert ed.line == "\u4e16"
+        assert ed.display.cursor == 2
+
+
+class TestLineEditorGraphemeEditing:
+    def test_backspace_emoji_with_skin_tone(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key("\U0001f44b\U0001f3fb")
+        assert len(ed._buf) == 2
+        ed.feed_key(_BACKSPACE)
+        assert ed.line == "a"
+        assert len(ed._buf) == 1
+
+    def test_backspace_flag_emoji(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("\U0001f1fa\U0001f1f8")
+        ed.feed_key(_BACKSPACE)
+        assert ed.line == ""
+
+    def test_insert_text_grapheme_clusters(self) -> None:
+        ed = LineEditor()
+        ed.insert_text("a\U0001f468\u200d\U0001f33eb")
+        assert len(ed._buf) == 3
+        assert ed._buf[1] == "\U0001f468\u200d\U0001f33e"
+
+    def test_cursor_movement_over_grapheme_clusters(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("x")
+        ed.feed_key("\U0001f44b\U0001f3fb")
+        ed.feed_key("y")
+        ed.feed_key(_LEFT)
+        ed.feed_key(_LEFT)
+        assert ed._cursor == 1
+        ed.feed_key(_RIGHT)
+        assert ed._cursor == 2
+
+
+class TestLineEditorKillRing:
+    def test_kill_to_end(self) -> None:
+        ed = LineEditor()
+        for ch in "hello":
+            ed.feed_key(ch)
+        ed.feed_key(_HOME)
+        ed.feed_key(_RIGHT)
+        ed.feed_key(_RIGHT)
+        r = ed.feed_key(_CTRL_K)
+        assert r.changed is True
+        assert ed.line == "he"
+
+    def test_kill_line(self) -> None:
+        ed = LineEditor()
+        for ch in "hello":
+            ed.feed_key(ch)
+        ed.feed_key(_LEFT)
+        ed.feed_key(_LEFT)
+        r = ed.feed_key(_CTRL_U)
+        assert r.changed is True
+        assert ed.line == "lo"
+        assert ed.display.cursor == 0
+
+    def test_kill_word_back(self) -> None:
+        ed = LineEditor()
+        for ch in "hello world":
+            ed.feed_key(ch)
+        r = ed.feed_key(_CTRL_W)
+        assert r.changed is True
+        assert ed.line == "hello "
+
+    def test_yank(self) -> None:
+        ed = LineEditor()
+        for ch in "hello world":
+            ed.feed_key(ch)
+        ed.feed_key(_CTRL_W)
+        ed.feed_key(_CTRL_Y)
+        assert ed.line == "hello world"
+
+    def test_yank_empty_ring(self) -> None:
+        ed = LineEditor()
+        r = ed.feed_key(_CTRL_Y)
+        assert r.changed is False
+
+    def test_kill_to_end_empty(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        r = ed.feed_key(_CTRL_K)
+        assert r.changed is False
+
+
+class TestLineEditorUndo:
+    def test_undo_insert(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ed.feed_key(_CTRL_Z)
+        assert ed.line == "a"
+        ed.feed_key(_CTRL_Z)
+        assert ed.line == ""
+
+    def test_undo_backspace(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ed.feed_key(_BACKSPACE)
+        assert ed.line == "a"
+        ed.feed_key(_CTRL_Z)
+        assert ed.line == "ab"
+
+    def test_undo_kill(self) -> None:
+        ed = LineEditor()
+        for ch in "hello":
+            ed.feed_key(ch)
+        ed.feed_key(_CTRL_U)
+        assert ed.line == ""
+        ed.feed_key(_CTRL_Z)
+        assert ed.line == "hello"
+
+    def test_undo_empty_stack(self) -> None:
+        ed = LineEditor()
+        r = ed.feed_key(_CTRL_Z)
+        assert r.changed is False
+
+
+class TestLineEditorHistory:
+    def test_up_down(self) -> None:
+        h = History()
+        h.add("alpha")
+        h.add("bravo")
+        ed = LineEditor(history=h)
+        ed.feed_key("c")
+        ed.feed_key(_UP)
+        assert ed.line == "bravo"
+        ed.feed_key(_UP)
+        assert ed.line == "alpha"
+        ed.feed_key(_DOWN)
+        assert ed.line == "bravo"
+        ed.feed_key(_DOWN)
+        assert ed.line == "c"
+
+    def test_up_at_top(self) -> None:
+        h = History()
+        h.add("only")
+        ed = LineEditor(history=h)
+        ed.feed_key(_UP)
+        assert ed.line == "only"
+        r = ed.feed_key(_UP)
+        assert r.changed is False
+
+    def test_down_without_history_browsing(self) -> None:
+        ed = LineEditor()
+        r = ed.feed_key(_DOWN)
+        assert r.changed is False
+
+    def test_enter_adds_to_history(self) -> None:
+        h = History()
+        ed = LineEditor(history=h)
+        ed.feed_key("x")
+        ed.feed_key(_ENTER)
+        assert h.entries == ["x"]
+
+    def test_enter_password_mode_skips_history(self) -> None:
+        h = History()
+        ed = LineEditor(history=h, is_password=lambda: True)
+        ed.feed_key("s")
+        ed.feed_key("e")
+        ed.feed_key("c")
+        ed.feed_key(_ENTER)
+        assert h.entries == []
+
+
+class TestLineEditorAutoSuggest:
+    def test_suggestion_from_history(self) -> None:
+        h = History()
+        h.add("hello world")
+        ed = LineEditor(history=h)
+        ed.feed_key("h")
+        ed.feed_key("e")
+        ds = ed.display
+        assert ds.suggestion == "llo world"
+
+    def test_no_suggestion_mid_line(self) -> None:
+        h = History()
+        h.add("hello world")
+        ed = LineEditor(history=h)
+        for ch in "hello":
+            ed.feed_key(ch)
+        ed.feed_key(_HOME)
+        assert ed.display.suggestion == ""
+
+    def test_no_suggestion_password_mode(self) -> None:
+        h = History()
+        h.add("secret123")
+        ed = LineEditor(history=h, is_password=lambda: True)
+        ed.feed_key("s")
+        assert ed.display.suggestion == ""
+
+    def test_accept_suggestion_via_right(self) -> None:
+        h = History()
+        h.add("hello world")
+        ed = LineEditor(history=h)
+        ed.feed_key("h")
+        ed.feed_key("e")
+        ed.feed_key(_RIGHT)
+        assert ed.line == "hello world"
+
+
+class TestLineEditorPasswordMode:
+    def test_masked_display(self) -> None:
+        ed = LineEditor(is_password=lambda: True)
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ed.feed_key("c")
+        ds = ed.display
+        assert ds.text == PASSWORD_CHAR * 3
+
+    def test_set_password_mode(self) -> None:
+        ed = LineEditor()
+        ed.set_password_mode(True)
+        ed.feed_key("x")
+        assert ed.display.text == PASSWORD_CHAR
+
+    def test_password_enter_not_saved(self) -> None:
+        h = History()
+        ed = LineEditor(history=h)
+        ed.set_password_mode(True)
+        ed.feed_key("p")
+        ed.feed_key("w")
+        r = ed.feed_key(_ENTER)
+        assert r.line == "pw"
+        assert h.entries == []
+
+
+class TestLineEditorCtrlCD:
+    def test_ctrl_c_clears_and_interrupts(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key("b")
+        r = ed.feed_key(_CTRL_C)
+        assert r.interrupt is True
+        assert r.changed is True
+        assert ed.line == ""
+
+    def test_ctrl_d_eof_on_empty(self) -> None:
+        ed = LineEditor()
+        r = ed.feed_key(_CTRL_D)
+        assert r.eof is True
+
+    def test_ctrl_d_deletes_on_nonempty(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ed.feed_key(_HOME)
+        r = ed.feed_key(_CTRL_D)
+        assert r.eof is False
+        assert r.changed is True
+        assert ed.line == "b"
+
+
+class TestLineEditorCtrlAE:
+    def test_ctrl_a_moves_home(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ed.feed_key(_CTRL_A)
+        assert ed.display.cursor == 0
+
+    def test_ctrl_e_moves_end(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ed.feed_key(_HOME)
+        ed.feed_key(_CTRL_E)
+        assert ed.display.cursor == 2

--- a/tests/test_line_editor.py
+++ b/tests/test_line_editor.py
@@ -56,6 +56,20 @@ _CTRL_W = _key("KEY_CTRL_W")
 _CTRL_Y = _key("KEY_CTRL_Y")
 _CTRL_Z = _key("KEY_CTRL_Z")
 
+_MT = MockTerminal()
+
+
+def _editor(*keys, **kwargs):
+    """Create a LineEditor, feed each key, return it."""
+    ed = LineEditor(**kwargs)
+    for k in keys:
+        if isinstance(k, str) and not hasattr(k, "name"):
+            for ch in k:
+                ed.feed_key(ch)
+        else:
+            ed.feed_key(k)
+    return ed
+
 
 class TestGraphemeHelpers:
     """Test grapheme splitting and display width helpers."""
@@ -178,17 +192,13 @@ class TestLineEditorBasicEditing:
 
     def test_insert_chars(self) -> None:
         """Test inserting characters into the buffer."""
-        ed = LineEditor()
-        ed.feed_key("h")
-        ed.feed_key("i")
+        ed = _editor("hi")
         assert ed.line == "hi"
         assert ed.display.cursor == 2
 
     def test_enter_returns_line(self) -> None:
         """Test enter key returns the current line."""
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key("b")
+        ed = _editor("ab")
         r = ed.feed_key(_ENTER)
         assert r.line == "ab"
         assert r.changed is True
@@ -196,108 +206,80 @@ class TestLineEditorBasicEditing:
 
     def test_enter_empty_line(self) -> None:
         """Test enter on empty buffer returns empty string."""
-        ed = LineEditor()
-        r = ed.feed_key(_ENTER)
+        r = _editor().feed_key(_ENTER)
         assert r.line == ""
 
     def test_backspace(self) -> None:
         """Test backspace removes last character."""
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key("b")
-        ed.feed_key("c")
+        ed = _editor("abc")
         r = ed.feed_key(_BACKSPACE)
         assert r.changed is True
         assert ed.line == "ab"
 
     def test_delete(self) -> None:
         """Test delete removes character at cursor."""
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key("b")
-        ed.feed_key(_HOME)
+        ed = _editor("ab", _HOME)
         r = ed.feed_key(_DELETE)
         assert r.changed is True
         assert ed.line == "b"
 
     def test_insert_text(self) -> None:
         """Test bulk text insertion via insert_text."""
-        ed = LineEditor()
-        ed.feed_key("a")
+        ed = _editor("a")
         ed.insert_text("bcd")
         assert ed.line == "abcd"
         assert ed.display.cursor == 4
 
     def test_clear(self) -> None:
         """Test clear resets buffer and cursor."""
-        ed = LineEditor()
-        ed.feed_key("h")
-        ed.feed_key("i")
+        ed = _editor("hi")
         ed.clear()
         assert ed.line == ""
         assert ed.display.cursor == 0
 
     def test_unknown_key_unchanged(self) -> None:
         """Test unrecognized key reports no change."""
-        ed = LineEditor()
-        r = ed.feed_key("\x00")
+        r = _editor().feed_key("\x00")
         assert r.changed is False
         assert r.line is None
 
     def test_ctrl_c_clears_and_interrupts(self) -> None:
         """Test Ctrl-C clears buffer and sets interrupt flag."""
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key("b")
+        ed = _editor("ab")
         r = ed.feed_key(_CTRL_C)
         assert r.interrupt is True
         assert r.changed is True
         assert ed.line == ""
 
-    def test_ctrl_d_eof_on_empty(self) -> None:
-        """Test Ctrl-D on empty buffer sets EOF flag."""
-        ed = LineEditor()
+    @pytest.mark.parametrize("setup,expected_eof,expected_line", [
+        ([], True, ""),
+        (["a", "b", _HOME], False, "b"),
+    ])
+    def test_ctrl_d_behavior(self, setup: list, expected_eof: bool,
+                             expected_line: str) -> None:
+        """Test Ctrl-D EOF on empty buffer, delete on non-empty."""
+        ed = _editor(*setup)
         r = ed.feed_key(_CTRL_D)
-        assert r.eof is True
-
-    def test_ctrl_d_deletes_on_nonempty(self) -> None:
-        """Test Ctrl-D on non-empty buffer deletes character at cursor."""
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key("b")
-        ed.feed_key(_HOME)
-        r = ed.feed_key(_CTRL_D)
-        assert r.eof is False
-        assert r.changed is True
-        assert ed.line == "b"
+        assert r.eof is expected_eof
+        assert ed.line == expected_line
 
     def test_ctrl_d_single_undo(self) -> None:
         """Test Ctrl-D delete pushes exactly one undo entry."""
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key("b")
-        ed.feed_key(_HOME)
+        ed = _editor("ab", _HOME)
         before = len(ed._undo_stack)
         ed.feed_key(_CTRL_D)
         assert len(ed._undo_stack) - before == 1
 
-    def test_feed_key_multi_grapheme_hits_limit(self) -> None:
-        """Test feed_key with multi-char string stops at limit."""
+    @pytest.mark.parametrize("method", ["feed_key", "insert_text"])
+    def test_insert_hits_limit(self, method: str) -> None:
+        """Test feed_key/insert_text stops at character limit."""
         ed = LineEditor(limit=2)
-        ed.feed_key("abc")
-        assert ed.line == "ab"
-
-    def test_insert_text_hits_limit(self) -> None:
-        """Test insert_text stops at character limit."""
-        ed = LineEditor(limit=2)
-        ed.insert_text("abc")
+        getattr(ed, method)("abc")
         assert ed.line == "ab"
 
     def test_insert_text_already_at_limit(self) -> None:
         """Test insert_text when buffer is already at limit."""
-        ed = LineEditor(limit=2)
-        ed.feed_key("a")
-        ed.feed_key("b")
+        ed = _editor("ab", limit=2)
         r = ed.insert_text("x")
         assert r.changed is False
         assert ed.line == "ab"
@@ -328,9 +310,7 @@ class TestLineEditorBasicEditing:
 ])
 def test_no_change_boundary(setup_text: str, key: str) -> None:
     """Test key at boundary reports changed=False."""
-    ed = LineEditor()
-    for ch in setup_text:
-        ed.feed_key(ch)
+    ed = _editor(setup_text) if setup_text else _editor()
     r = ed.feed_key(key)
     assert r.changed is False
 
@@ -340,10 +320,7 @@ class TestLineEditorCursorMovement:
 
     def test_left_right(self) -> None:
         """Test left and right arrow cursor movement."""
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key("b")
-        ed.feed_key(_LEFT)
+        ed = _editor("ab", _LEFT)
         assert ed.display.cursor == 1
         ed.feed_key(_RIGHT)
         assert ed.display.cursor == 2
@@ -351,58 +328,38 @@ class TestLineEditorCursorMovement:
     @pytest.mark.parametrize("key", [_HOME, _CTRL_A])
     def test_home_keys(self, key: str) -> None:
         """Test Home/Ctrl-A moves cursor to start."""
-        ed = LineEditor()
-        for ch in "abc":
-            ed.feed_key(ch)
-        ed.feed_key(key)
+        ed = _editor("abc", key)
         assert ed.display.cursor == 0
 
     @pytest.mark.parametrize("key", [_END, _CTRL_E])
     def test_end_keys(self, key: str) -> None:
         """Test End/Ctrl-E moves cursor to end."""
-        ed = LineEditor()
-        for ch in "abc":
-            ed.feed_key(ch)
-        ed.feed_key(_HOME)
-        ed.feed_key(key)
+        ed = _editor("abc", _HOME, key)
         assert ed.display.cursor == 3
 
     def test_word_left(self) -> None:
         """Test word-left jumps to previous word boundary."""
-        ed = LineEditor()
-        for ch in "hello world":
-            ed.feed_key(ch)
-        ed.feed_key(_WORD_LEFT)
+        ed = _editor("hello world", _WORD_LEFT)
         assert ed.line[ed._cursor:] == "world"
         ed.feed_key(_WORD_LEFT)
         assert ed._cursor == 0
 
     def test_word_right(self) -> None:
         """Test word-right jumps to next word boundary."""
-        ed = LineEditor()
-        for ch in "hello world":
-            ed.feed_key(ch)
-        ed.feed_key(_HOME)
-        ed.feed_key(_WORD_RIGHT)
+        ed = _editor("hello world", _HOME, _WORD_RIGHT)
         assert ed.line[:ed._cursor] == "hello"
         ed.feed_key(_WORD_RIGHT)
         assert ed._cursor == 11
 
     def test_insert_at_cursor(self) -> None:
         """Test inserting a character at mid-buffer cursor position."""
-        ed = LineEditor()
-        for ch in "ac":
-            ed.feed_key(ch)
-        ed.feed_key(_LEFT)
-        ed.feed_key("b")
+        ed = _editor("ac", _LEFT, "b")
         assert ed.line == "abc"
         assert ed.display.cursor == 2
 
     def test_ctrl_f_at_end(self) -> None:
         """Test Ctrl-F at end reports no change."""
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key(_key("KEY_CTRL_F"))
+        ed = _editor("a", _key("KEY_CTRL_F"))
         r = ed.feed_key(_key("KEY_CTRL_F"))
         assert r.changed is False
 
@@ -477,23 +434,14 @@ class TestLineEditorKillRing:
 
     def test_kill_to_end(self) -> None:
         """Test Ctrl-K removes text from cursor to end."""
-        ed = LineEditor()
-        for ch in "hello":
-            ed.feed_key(ch)
-        ed.feed_key(_HOME)
-        ed.feed_key(_RIGHT)
-        ed.feed_key(_RIGHT)
+        ed = _editor("hello", _HOME, _RIGHT, _RIGHT)
         r = ed.feed_key(_CTRL_K)
         assert r.changed is True
         assert ed.line == "he"
 
     def test_kill_line(self) -> None:
         """Test Ctrl-U removes text from start to cursor."""
-        ed = LineEditor()
-        for ch in "hello":
-            ed.feed_key(ch)
-        ed.feed_key(_LEFT)
-        ed.feed_key(_LEFT)
+        ed = _editor("hello", _LEFT, _LEFT)
         r = ed.feed_key(_CTRL_U)
         assert r.changed is True
         assert ed.line == "lo"
@@ -501,62 +449,45 @@ class TestLineEditorKillRing:
 
     def test_kill_word_back(self) -> None:
         """Test Ctrl-W removes previous word."""
-        ed = LineEditor()
-        for ch in "hello world":
-            ed.feed_key(ch)
+        ed = _editor("hello world")
         r = ed.feed_key(_CTRL_W)
         assert r.changed is True
         assert ed.line == "hello "
 
     def test_yank(self) -> None:
         """Test Ctrl-Y yanks last killed text back."""
-        ed = LineEditor()
-        for ch in "hello world":
-            ed.feed_key(ch)
-        ed.feed_key(_CTRL_W)
+        ed = _editor("hello world", _CTRL_W)
         ed.feed_key(_CTRL_Y)
         assert ed.line == "hello world"
 
-    def test_kill_to_end_at_end(self) -> None:
-        """Test Ctrl-K at end of buffer reports no change."""
-        ed = LineEditor()
-        ed.feed_key("a")
-        r = ed.feed_key(_CTRL_K)
-        assert r.changed is False
-
     def test_kill_line_at_position_zero(self) -> None:
         """Test Ctrl-U at position zero reports no change."""
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key("b")
-        ed.feed_key(_HOME)
+        ed = _editor("ab", _HOME)
         r = ed.feed_key(_CTRL_U)
         assert r.changed is False
         assert ed.line == "ab"
         assert len(ed._kill_ring) == 0
 
-    def test_kill_line_empty_buffer(self) -> None:
-        """Test Ctrl-U on empty buffer reports no change."""
-        ed = LineEditor()
-        r = ed.feed_key(_CTRL_U)
+    @pytest.mark.parametrize("setup,key", [
+        (["a"], _CTRL_K),
+        ([], _CTRL_U),
+        (["a", _HOME], _CTRL_W),
+    ])
+    def test_kill_no_change_at_boundary(self, setup: list,
+                                        key: str) -> None:
+        """Test kill ops at boundaries report no change."""
+        ed = _editor(*setup)
+        r = ed.feed_key(key)
         assert r.changed is False
 
     def test_kill_ring_capped_at_64(self) -> None:
         """Test kill ring is capped at 64 entries."""
-        ed = LineEditor()
+        ed = _editor()
         for i in range(70):
             ed.feed_key(str(i % 10))
             ed.feed_key(_CTRL_K)
             ed.feed_key(_HOME)
         assert len(ed._kill_ring) == 64
-
-    def test_kill_word_back_at_start(self) -> None:
-        """Test Ctrl-W at start reports no change."""
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key(_HOME)
-        r = ed.feed_key(_CTRL_W)
-        assert r.changed is False
 
 
 class TestLineEditorUndo:
@@ -564,10 +495,7 @@ class TestLineEditorUndo:
 
     def test_undo_insert(self) -> None:
         """Test undo reverses character insertion."""
-        ed = LineEditor()
-        ed.feed_key("a")
-        ed.feed_key("b")
-        ed.feed_key(_CTRL_Z)
+        ed = _editor("ab", _CTRL_Z)
         assert ed.line == "a"
         ed.feed_key(_CTRL_Z)
         assert ed.line == ""
@@ -581,17 +509,14 @@ class TestLineEditorUndo:
         self, action_keys: list, mid_line: str, restored_line: str
     ) -> None:
         """Test undo reverses backspace, kill, and delete operations."""
-        ed = LineEditor()
-        for k in action_keys:
-            ed.feed_key(k)
+        ed = _editor(*action_keys)
         assert ed.line == mid_line
         ed.feed_key(_CTRL_Z)
         assert ed.line == restored_line
 
     def test_undo_empty_stack(self) -> None:
         """Test undo with empty stack reports no change."""
-        ed = LineEditor()
-        r = ed.feed_key(_CTRL_Z)
+        r = _editor().feed_key(_CTRL_Z)
         assert r.changed is False
 
 
@@ -603,9 +528,7 @@ class TestLineEditorHistory:
         h = History()
         h.add("alpha")
         h.add("bravo")
-        ed = LineEditor(history=h)
-        ed.feed_key("c")
-        ed.feed_key(_UP)
+        ed = _editor("c", _UP, history=h)
         assert ed.line == "bravo"
         ed.feed_key(_UP)
         assert ed.line == "alpha"
@@ -618,8 +541,7 @@ class TestLineEditorHistory:
         """Test up key at oldest entry reports no change."""
         h = History()
         h.add("only")
-        ed = LineEditor(history=h)
-        ed.feed_key(_UP)
+        ed = _editor(_UP, history=h)
         assert ed.line == "only"
         r = ed.feed_key(_UP)
         assert r.changed is False
@@ -627,80 +549,56 @@ class TestLineEditorHistory:
     def test_enter_adds_to_history(self) -> None:
         """Test enter adds submitted line to history."""
         h = History()
-        ed = LineEditor(history=h)
-        ed.feed_key("x")
-        ed.feed_key(_ENTER)
+        _editor("x", _ENTER, history=h)
         assert h.entries == ["x"]
 
     def test_enter_password_mode_skips_history(self) -> None:
         """Test enter in password mode does not add to history."""
         h = History()
-        ed = LineEditor(history=h, password=True)
-        ed.feed_key("s")
-        ed.feed_key("e")
-        ed.feed_key("c")
-        ed.feed_key(_ENTER)
+        _editor("sec", _ENTER, history=h, password=True)
         assert not h.entries
 
 
 class TestLineEditorAutoSuggest:
     """Test auto-suggestion from history prefix matching."""
 
+    def _history(self, *entries):
+        h = History()
+        for e in entries:
+            h.add(e)
+        return h
+
     def test_suggestion_from_history(self) -> None:
         """Test suggestion shows completion from history match."""
-        h = History()
-        h.add("hello world")
-        ed = LineEditor(history=h)
-        ed.feed_key("h")
-        ed.feed_key("e")
+        ed = _editor("he", history=self._history("hello world"))
         ds = ed.display
         assert ds.suggestion == "llo world"
 
     def test_no_suggestion_mid_line(self) -> None:
         """Test no suggestion when cursor is not at end."""
-        h = History()
-        h.add("hello world")
-        ed = LineEditor(history=h)
-        for ch in "hello":
-            ed.feed_key(ch)
-        ed.feed_key(_HOME)
+        ed = _editor("hello", _HOME, history=self._history("hello world"))
         assert ed.display.suggestion == ""
 
     def test_no_suggestion_password_mode(self) -> None:
         """Test no suggestion in password mode."""
-        h = History()
-        h.add("secret123")
-        ed = LineEditor(history=h, password=True)
-        ed.feed_key("s")
+        ed = _editor("s", history=self._history("secret123"), password=True)
         assert ed.display.suggestion == ""
 
     def test_accept_suggestion_via_right(self) -> None:
         """Test right arrow accepts the current suggestion."""
-        h = History()
-        h.add("hello world")
-        ed = LineEditor(history=h)
-        ed.feed_key("h")
-        ed.feed_key("e")
-        ed.feed_key(_RIGHT)
+        ed = _editor("he", _RIGHT, history=self._history("hello world"))
         assert ed.line == "hello world"
 
     def test_accept_suggestion_at_end_no_match(self) -> None:
         """Test right arrow at end with no suggestion reports no change."""
-        ed = LineEditor()
-        for ch in "hello":
-            ed.feed_key(ch)
+        ed = _editor("hello")
         r = ed.feed_key(_RIGHT)
         assert r.changed is False
         assert ed.line == "hello"
 
     def test_accept_suggestion_mid_line(self) -> None:
         """Test right arrow mid-line moves cursor without accepting."""
-        h = History()
-        h.add("hello world")
-        ed = LineEditor(history=h)
-        for ch in "hello":
-            ed.feed_key(ch)
-        ed.feed_key(_LEFT)
+        ed = _editor("hello", _LEFT, history=self._history("hello world"))
         r = ed.feed_key(_RIGHT)
         assert r.changed is True
         assert ed._cursor == 5
@@ -712,10 +610,7 @@ class TestLineEditorPasswordMode:
 
     def test_masked_display(self) -> None:
         """Test display text is masked with password character."""
-        ed = LineEditor(password=True)
-        ed.feed_key("a")
-        ed.feed_key("b")
-        ed.feed_key("c")
+        ed = _editor("abc", password=True)
         ds = ed.display
         assert ds.text == PASSWORD_CHAR * 3
 
@@ -728,20 +623,14 @@ class TestLineEditorPasswordMode:
 
     def test_password_cursor_with_wide_char(self) -> None:
         """Test cursor position with wide password character."""
-        ed = LineEditor(password=True, password_char="\u4e16")
-        ed.feed_key("a")
-        ed.feed_key("b")
+        ed = _editor("ab", password=True, password_char="\u4e16")
         ds = ed.display
         assert ds.cursor == 4
         assert wcswidth(ds.text) == 4
 
     def test_password_cursor_after_left(self) -> None:
         """Test cursor position after left in password mode."""
-        ed = LineEditor(password=True, password_char="\u4e16")
-        ed.feed_key("a")
-        ed.feed_key("b")
-        ed.feed_key("c")
-        ed.feed_key(_LEFT)
+        ed = _editor("abc", _LEFT, password=True, password_char="\u4e16")
         ds = ed.display
         assert ds.cursor == 4
 
@@ -789,8 +678,7 @@ class TestLineEditorKeymap:
 
     def test_custom_keymap_disable_binding(self) -> None:
         """Test custom keymap disables a binding with None."""
-        ed = LineEditor(keymap={"KEY_CTRL_C": None})
-        ed.feed_key("a")
+        ed = _editor("a", keymap={"KEY_CTRL_C": None})
         r = ed.feed_key(_CTRL_C)
         assert r.interrupt is False
         assert r.changed is False
@@ -800,14 +688,18 @@ class TestLineEditorKeymap:
 class TestApplyHscroll:
     """Test _apply_hscroll horizontal scrolling and clipping."""
 
-    def test_no_scroll_needed(self) -> None:
-        """Test no scrolling when text fits within width."""
-        ds = _apply_hscroll("hello", "", 5, 20)
-        assert ds.text == "hello"
-        assert ds.cursor == 5
-        assert ds.suggestion == ""
-        assert ds.overflow_left is False
-        assert ds.overflow_right is False
+    @pytest.mark.parametrize("text,suggestion,cursor,width,exp_cursor,exp_left,exp_right", [
+        ("hello", "", 5, 20, 5, False, False),
+        ("", "", 0, 10, 0, False, False),
+        ("a" * 30, "", 0, 10, 0, False, True),
+    ])
+    def test_hscroll_basic(self, text, suggestion, cursor, width,
+                           exp_cursor, exp_left, exp_right) -> None:
+        """Test basic hscroll cursor and overflow results."""
+        ds = _apply_hscroll(text, suggestion, cursor, width)
+        assert ds.cursor == exp_cursor
+        assert ds.overflow_left is exp_left
+        assert ds.overflow_right is exp_right
 
     def test_text_with_suggestion_fits(self) -> None:
         """Test text with suggestion fits within width."""
@@ -817,24 +709,16 @@ class TestApplyHscroll:
         assert ds.overflow_left is False
         assert ds.overflow_right is False
 
-    def test_text_overflows_right(self) -> None:
-        """Test text exceeding width sets overflow_right flag."""
-        ds = _apply_hscroll("abcdefghij", "", 3, 5)
-        assert ds.overflow_right is True
-        assert len(ds.text) <= 5
-
-    def test_cursor_at_end_scrolls(self) -> None:
-        """Test cursor at end of long text sets overflow_left flag."""
-        ds = _apply_hscroll("a" * 30, "", 30, 10)
-        assert ds.overflow_left is True
-        assert 0 <= ds.cursor <= 10
-
-    def test_cursor_at_start_no_left_clip(self) -> None:
-        """Test cursor at start does not clip left side."""
-        ds = _apply_hscroll("a" * 30, "", 0, 10)
-        assert ds.overflow_left is False
-        assert ds.overflow_right is True
-        assert ds.cursor == 0
+    @pytest.mark.parametrize("text,cursor,width,exp_left,exp_right", [
+        ("abcdefghij", 3, 5, False, True),
+        ("a" * 30, 30, 10, True, False),
+    ])
+    def test_overflow_flags(self, text, cursor, width,
+                            exp_left, exp_right) -> None:
+        """Test overflow flags for text exceeding width."""
+        ds = _apply_hscroll(text, "", cursor, width)
+        assert ds.overflow_left is exp_left
+        assert ds.overflow_right is exp_right
 
     def test_suggestion_clipped(self) -> None:
         """Test suggestion is clipped to fit within width."""
@@ -847,14 +731,6 @@ class TestApplyHscroll:
         """Test hscroll with custom ellipsis string."""
         ds = _apply_hscroll("a" * 20, "", 20, 10, ellipsis="...")
         assert ds.overflow_left is True
-
-    def test_empty_text(self) -> None:
-        """Test hscroll with empty text string."""
-        ds = _apply_hscroll("", "", 0, 10)
-        assert ds.text == ""
-        assert ds.cursor == 0
-        assert ds.overflow_left is False
-        assert ds.overflow_right is False
 
     def test_explicit_scroll_offset(self) -> None:
         """Test _apply_hscroll with explicit non-zero scroll offset."""
@@ -873,58 +749,41 @@ class TestApplyHscroll:
 class TestLineEditorMaxWidth:
     """Test max_width field clipping and limit bell behavior."""
 
-    def test_no_max_width_no_clipping(self) -> None:
-        """Test no clipping when max_width is not set."""
-        ed = LineEditor()
-        for ch in "hello world this is a long line":
-            ed.feed_key(ch)
+    @pytest.mark.parametrize("max_width,text", [
+        (None, "hello world this is a long line"),
+        (20, "hi"),
+    ])
+    def test_no_overflow(self, max_width: int, text: str) -> None:
+        """Test no overflow when text fits."""
+        ed = _editor(text, max_width=max_width) if max_width else _editor(text)
         ds = ed.display
         assert ds.overflow_left is False
         assert ds.overflow_right is False
 
     def test_max_width_clips(self) -> None:
         """Test display is clipped to max_width."""
-        ed = LineEditor(max_width=10)
-        for ch in "abcdefghijklmnop":
-            ed.feed_key(ch)
+        ed = _editor("abcdefghijklmnop", max_width=10)
         ds = ed.display
         assert ds.overflow_left is True
         total = wcswidth(ds.text) + wcswidth(ds.suggestion)
         assert total <= 10
 
-    def test_max_width_short_text_no_clip(self) -> None:
-        """Test short text within max_width is not clipped."""
-        ed = LineEditor(max_width=20)
-        for ch in "hi":
-            ed.feed_key(ch)
-        ds = ed.display
-        assert ds.overflow_left is False
-        assert ds.overflow_right is False
-        assert ds.text == "hi"
-
     def test_max_width_cursor_stays_visible(self) -> None:
         """Test cursor stays within visible max_width region."""
-        ed = LineEditor(max_width=10)
-        for ch in "a" * 50:
-            ed.feed_key(ch)
+        ed = _editor("a" * 50, max_width=10)
         ds = ed.display
         assert 0 <= ds.cursor <= 10
 
     def test_max_width_home_shows_start(self) -> None:
         """Test Home key scrolls view to show buffer start."""
-        ed = LineEditor(max_width=10)
-        for ch in "abcdefghijklmnop":
-            ed.feed_key(ch)
-        ed.feed_key(_HOME)
+        ed = _editor("abcdefghijklmnop", _HOME, max_width=10)
         ds = ed.display
         assert ds.overflow_left is False
         assert ds.cursor == 0
 
     def test_max_width_updated_dynamically(self) -> None:
         """Test changing max_width dynamically updates display."""
-        ed = LineEditor(max_width=5)
-        for ch in "abcdefghij":
-            ed.feed_key(ch)
+        ed = _editor("abcdefghij", max_width=5)
         assert ed.display.overflow_left is True
         ed.max_width = 20
         ds = ed.display
@@ -932,9 +791,7 @@ class TestLineEditorMaxWidth:
 
     def test_max_width_password_mode(self) -> None:
         """Test max_width clipping works in password mode."""
-        ed = LineEditor(max_width=5, password=True)
-        for ch in "abcdefghij":
-            ed.feed_key(ch)
+        ed = _editor("abcdefghij", max_width=5, password=True)
         ds = ed.display
         assert PASSWORD_CHAR in ds.text
         assert wcswidth(ds.text) <= 5
@@ -967,9 +824,7 @@ class TestStatefulHScroll:
 
     def test_no_scroll_while_inside_window(self) -> None:
         """Test no scroll offset while text fits in window."""
-        ed = LineEditor(max_width=20)
-        for ch in "abcdef":
-            ed.feed_key(ch)
+        ed = _editor("abcdef", max_width=20)
         ds = ed.display
         assert ed._scroll_offset == 0
         assert ds.cursor == 6
@@ -977,9 +832,7 @@ class TestStatefulHScroll:
 
     def test_first_scroll_at_field_boundary(self) -> None:
         """Test first scroll triggers at field width boundary."""
-        ed = LineEditor(max_width=20)
-        for ch in "a" * 19:
-            ed.feed_key(ch)
+        ed = _editor("a" * 19, max_width=20)
         ds = ed.display
         assert ed._scroll_offset == 0
         assert ds.cursor == 19
@@ -999,9 +852,7 @@ class TestStatefulHScroll:
 
     def test_scroll_left_on_home(self) -> None:
         """Test Home key resets scroll offset to zero."""
-        ed = LineEditor(max_width=20)
-        for ch in "a" * 40:
-            ed.feed_key(ch)
+        ed = _editor("a" * 40, max_width=20)
         _ = ed.display
         assert ed._scroll_offset > 0
         ed.feed_key(_HOME)
@@ -1033,18 +884,14 @@ class TestStatefulHScroll:
 
     def test_default_jump_makes_room(self) -> None:
         """Test default scroll_jump places cursor away from edge."""
-        ed = LineEditor(max_width=40)
-        for ch in "a" * 40:
-            ed.feed_key(ch)
+        ed = _editor("a" * 40, max_width=40)
         ds = ed.display
         assert ed._scroll_offset > 0
         assert ds.cursor < 25
 
     def test_scroll_left_near_left_edge(self) -> None:
         """Test scrolling left when cursor approaches left edge."""
-        ed = LineEditor(max_width=20)
-        for ch in "a" * 30:
-            ed.feed_key(ch)
+        ed = _editor("a" * 30, max_width=20)
         _ = ed.display
         right_offset = ed._scroll_offset
         for _ in range(25):
@@ -1055,9 +902,7 @@ class TestStatefulHScroll:
     @pytest.mark.parametrize("reset_key", [_ENTER, _CTRL_C])
     def test_key_resets_scroll_offset(self, reset_key: str) -> None:
         """Test Enter/Ctrl-C resets scroll offset to zero."""
-        ed = LineEditor(max_width=10)
-        for ch in "a" * 20:
-            ed.feed_key(ch)
+        ed = _editor("a" * 20, max_width=10)
         _ = ed.display
         assert ed._scroll_offset > 0
         ed.feed_key(reset_key)
@@ -1065,9 +910,7 @@ class TestStatefulHScroll:
 
     def test_clear_resets_scroll_offset(self) -> None:
         """Test clear resets scroll offset to zero."""
-        ed = LineEditor(max_width=10)
-        for ch in "a" * 30:
-            ed.feed_key(ch)
+        ed = _editor("a" * 30, max_width=10)
         _ = ed.display
         assert ed._scroll_offset > 0
         ed.clear()
@@ -1076,9 +919,7 @@ class TestStatefulHScroll:
     @pytest.mark.parametrize("password", [False, True])
     def test_small_field_scrolls(self, password: bool) -> None:
         """Test scrolling in a small 10-column field."""
-        ed = LineEditor(max_width=10, password=password)
-        for ch in "a" * 15:
-            ed.feed_key(ch)
+        ed = _editor("a" * 15, max_width=10, password=password)
         ds = ed.display
         assert 0 <= ds.cursor <= 10
         assert ed._scroll_offset > 0
@@ -1089,11 +930,8 @@ class TestRender:
 
     def test_render_basic(self) -> None:
         """Test render produces move, text, and normal sequences."""
-        mt = MockTerminal()
-        ed = LineEditor()
-        for ch in "hello":
-            ed.feed_key(ch)
-        out = ed.render(mt, 3, 40)
+        ed = _editor("hello")
+        out = ed.render(_MT, 3, 40)
         assert "<MV:3,0>" in out
         assert "hello" in out
         assert "<MV:3,5>" in out
@@ -1101,28 +939,18 @@ class TestRender:
 
     def test_render_with_suggestion(self) -> None:
         """Test render includes suggestion text with SGR styling."""
-        mt = MockTerminal()
         h = History()
         h.add("hello world")
-        ed = LineEditor(history=h)
-        for ch in "he":
-            ed.feed_key(ch)
-        out = ed.render(mt, 0, 40)
+        ed = _editor("he", history=h)
+        out = ed.render(_MT, 0, 40)
         assert "he" in out
         assert "llo world" in out
         assert ed.suggestion_sgr in out
 
     def test_render_overflow_left_right(self) -> None:
         """Test render shows ellipsis indicators on overflow."""
-        mt = MockTerminal()
-        ed = LineEditor(max_width=10)
-        for ch in "abcdefghijklmnop":
-            ed.feed_key(ch)
-        ed.feed_key(_HOME)
-        ed.feed_key(_RIGHT)
-        for ch in "xyz":
-            ed.feed_key(ch)
-        out = ed.render(mt, 0, 10)
+        ed = _editor("abcdefghijklmnop", _HOME, _RIGHT, "xyz", max_width=10)
+        out = ed.render(_MT, 0, 10)
         ds = ed.display
         if ds.overflow_left:
             assert ed.ellipsis in out
@@ -1131,217 +959,136 @@ class TestRender:
 
     def test_render_updates_prev_state(self) -> None:
         """Test render updates previous state tracking fields."""
-        mt = MockTerminal()
-        ed = LineEditor()
-        for ch in "abc":
-            ed.feed_key(ch)
-        ed.render(mt, 0, 40)
+        ed = _editor("abc")
+        ed.render(_MT, 0, 40)
         assert ed._prev_cursor == 3
         assert ed._prev_content_w == 3
         assert ed._prev_overflow == (False, False)
 
     def test_render_padding(self) -> None:
         """Test render pads remaining width with spaces."""
-        mt = MockTerminal()
-        ed = LineEditor()
-        ed.feed_key("a")
-        out = ed.render(mt, 0, 10)
+        ed = _editor("a")
+        out = ed.render(_MT, 0, 10)
         assert " " * 9 in out
 
     def test_render_empty_text(self) -> None:
         """Test render with empty buffer produces blank padding."""
-        mt = MockTerminal()
-        ed = LineEditor()
-        out = ed.render(mt, 0, 10)
+        ed = _editor()
+        out = ed.render(_MT, 0, 10)
         assert "<MV:0,0>" in out
         assert " " * 10 in out
 
 
-class TestRenderInsert:
-    """Test render_insert incremental rendering optimization."""
+class TestIncrementalRender:
+    """Test render_insert and render_backspace incremental optimizations."""
 
-    def test_render_insert_at_end(self) -> None:
-        """Test render_insert produces output for append at end."""
-        mt = MockTerminal()
-        ed = LineEditor()
-        for ch in "hel":
-            ed.feed_key(ch)
-        ed.render(mt, 0, 40)
-        ed.feed_key("l")
-        result = ed.render_insert(mt, 0, "l")
-        assert result is not None
-        assert "l" in result
-
-    def test_render_insert_mid_buffer_returns_none(self) -> None:
-        """Test render_insert returns None for mid-buffer insert."""
-        mt = MockTerminal()
-        ed = LineEditor()
-        for ch in "abc":
-            ed.feed_key(ch)
-        ed.render(mt, 0, 40)
-        ed.feed_key(_LEFT)
-        ed.feed_key("x")
-        result = ed.render_insert(mt, 0, "x")
-        assert result is None
-
-    def test_render_insert_overflow_change_returns_none(self) -> None:
-        """Test render_insert returns None when overflow state changes."""
-        mt = MockTerminal()
-        ed = LineEditor(max_width=5)
-        for ch in "abcd":
-            ed.feed_key(ch)
-        ed.render(mt, 0, 5)
-        ed.feed_key("e")
-        ed.feed_key("f")
-        result = ed.render_insert(mt, 0, "f")
-        assert result is None
-
-    def test_render_insert_scroll_change_returns_none(self) -> None:
-        """Test render_insert returns None when scroll offset changes."""
-        mt = MockTerminal()
-        ed = LineEditor(max_width=10)
-        for ch in "a" * 9:
-            ed.feed_key(ch)
-        ed.render(mt, 0, 10)
-        old_offset = ed._scroll_offset
-        for ch in "bbb":
-            ed.feed_key(ch)
-        _ = ed.display
-        assert ed._scroll_offset != old_offset
-        result = ed.render_insert(mt, 0, "b")
-        assert result is None
-
-    def test_render_insert_clears_stale_suggestion(self) -> None:
-        """Test render_insert clears previous suggestion text."""
-        mt = MockTerminal()
-        h = History()
-        h.add("hello world")
-        ed = LineEditor(history=h)
-        for ch in "he":
-            ed.feed_key(ch)
-        ed.render(mt, 0, 40)
-        ed.feed_key("l")
-        result = ed.render_insert(mt, 0, "l")
+    @pytest.mark.parametrize("op,method", [
+        ("l", "render_insert"),
+        (_BACKSPACE, "render_backspace"),
+    ])
+    def test_at_end(self, op, method) -> None:
+        """Test incremental render produces output for op at end."""
+        ed = _editor("hel")
+        ed.render(_MT, 0, 40)
+        ed.feed_key(op)
+        args = (_MT, 0, "l") if method == "render_insert" else (_MT, 0)
+        result = getattr(ed, method)(*args)
         assert result is not None
 
-    def test_render_insert_updates_prev_state(self) -> None:
-        """Test render_insert updates previous state tracking fields."""
-        mt = MockTerminal()
-        ed = LineEditor()
-        for ch in "ab":
-            ed.feed_key(ch)
-        ed.render(mt, 0, 40)
-        ed.feed_key("c")
-        ed.render_insert(mt, 0, "c")
-        assert ed._prev_cursor == 3
-        assert ed._prev_content_w == 3
+    @pytest.mark.parametrize("max_width,fill,render_w,pre_ops,char", [
+        (None, "abc", 40, [_LEFT], "x"),
+        (5, "abcd", 5, ["e"], "f"),
+        (10, "a" * 9, 10, list("bbb"), "b"),
+    ])
+    def test_render_insert_returns_none(self, max_width, fill, render_w,
+                                        pre_ops, char) -> None:
+        """Test render_insert returns None for non-appendable inserts."""
+        ed = _editor(fill, max_width=max_width) if max_width else _editor(fill)
+        ed.render(_MT, 0, render_w)
+        for op in pre_ops:
+            ed.feed_key(op)
+        if max_width == 10:
+            _ = ed.display
+        result = ed.render_insert(_MT, 0, char)
+        assert result is None
+
+    @pytest.mark.parametrize("max_width,fill,render_w,pre_ops", [
+        (None, "abc", 40, [_LEFT, _BACKSPACE]),
+        (5, "abcdef", 5, [_BACKSPACE] * 4),
+        (10, "a" * 20, 10, [_BACKSPACE] * 15),
+    ])
+    def test_render_backspace_returns_none(self, max_width, fill, render_w,
+                                           pre_ops) -> None:
+        """Test render_backspace returns None for non-tail deletions."""
+        ed = _editor(fill, max_width=max_width) if max_width else _editor(fill)
+        ed.render(_MT, 0, render_w)
+        for op in pre_ops:
+            ed.feed_key(op)
+        if max_width == 10:
+            _ = ed.display
+        result = ed.render_backspace(_MT, 0)
+        assert result is None
+
+    @pytest.mark.parametrize("mode,op,method,exp_cursor,exp_w", [
+        ("insert", "d", "render_insert", 4, 4),
+        ("backspace", _BACKSPACE, "render_backspace", 2, 2),
+    ])
+    def test_updates_prev_state(self, mode, op, method,
+                                exp_cursor, exp_w) -> None:
+        """Test incremental render updates previous state tracking."""
+        ed = _editor("abc")
+        ed.render(_MT, 0, 40)
+        ed.feed_key(op)
+        args = (_MT, 0, op) if mode == "insert" else (_MT, 0)
+        getattr(ed, method)(*args)
+        assert ed._prev_cursor == exp_cursor
+        assert ed._prev_content_w == exp_w
         assert ed._prev_overflow == (False, False)
-
-    def test_render_insert_trailing_space_cleanup(self) -> None:
-        """render_insert pads with spaces when new content is narrower."""
-        mt = MockTerminal()
-        h = History()
-        h.add("hello")
-        ed = LineEditor(history=h)
-        for ch in "hel":
-            ed.feed_key(ch)
-        ed.render(mt, 0, 40)
-        prev_w = ed._prev_content_w
-        assert prev_w == 5
-        ed.feed_key("x")
-        result = ed.render_insert(mt, 0, "x")
-        assert result is not None
-        assert "x " in result
-
-
-class TestRenderBackspace:
-    """Test render_backspace incremental rendering optimization."""
-
-    def test_render_backspace_at_end(self) -> None:
-        """Test render_backspace produces output for deletion at end."""
-        mt = MockTerminal()
-        ed = LineEditor()
-        for ch in "abc":
-            ed.feed_key(ch)
-        ed.render(mt, 0, 40)
-        ed.feed_key(_BACKSPACE)
-        result = ed.render_backspace(mt, 0)
-        assert result is not None
-
-    def test_render_backspace_mid_buffer_returns_none(self) -> None:
-        """Test render_backspace returns None for mid-buffer deletion."""
-        mt = MockTerminal()
-        ed = LineEditor()
-        for ch in "abc":
-            ed.feed_key(ch)
-        ed.render(mt, 0, 40)
-        ed.feed_key(_LEFT)
-        ed.feed_key(_BACKSPACE)
-        result = ed.render_backspace(mt, 0)
-        assert result is None
-
-    def test_render_backspace_overflow_change_returns_none(self) -> None:
-        """Test render_backspace returns None on overflow state change."""
-        mt = MockTerminal()
-        ed = LineEditor(max_width=5)
-        for ch in "abcdef":
-            ed.feed_key(ch)
-        ed.render(mt, 0, 5)
-        for _ in range(4):
-            ed.feed_key(_BACKSPACE)
-        result = ed.render_backspace(mt, 0)
-        assert result is None
-
-    def test_render_backspace_scroll_change_returns_none(self) -> None:
-        """Test render_backspace returns None when scroll changes."""
-        mt = MockTerminal()
-        ed = LineEditor(max_width=10)
-        for ch in "a" * 20:
-            ed.feed_key(ch)
-        ed.render(mt, 0, 10)
-        old_offset = ed._scroll_offset
-        for _ in range(15):
-            ed.feed_key(_BACKSPACE)
-        _ = ed.display
-        assert ed._scroll_offset != old_offset
-        result = ed.render_backspace(mt, 0)
-        assert result is None
 
     def test_render_backspace_erases_trailing(self) -> None:
         """Test render_backspace erases trailing character with space."""
-        mt = MockTerminal()
-        ed = LineEditor()
-        for ch in "abc":
-            ed.feed_key(ch)
-        ed.render(mt, 0, 40)
+        ed = _editor("abc")
+        ed.render(_MT, 0, 40)
         ed.feed_key(_BACKSPACE)
-        result = ed.render_backspace(mt, 0)
+        result = ed.render_backspace(_MT, 0)
         assert result is not None
         assert " " in result
 
-    def test_render_backspace_updates_prev_state(self) -> None:
-        """Test render_backspace updates previous state tracking."""
-        mt = MockTerminal()
-        ed = LineEditor()
-        for ch in "abc":
-            ed.feed_key(ch)
-        ed.render(mt, 0, 40)
-        ed.feed_key(_BACKSPACE)
-        ed.render_backspace(mt, 0)
-        assert ed._prev_cursor == 2
-        assert ed._prev_content_w == 2
-        assert ed._prev_overflow == (False, False)
-
-    def test_render_backspace_with_suggestion(self) -> None:
-        """Test render_backspace redraws updated suggestion."""
-        mt = MockTerminal()
+    def test_render_insert_clears_stale_suggestion(self) -> None:
+        """Test render_insert clears previous suggestion text."""
         h = History()
         h.add("hello world")
-        ed = LineEditor(history=h)
-        for ch in "hel":
-            ed.feed_key(ch)
-        ed.render(mt, 0, 40)
-        ed.feed_key(_BACKSPACE)
-        result = ed.render_backspace(mt, 0)
+        ed = _editor("he", history=h)
+        ed.render(_MT, 0, 40)
+        ed.feed_key("l")
+        result = ed.render_insert(_MT, 0, "l")
         assert result is not None
-        assert ed.suggestion_sgr in result
+
+    def test_render_insert_trailing_space_cleanup(self) -> None:
+        """render_insert pads with spaces when new content is narrower."""
+        h = History()
+        h.add("hello")
+        ed = _editor("hel", history=h)
+        ed.render(_MT, 0, 40)
+        prev_w = ed._prev_content_w
+        assert prev_w == 5
+        ed.feed_key("x")
+        result = ed.render_insert(_MT, 0, "x")
+        assert result is not None
+        assert "x " in result
+
+    @pytest.mark.parametrize("op,method,sgr_check", [
+        (_BACKSPACE, "render_backspace", True),
+    ])
+    def test_render_with_suggestion(self, op, method, sgr_check) -> None:
+        """Test incremental render redraws updated suggestion."""
+        h = History()
+        h.add("hello world")
+        ed = _editor("hel", history=h)
+        ed.render(_MT, 0, 40)
+        ed.feed_key(op)
+        args = (_MT, 0) if method == "render_backspace" else (_MT, 0, op)
+        result = getattr(ed, method)(*args)
+        assert result is not None
+        if sgr_check:
+            assert ed.suggestion_sgr in result

--- a/tests/test_line_editor.py
+++ b/tests/test_line_editor.py
@@ -8,9 +8,10 @@ import pytest
 from blessed.line_editor import (
     PASSWORD_CHAR,
     DisplayState,
-    EditResult,
-    History,
+    LineEditResult,
+    LineHistory as History,
     LineEditor,
+    _apply_hscroll,
     _display_width,
     _graphemes,
 )
@@ -68,16 +69,16 @@ class TestGraphemeHelpers:
         assert _display_width("") == 0
 
 
-class TestEditResult:
+class TestLineEditResult:
     def test_defaults(self) -> None:
-        r = EditResult()
+        r = LineEditResult()
         assert r.line is None
         assert r.eof is False
         assert r.interrupt is False
         assert r.changed is False
 
     def test_accept(self) -> None:
-        r = EditResult(line="hello", changed=True)
+        r = LineEditResult(line="hello", changed=True)
         assert r.line == "hello"
         assert r.changed is True
 
@@ -613,3 +614,117 @@ class TestLineEditorCtrlAE:
         ed.feed_key(_HOME)
         ed.feed_key(_CTRL_E)
         assert ed.display.cursor == 2
+
+
+class TestApplyHscroll:
+    def test_no_scroll_needed(self) -> None:
+        ds = _apply_hscroll("hello", "", 5, 20)
+        assert ds.text == "hello"
+        assert ds.cursor == 5
+        assert ds.suggestion == ""
+        assert ds.clipped_left is False
+        assert ds.clipped_right is False
+
+    def test_text_with_suggestion_fits(self) -> None:
+        ds = _apply_hscroll("he", "llo world", 2, 20)
+        assert ds.text == "he"
+        assert ds.suggestion == "llo world"
+        assert ds.clipped_left is False
+        assert ds.clipped_right is False
+
+    def test_text_overflows_right(self) -> None:
+        ds = _apply_hscroll("abcdefghij", "", 3, 5)
+        assert ds.clipped_right is True
+        assert len(ds.text) <= 5
+
+    def test_cursor_at_end_scrolls(self) -> None:
+        text = "a" * 30
+        ds = _apply_hscroll(text, "", 30, 10)
+        assert ds.clipped_left is True
+        assert ds.cursor >= 0
+        assert ds.cursor <= 10
+
+    def test_cursor_at_start_no_left_clip(self) -> None:
+        text = "a" * 30
+        ds = _apply_hscroll(text, "", 0, 10)
+        assert ds.clipped_left is False
+        assert ds.clipped_right is True
+        assert ds.cursor == 0
+
+    def test_suggestion_clipped(self) -> None:
+        ds = _apply_hscroll("ab", "cdefghijklmnop", 2, 8)
+        assert ds.clipped_right is True
+        total = _display_width(ds.text) + _display_width(ds.suggestion)
+        assert total <= 8
+
+    def test_custom_ellipsis(self) -> None:
+        ds = _apply_hscroll("a" * 20, "", 20, 10, ellipsis="...")
+        assert ds.clipped_left is True
+
+    def test_empty_text(self) -> None:
+        ds = _apply_hscroll("", "", 0, 10)
+        assert ds.text == ""
+        assert ds.cursor == 0
+        assert ds.clipped_left is False
+        assert ds.clipped_right is False
+
+
+class TestLineEditorMaxWidth:
+    def test_no_max_width_no_clipping(self) -> None:
+        ed = LineEditor()
+        for ch in "hello world this is a long line":
+            ed.feed_key(ch)
+        ds = ed.display
+        assert ds.clipped_left is False
+        assert ds.clipped_right is False
+
+    def test_max_width_clips(self) -> None:
+        ed = LineEditor(max_width=10)
+        for ch in "abcdefghijklmnop":
+            ed.feed_key(ch)
+        ds = ed.display
+        assert ds.clipped_left is True
+        total = _display_width(ds.text) + _display_width(ds.suggestion)
+        assert total <= 10
+
+    def test_max_width_short_text_no_clip(self) -> None:
+        ed = LineEditor(max_width=20)
+        for ch in "hi":
+            ed.feed_key(ch)
+        ds = ed.display
+        assert ds.clipped_left is False
+        assert ds.clipped_right is False
+        assert ds.text == "hi"
+
+    def test_max_width_cursor_stays_visible(self) -> None:
+        ed = LineEditor(max_width=10)
+        for ch in "a" * 50:
+            ed.feed_key(ch)
+        ds = ed.display
+        assert 0 <= ds.cursor <= 10
+
+    def test_max_width_home_shows_start(self) -> None:
+        ed = LineEditor(max_width=10)
+        for ch in "abcdefghijklmnop":
+            ed.feed_key(ch)
+        ed.feed_key(_HOME)
+        ds = ed.display
+        assert ds.clipped_left is False
+        assert ds.cursor == 0
+
+    def test_max_width_updated_dynamically(self) -> None:
+        ed = LineEditor(max_width=5)
+        for ch in "abcdefghij":
+            ed.feed_key(ch)
+        assert ed.display.clipped_left is True
+        ed.max_width = 20
+        ds = ed.display
+        assert ds.clipped_left is False
+
+    def test_max_width_password_mode(self) -> None:
+        ed = LineEditor(max_width=5, is_password=lambda: True)
+        for ch in "abcdefghij":
+            ed.feed_key(ch)
+        ds = ed.display
+        assert PASSWORD_CHAR in ds.text
+        assert _display_width(ds.text) <= 5

--- a/tests/test_line_editor.py
+++ b/tests/test_line_editor.py
@@ -505,12 +505,20 @@ class TestLineEditorKillRing:
         r = ed.feed_key(_CTRL_U)
         assert r.changed is False
         assert ed.line == "ab"
-        assert ed._kill_ring == []
+        assert len(ed._kill_ring) == 0
 
     def test_kill_line_empty_buffer(self) -> None:
         ed = LineEditor()
         r = ed.feed_key(_CTRL_U)
         assert r.changed is False
+
+    def test_kill_ring_capped_at_64(self) -> None:
+        ed = LineEditor()
+        for i in range(70):
+            ed.feed_key(str(i % 10))
+            ed.feed_key(_CTRL_K)
+            ed.feed_key(_HOME)
+        assert len(ed._kill_ring) == 64
 
     def test_kill_word_back_at_start(self) -> None:
         ed = LineEditor()
@@ -603,7 +611,7 @@ class TestLineEditorHistory:
 
     def test_enter_password_mode_skips_history(self) -> None:
         h = History()
-        ed = LineEditor(history=h, is_password=lambda: True)
+        ed = LineEditor(history=h, password=True)
         ed.feed_key("s")
         ed.feed_key("e")
         ed.feed_key("c")
@@ -633,7 +641,7 @@ class TestLineEditorAutoSuggest:
     def test_no_suggestion_password_mode(self) -> None:
         h = History()
         h.add("secret123")
-        ed = LineEditor(history=h, is_password=lambda: True)
+        ed = LineEditor(history=h, password=True)
         ed.feed_key("s")
         assert ed.display.suggestion == ""
 
@@ -669,7 +677,7 @@ class TestLineEditorAutoSuggest:
 
 class TestLineEditorPasswordMode:
     def test_masked_display(self) -> None:
-        ed = LineEditor(is_password=lambda: True)
+        ed = LineEditor(password=True)
         ed.feed_key("a")
         ed.feed_key("b")
         ed.feed_key("c")
@@ -683,7 +691,7 @@ class TestLineEditorPasswordMode:
         assert ed.display.text == PASSWORD_CHAR
 
     def test_password_cursor_with_wide_char(self) -> None:
-        ed = LineEditor(is_password=lambda: True, password_char="\u4e16")
+        ed = LineEditor(password=True, password_char="\u4e16")
         ed.feed_key("a")
         ed.feed_key("b")
         ds = ed.display
@@ -691,7 +699,7 @@ class TestLineEditorPasswordMode:
         assert wcswidth(ds.text) == 4
 
     def test_password_cursor_after_left(self) -> None:
-        ed = LineEditor(is_password=lambda: True, password_char="\u4e16")
+        ed = LineEditor(password=True, password_char="\u4e16")
         ed.feed_key("a")
         ed.feed_key("b")
         ed.feed_key("c")
@@ -851,7 +859,7 @@ class TestLineEditorMaxWidth:
         assert ds.overflow_left is False
 
     def test_max_width_password_mode(self) -> None:
-        ed = LineEditor(max_width=5, is_password=lambda: True)
+        ed = LineEditor(max_width=5, password=True)
         for ch in "abcdefghij":
             ed.feed_key(ch)
         ds = ed.display
@@ -1000,7 +1008,7 @@ class TestStatefulHScroll:
         assert ed._scroll_offset > 0
 
     def test_password_mode_stateful_scroll(self) -> None:
-        ed = LineEditor(max_width=10, is_password=lambda: True)
+        ed = LineEditor(max_width=10, password=True)
         for ch in "a" * 20:
             ed.feed_key(ch)
         ds = ed.display
@@ -1116,6 +1124,20 @@ class TestRenderInsert:
         result = ed.render_insert(mt, 0, "f")
         assert result is None
 
+    def test_render_insert_returns_none_when_scroll_changes(self) -> None:
+        mt = MockTerminal()
+        ed = LineEditor(max_width=10)
+        for ch in "a" * 9:
+            ed.feed_key(ch)
+        ed.render(mt, 0, 10)
+        old_offset = ed._scroll_offset
+        for ch in "bbb":
+            ed.feed_key(ch)
+        _ = ed.display
+        assert ed._scroll_offset != old_offset
+        result = ed.render_insert(mt, 0, "b")
+        assert result is None
+
     def test_render_insert_clears_stale_suggestion(self) -> None:
         mt = MockTerminal()
         h = History()
@@ -1171,6 +1193,20 @@ class TestRenderBackspace:
         ed.render(mt, 0, 5)
         for _ in range(4):
             ed.feed_key(_BACKSPACE)
+        result = ed.render_backspace(mt, 0)
+        assert result is None
+
+    def test_render_backspace_returns_none_when_scroll_changes(self) -> None:
+        mt = MockTerminal()
+        ed = LineEditor(max_width=10)
+        for ch in "a" * 20:
+            ed.feed_key(ch)
+        ed.render(mt, 0, 10)
+        old_offset = ed._scroll_offset
+        for _ in range(15):
+            ed.feed_key(_BACKSPACE)
+        _ = ed.display
+        assert ed._scroll_offset != old_offset
         result = ed.render_backspace(mt, 0)
         assert result is None
 

--- a/tests/test_line_editor.py
+++ b/tests/test_line_editor.py
@@ -246,6 +246,15 @@ class TestLineEditorBasicEditing:
         assert r.changed is True
         assert ed.line == "b"
 
+    def test_ctrl_d_single_undo(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ed.feed_key(_HOME)
+        before = len(ed._undo_stack)
+        ed.feed_key(_CTRL_D)
+        assert len(ed._undo_stack) - before == 1
+
     def test_feed_key_multi_grapheme_hits_limit_mid_insertion(self) -> None:
         ed = LineEditor(limit=2)
         ed.feed_key("abc")
@@ -268,6 +277,20 @@ class TestLineEditorBasicEditing:
         ed = LineEditor()
         ed.insert_text("a\x01b")
         assert ed.line == "ab"
+
+    def test_insert_text_empty_string(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        r = ed.insert_text("")
+        assert r.changed is False
+        assert ed.line == "a"
+
+    def test_insert_text_only_control_chars(self) -> None:
+        ed = LineEditor()
+        ed.feed_key("a")
+        r = ed.insert_text("\x01\x02")
+        assert r.changed is False
+        assert ed.line == "a"
 
 
 class TestLineEditorCursorMovement:
@@ -659,6 +682,23 @@ class TestLineEditorPasswordMode:
         ed.feed_key("x")
         assert ed.display.text == PASSWORD_CHAR
 
+    def test_password_cursor_with_wide_char(self) -> None:
+        ed = LineEditor(is_password=lambda: True, password_char="\u4e16")
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ds = ed.display
+        assert ds.cursor == 4
+        assert wcswidth(ds.text) == 4
+
+    def test_password_cursor_after_left(self) -> None:
+        ed = LineEditor(is_password=lambda: True, password_char="\u4e16")
+        ed.feed_key("a")
+        ed.feed_key("b")
+        ed.feed_key("c")
+        ed.feed_key(_LEFT)
+        ds = ed.display
+        assert ds.cursor == 4
+
     def test_password_enter_not_saved(self) -> None:
         h = History()
         ed = LineEditor(history=h)
@@ -919,7 +959,7 @@ class TestStatefulHScroll:
         right_offset = ed._scroll_offset
         for _ in range(25):
             ed.feed_key(_LEFT)
-        ds = ed.display
+        _ = ed.display
         assert ed._scroll_offset < right_offset
 
     def test_apply_hscroll_with_explicit_scroll_offset(self) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -193,8 +193,8 @@ commands =
 basepython = python3.13
 deps =
     {[testenv:isort]deps}
-    {[testenv:docformatter]deps}
     {[testenv:autopep8]deps}
+    {[testenv:docformatter]deps}
 commands =
     {[testenv:isort]commands}
     {[testenv:docformatter]commands}

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,10 @@ passenv =
     TEST_QUICK
     TEST_KEYBOARD
     TEST_RAW
+# although we don't depend on any specific termcap, many tests casually call setupterm(),
+# so we must ensure the TERM *is* valid
 setenv =
+    TERM = xterm
     TEST_QUICK = {env:TEST_QUICK:1}
 deps =
     pytest
@@ -36,6 +39,7 @@ commands =
 
 [testenv:py314]
 setenv =
+    TERM = xterm
     TEST_QUICK = {env:TEST_QUICK:0}
     TEST_KEYBOARD = {env:TEST_KEYBOARD:1}
 


### PR DESCRIPTION
Closes #154 by introducing async_inkey, and provides a nice "headless" repl "LineEditor".

Line Editor
---------------

I've been working with python-prompt-toolkit and urwid and briefly evaluated others, and had a terrible time integrating with an asyncio api -- not in the expected asyncio integration, async_inkey was very easy to write and work with, our existing inkey() pattern is very asyncio friendly -- but, in that they don't do what blessed does best -- to provide an interface to conditionally **return output to render as a string**

Other "line editors" want to "own" the terminal entirely, and in many cases also to own the event loop. To be fully responsible for setting the terminal mode, capturing all keyboard/mouse input, and writing directly to output.

This is a problem for many situations where blessed shines, in my case of an advanced "telnet client" GUI, where I am using asyncio to manage many simultaneous tasks which can cause rapid screen updates, and processing and rendering the repl is only a small part, eg. https://www.jeffquast.com/telnetlib3-lerp.mp4 -- but there are other amazing use cases, to provide a readline interface without initialization or control of a terminal or tty interface.