### PR TITLE
More detections and minor fix

### DIFF
--- a/bin/display-unicode.py
+++ b/bin/display-unicode.py
@@ -60,6 +60,8 @@ VS16_TEST = '\u231A\uFE0F'  # watch + VS16
 
 def detect_wide_version(term, timeout=0.5):
     """Detect highest supported Unicode version for wide characters."""
+    if not term.does_styling:
+        return False
     best_version = None
     for version, char in WIDE_VERSION_TESTS:
         width = measure_width(term, char, timeout)
@@ -70,6 +72,8 @@ def detect_wide_version(term, timeout=0.5):
 
 def detect_zwj_version(term, timeout=0.5):
     """Detect highest supported Emoji ZWJ version."""
+    if not term.does_styling:
+        return False
     best_version = None
     for version, seq in EMOJI_ZWJ_TESTS:
         width = measure_width(term, seq, timeout)
@@ -80,6 +84,8 @@ def detect_zwj_version(term, timeout=0.5):
 
 
 def detect_vs16_support(term, timeout=1):
+    if not term.does_styling:
+        return False
     return measure_width(term, VS16_TEST, timeout) == 2
 
 

--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -15,4 +15,4 @@ else:
 from blessed.line_editor import LineEditor, LineHistory
 
 __all__ = ('Terminal', 'LineEditor', 'LineHistory')
-__version__ = "1.31.0"
+__version__ = "1.32.0"

--- a/blessed/_capabilities.py
+++ b/blessed/_capabilities.py
@@ -389,3 +389,27 @@ class ITerm2Capabilities:
         """Return string representation."""
         return (f'ITerm2Capabilities(supported={self.supported}, '
                 f'features={self.features})')
+
+
+class TextSizingResult:
+    """
+    Result of Kitty text sizing protocol detection (OSC 66).
+
+    :param bool width: True if width sizing is supported.
+    :param bool scale: True if scale sizing is supported.
+    """
+
+    def __init__(self, width: bool = False, scale: bool = False) -> None:
+        self.width = width
+        self.scale = scale
+
+    def __bool__(self) -> bool:
+        return self.width or self.scale
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, TextSizingResult):
+            return self.width == other.width and self.scale == other.scale
+        return NotImplemented
+
+    def __repr__(self) -> str:
+        return f"TextSizingResult(width={self.width}, scale={self.scale})"

--- a/blessed/dec_modes.py
+++ b/blessed/dec_modes.py
@@ -1,7 +1,7 @@
 """Class definitions for DEC Private Modes and their Response values."""
 
 # std imports
-from typing import Any, Union
+from typing import Any, Dict, Union
 
 
 class DecModeResponse:
@@ -133,7 +133,7 @@ class DecModeResponse:
         """
         return self.value < 0
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> Dict[str, Any]:
         """
         Return response as a dictionary.
 

--- a/blessed/dec_modes.py
+++ b/blessed/dec_modes.py
@@ -133,6 +133,25 @@ class DecModeResponse:
         """
         return self.value < 0
 
+    def to_dict(self) -> dict:
+        """
+        Return response as a dictionary.
+
+        :rtype: dict
+        :returns: Dictionary with keys ``value``, ``value_description``,
+            ``mode_description``, ``mode_name``, ``supported``, ``enabled``,
+            and ``changeable``.
+        """
+        return {
+            'value': self.value,
+            'value_description': str(self),
+            'mode_description': self.description,
+            'mode_name': self.mode.name,
+            'supported': self.supported,
+            'enabled': self.enabled,
+            'changeable': self.changeable,
+        }
+
     def __str__(self) -> str:
         """
         Return the constant name for the response value.
@@ -340,6 +359,7 @@ class DecPrivateMode:
     REPORT_GRID_CELL_SELECTION = 2030
     COLOR_PALETTE_UPDATES = 2031
     IN_BAND_WINDOW_RESIZE = 2048
+    BRACKETED_PASTE_MIME = 5522
 
     # VTE bidirectional text extensions
     MIRROR_BOX_DRAWING = 2500
@@ -540,6 +560,7 @@ class DecPrivateMode:
         REPORT_GRID_CELL_SELECTION: "Report grid cell selection",
         COLOR_PALETTE_UPDATES: "Color palette updates",
         IN_BAND_WINDOW_RESIZE: "In-Band Window Resize Notifications",
+        BRACKETED_PASTE_MIME: "Bracketed Paste MIME",
 
         # VTE bidirectional text extensions
         MIRROR_BOX_DRAWING: "Mirror box drawing characters",

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -308,6 +308,9 @@ class Terminal():
         # Kitty pointer shapes (OSC 22) detection cache
         self._kitty_pointer_shapes_result: Optional[Tuple[bool, str]] = None
 
+        # Text sizing (OSC 66) detection cache
+        self._text_sizing_cache: Optional[TextSizingResult] = None
+
     def __init_set_styling(self, force_styling: bool) -> None:
         self._does_styling = False
         if os.getenv('NO_COLOR'):
@@ -1820,7 +1823,8 @@ class Terminal():
         self._kitty_pointer_shapes_result = (False, '')
         return None
 
-    def does_text_sizing(self, timeout: float = 1) -> TextSizingResult:
+    def does_text_sizing(self, timeout: float = 1,
+                         force: bool = False) -> TextSizingResult:
         """
         Detect Kitty text sizing protocol support (OSC 66).
 
@@ -1829,12 +1833,17 @@ class Terminal():
         up to 2 destructive spaces at the current cursor position, while
         unsupported terminals typically produce no output.
 
+        Responses are cached unless *force* is True.
+
         :arg float timeout: Timeout in seconds for each CPR query.
+        :arg bool force: Bypass cached result.
         :rtype: TextSizingResult
         :returns: Result with ``.width`` and ``.scale`` boolean attributes.
         """
         if not self.is_a_tty or not self._does_styling:
             return TextSizingResult()
+        if self._text_sizing_cache is not None and not force:
+            return self._text_sizing_cache
 
         _, col0 = self.get_location(timeout)
         if col0 == -1:
@@ -1856,7 +1865,9 @@ class Terminal():
 
         width = col1 - col0 == 2
         scale = col2 - col1 == 2
-        return TextSizingResult(width=width, scale=scale)
+        result = TextSizingResult(width=width, scale=scale)
+        self._text_sizing_cache = result
+        return result
 
     @contextlib.contextmanager
     def mouse_enabled(self, *, clicks: bool = True, report_pixels: bool = False,

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -56,8 +56,8 @@ from ._capabilities import (CAPABILITY_DATABASE,
                             XTGETTCAP_CAPABILITIES,
                             CAPABILITIES_HORIZONTAL_DISTANCE,
                             TermcapResponse,
-                            ITerm2Capabilities,
-                            TextSizingResult)
+                            TextSizingResult,
+                            ITerm2Capabilities)
 
 # isort: off
 

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -675,7 +675,6 @@ class Terminal():
         :return: re.match object for response_re or None if not found
         :rtype: re.Match
         """
-        # No query is ever done for terminals where is_a_tty is False
         if not self.is_a_tty:
             return None
 
@@ -713,7 +712,8 @@ class Terminal():
 
     def _query_with_boundary(self, query_str: str,
                              feature_re: "re.Pattern[str]",
-                             timeout: Optional[float]
+                             timeout: Optional[float],
+                             requires_styling: bool = True
                              ) -> Optional[Match[str]]:
         """
         Query the terminal with a CPR boundary guard for fast negatives.
@@ -725,9 +725,14 @@ class Terminal():
         :arg str query_str: Query string written to output.
         :arg re.Pattern feature_re: Compiled regex for the feature response.
         :arg float timeout: Timeout in seconds for each sub-query.
+        :arg bool requires_styling: When True (default), return None if
+            :attr:`does_styling` is False.  Set to False for queries
+            unrelated to visual styling, such as keyboard protocol state.
         :rtype: re.Match or None
         """
         if not self.is_a_tty:
+            return None
+        if requires_styling and not self._does_styling:
             return None
 
         # Send feature query + CPR request. We always wait for the CPR
@@ -1765,9 +1770,8 @@ class Terminal():
         """
         Check if the terminal supports the Kitty clipboard protocol (mode 5522).
 
-        Sends a DECRQM query for DEC private mode 5522 (Bracketed Paste MIME)
-        with a CPR boundary guard for fast negative detection on terminals that
-        do not recognize the mode.
+        Sends a DECRQM query for DEC private mode 5522 (Bracketed Paste MIME) with a CPR boundary
+        guard for fast negative detection on terminals that do not recognize the mode.
 
         :arg float timeout: Timeout in seconds.
         :arg bool force: Bypass cached result.
@@ -1828,7 +1832,7 @@ class Terminal():
         :rtype: tuple
         :returns: ``(width, scale)`` where each is ``True`` if supported.
         """
-        if not self.is_a_tty:
+        if not self.is_a_tty or not self._does_styling:
             return (False, False)
 
         _, col0 = self.get_location(timeout)
@@ -2303,7 +2307,8 @@ class Terminal():
 
         response_pattern = re.compile(r'\x1b\[\?([0-9]*)u')
         match = self._query_with_boundary(
-            '\x1b[?u', response_pattern, timeout)
+            '\x1b[?u', response_pattern, timeout,
+            requires_styling=False)
 
         if match is None:
             if self.is_a_tty:

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -56,7 +56,8 @@ from ._capabilities import (CAPABILITY_DATABASE,
                             XTGETTCAP_CAPABILITIES,
                             CAPABILITIES_HORIZONTAL_DISTANCE,
                             TermcapResponse,
-                            ITerm2Capabilities)
+                            ITerm2Capabilities,
+                            TextSizingResult)
 
 # isort: off
 
@@ -1819,7 +1820,7 @@ class Terminal():
         self._kitty_pointer_shapes_result = (False, '')
         return None
 
-    def does_text_sizing(self, timeout: float = 1) -> Tuple[bool, bool]:
+    def does_text_sizing(self, timeout: float = 1) -> TextSizingResult:
         """
         Detect Kitty text sizing protocol support (OSC 66).
 
@@ -1829,31 +1830,33 @@ class Terminal():
         unsupported terminals typically produce no output.
 
         :arg float timeout: Timeout in seconds for each CPR query.
-        :rtype: tuple
-        :returns: ``(width, scale)`` where each is ``True`` if supported.
+        :rtype: TextSizingResult
+        :returns: Result with ``.width`` and ``.scale`` boolean attributes.
         """
         if not self.is_a_tty or not self._does_styling:
-            return (False, False)
+            return TextSizingResult()
 
         _, col0 = self.get_location(timeout)
         if col0 == -1:
-            return (False, False)
+            return TextSizingResult()
 
+        # width test
         self.stream.write('\x1b]66;w=2; \x07')
         self.stream.flush()
         _, col1 = self.get_location(timeout)
         if col1 == -1:
-            return (False, False)
+            return TextSizingResult()
 
+        # scale test
         self.stream.write('\x1b]66;s=2; \x07')
         self.stream.flush()
         _, col2 = self.get_location(timeout)
         if col2 == -1:
-            return (False, False)
+            return TextSizingResult()
 
         width = col1 - col0 == 2
         scale = col2 - col1 == 2
-        return (width, scale)
+        return TextSizingResult(width=width, scale=scale)
 
     @contextlib.contextmanager
     def mouse_enabled(self, *, clicks: bool = True, report_pixels: bool = False,

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -107,6 +107,8 @@ _RE_ITERM2_CAPABILITIES_RESPONSE = re.compile(
 _RE_KITTY_NOTIFICATIONS_RESPONSE = re.compile(
     r'\x1b\]99;([^\x07\x1b]*?)[\x07\x1b]')
 _RE_CPR_BOUNDARY = re.compile(r'\x1b\[[0-9]+;[0-9]+R')
+_RE_KITTY_CLIPBOARD = re.compile(r'\x1b\[\?5522;(\d+)\$y')
+_RE_KITTY_POINTER = re.compile(r'\x1b\]22;([^\x07\x1b]+)[\x07\x1b]')
 
 
 class Terminal():
@@ -298,6 +300,12 @@ class Terminal():
 
         # Kitty notifications (OSC 99) detection cache
         self._kitty_notifications_supported: Optional[bool] = None
+
+        # Kitty clipboard protocol (DECRQM 5522) detection cache
+        self._kitty_clipboard_supported: Optional[bool] = None
+
+        # Kitty pointer shapes (OSC 22) detection cache
+        self._kitty_pointer_shapes_result: Optional[Tuple[bool, str]] = None
 
     def __init_set_styling(self, force_styling: bool) -> None:
         self._does_styling = False
@@ -1751,6 +1759,97 @@ class Terminal():
         supported = match is not None
         self._kitty_notifications_supported = supported
         return supported
+
+    def does_kitty_clipboard(self, timeout: Optional[float] = 1,
+                             force: bool = False) -> bool:
+        """
+        Check if the terminal supports the Kitty clipboard protocol (mode 5522).
+
+        Sends a DECRQM query for DEC private mode 5522 (Bracketed Paste MIME)
+        with a CPR boundary guard for fast negative detection on terminals that
+        do not recognize the mode.
+
+        :arg float timeout: Timeout in seconds.
+        :arg bool force: Bypass cached result.
+        :rtype: bool
+        """
+        if self._kitty_clipboard_supported is not None and not force:
+            return self._kitty_clipboard_supported
+
+        match = self._query_with_boundary(
+            '\x1b[?5522$p', _RE_KITTY_CLIPBOARD, timeout)
+        supported = False
+        if match:
+            ps = int(match.group(1))
+            if ps not in (0, 4):
+                supported = True
+        self._kitty_clipboard_supported = supported
+        return supported
+
+    def does_kitty_pointer_shapes(self, timeout: Optional[float] = 1,
+                                  force: bool = False
+                                  ) -> Optional[str]:
+        """
+        Query Kitty mouse pointer shape support (OSC 22).
+
+        Returns the current pointer shape name if supported, or ``None``
+        if the terminal does not respond.  Uses a CPR boundary guard for
+        fast negative detection.
+
+        .. seealso:: https://sw.kovidgoyal.net/kitty/pointer-shapes/
+
+        :arg float timeout: Timeout in seconds.
+        :arg bool force: Bypass cached result.
+        :rtype: str or None
+        """
+        if self._kitty_pointer_shapes_result is not None and not force:
+            supported, shape = self._kitty_pointer_shapes_result
+            return shape if supported else None
+
+        match = self._query_with_boundary(
+            '\x1b]22;?__current__\x1b\\', _RE_KITTY_POINTER, timeout)
+        if match:
+            shape = match.group(1)
+            self._kitty_pointer_shapes_result = (True, shape)
+            return shape
+        self._kitty_pointer_shapes_result = (False, '')
+        return None
+
+    def does_text_sizing(self, timeout: float = 1) -> Tuple[bool, bool]:
+        """
+        Detect Kitty text sizing protocol support (OSC 66).
+
+        Tests width and scale text sizing by sending OSC 66 probes and
+        measuring cursor position delta.  Supported terminals may write
+        up to 2 destructive spaces at the current cursor position, while
+        unsupported terminals typically produce no output.
+
+        :arg float timeout: Timeout in seconds for each CPR query.
+        :rtype: tuple
+        :returns: ``(width, scale)`` where each is ``True`` if supported.
+        """
+        if not self.is_a_tty:
+            return (False, False)
+
+        _, col0 = self.get_location(timeout)
+        if col0 == -1:
+            return (False, False)
+
+        self.stream.write('\x1b]66;w=2; \x07')
+        self.stream.flush()
+        _, col1 = self.get_location(timeout)
+        if col1 == -1:
+            return (False, False)
+
+        self.stream.write('\x1b]66;s=2; \x07')
+        self.stream.flush()
+        _, col2 = self.get_location(timeout)
+        if col2 == -1:
+            return (False, False)
+
+        width = col1 - col0 == 2
+        scale = col2 - col1 == 2
+        return (width, scale)
 
     @contextlib.contextmanager
     def mouse_enabled(self, *, clicks: bool = True, report_pixels: bool = False,

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -6,6 +6,8 @@ Version History
 1.32
   * bugfix: :meth:`~.Terminal.get_kitty_keyboard_state` should not check for
     :attr:`~.Terminal.does_styling` as a requirement.
+  * bugfix: :meth:`~.Terminal.get_fgcolor` and :meth:`~.Terminal.get_bgcolor` now
+    return "no support" value, ``(-1, -1, -1)`` when :attr:`~.Terminal.does_styling` is False.
   * introduced: :meth:`~.Terminal.does_kitty_clipboard`,
     :meth:`~.Terminal.does_kitty_pointer_shapes`, and :meth:`~.Terminal.does_text_sizing`
   * introduced: :meth:`~.DecModeResponse.to_dict` and ``DecPrivateMode.BRACKETED_PASTE_MIME``

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,14 @@
 Version History
 ===============
 
+1.32
+  * bugfix: :meth:`~.Terminal.get_kitty_keyboard_state` should not check for
+    :attr:`~.Terminal.does_styling` as a requirement.
+  * introduced: :meth:`~.Terminal.does_kitty_clipboard`,
+    :meth:`~.Terminal.does_kitty_pointer_shapes`, and :meth:`~.Terminal.does_text_sizing`
+  * introduced: :meth:`~.DecModeResponse.to_dict` and ``DecPrivateMode.BRACKETED_PASTE_MIME``
+    constant (mode 5522).
+
 1.31
   * bugfix: :meth:`~.cbreak` and :meth:`~.raw` should use ``TCSADRAIN`` to preserve keystrokes
     buffered during mode switches, previously ``TCSAFLUSH`` was used which discarded unread input,

--- a/tests/test_autoresponses.py
+++ b/tests/test_autoresponses.py
@@ -6,7 +6,7 @@ import io
 import pytest
 
 # local
-from blessed._capabilities import ITerm2Capabilities
+from blessed._capabilities import ITerm2Capabilities, TextSizingResult
 from .conftest import IS_WINDOWS
 from .accessories import TestTerminal, as_subprocess, pty_test
 
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.skipif(
     ('does_kitty_clipboard', False),
     ('does_kitty_pointer_shapes', None),
     ('get_iterm2_capabilities', None),
-    ('does_text_sizing', (False, False)),
+    ('does_text_sizing', TextSizingResult()),
 ])
 def test_detection_not_a_tty(method_name, expected):
     """Detection methods return falsy default when not a TTY."""
@@ -41,7 +41,7 @@ def test_detection_not_a_tty(method_name, expected):
     ('does_kitty_clipboard', False),
     ('does_kitty_pointer_shapes', None),
     ('get_iterm2_capabilities', None),
-    ('does_text_sizing', (False, False)),
+    ('does_text_sizing', TextSizingResult()),
 ])
 def test_detection_no_styling(method_name, expected):
     """Detection methods return falsy default when does_styling is False."""
@@ -348,4 +348,102 @@ def test_query_with_boundary_timeout():
 
     output = pty_test(child, parent_func=None,
                       test_name='test_query_with_boundary_timeout')
+    assert 'OK' in output
+
+
+def test_query_with_boundary_requires_styling():
+    """_query_with_boundary returns None when requires_styling and not styling."""
+    import re
+
+    def child(term):
+        feature_re = re.compile(r'\x1b_Gi=31;(.+?)\x1b\\')
+        term._does_styling = False
+        match = term._query_with_boundary(
+            '\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\',
+            feature_re, timeout=0.5, requires_styling=True)
+        assert match is None
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_query_with_boundary_requires_styling')
+    assert 'OK' in output
+
+
+def test_does_text_sizing_both_supported():
+    """does_text_sizing returns (True, True) when both width and scale detected."""
+    def child(term):
+        term.ungetch('\x1b[1;11R\x1b[1;13R\x1b[1;15R')
+        result = term.does_text_sizing(timeout=0.1)
+        assert result == TextSizingResult(width=True, scale=True)
+        assert result
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_does_text_sizing_both_supported')
+    assert 'OK' in output
+
+
+def test_does_text_sizing_width_only():
+    """does_text_sizing returns (True, False) when only width detected."""
+    def child(term):
+        term.ungetch('\x1b[1;11R\x1b[1;13R\x1b[1;14R')
+        result = term.does_text_sizing(timeout=0.1)
+        assert result == TextSizingResult(width=True, scale=False)
+        assert result
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_does_text_sizing_width_only')
+    assert 'OK' in output
+
+
+def test_does_text_sizing_neither_supported():
+    """does_text_sizing returns falsy result when no sizing detected."""
+    def child(term):
+        term.ungetch('\x1b[1;11R\x1b[1;11R\x1b[1;11R')
+        result = term.does_text_sizing(timeout=0.1)
+        assert result == TextSizingResult()
+        assert not result
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_does_text_sizing_neither_supported')
+    assert 'OK' in output
+
+
+def test_does_text_sizing_initial_location_timeout():
+    """does_text_sizing returns falsy result when first get_location times out."""
+    def child(term):
+        result = term.does_text_sizing(timeout=0.01)
+        assert result == TextSizingResult()
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_does_text_sizing_initial_location_timeout')
+    assert 'OK' in output
+
+
+def test_does_text_sizing_width_location_timeout():
+    """does_text_sizing returns falsy result when second get_location times out."""
+    def child(term):
+        term.ungetch('\x1b[1;11R')
+        result = term.does_text_sizing(timeout=0.01)
+        assert result == TextSizingResult()
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_does_text_sizing_width_location_timeout')
+    assert 'OK' in output
+
+
+def test_does_text_sizing_scale_location_timeout():
+    """does_text_sizing returns falsy result when third get_location times out."""
+    def child(term):
+        term.ungetch('\x1b[1;11R\x1b[1;13R')
+        result = term.does_text_sizing(timeout=0.01)
+        assert result == TextSizingResult()
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_does_text_sizing_scale_location_timeout')
     assert 'OK' in output

--- a/tests/test_autoresponses.py
+++ b/tests/test_autoresponses.py
@@ -19,70 +19,57 @@ pytestmark = pytest.mark.skipif(
     ('does_iterm2', False),
     ('does_iterm2_graphics', False),
     ('does_kitty_notifications', False),
+    ('does_kitty_clipboard', False),
+    ('does_kitty_pointer_shapes', None),
+    ('get_iterm2_capabilities', None),
+    ('does_text_sizing', (False, False)),
 ])
 def test_detection_not_a_tty(method_name, expected):
-    """Boolean detection methods return False when not a TTY."""
+    """Detection methods return falsy default when not a TTY."""
     @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True,
                             is_a_tty=False)
         result = getattr(term, method_name)(timeout=0.01)
-        assert result is expected
+        assert result == expected
     child()
 
 
-def test_get_iterm2_capabilities_not_a_tty():
-    """get_iterm2_capabilities returns None when not a TTY."""
-    @as_subprocess
-    def child():
-        term = TestTerminal(stream=io.StringIO(), force_styling=True,
-                            is_a_tty=False)
-        result = term.get_iterm2_capabilities(timeout=0.01)
-        assert result is None
-    child()
-
-
-def test_does_kitty_graphics_no_styling():
-    """does_kitty_graphics returns False when does_styling is False."""
+@pytest.mark.parametrize('method_name,expected', [
+    ('does_kitty_graphics', False),
+    ('does_kitty_notifications', False),
+    ('does_kitty_clipboard', False),
+    ('does_kitty_pointer_shapes', None),
+    ('get_iterm2_capabilities', None),
+    ('does_text_sizing', (False, False)),
+])
+def test_detection_no_styling(method_name, expected):
+    """Detection methods return falsy default when does_styling is False."""
     @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=False)
-        result = term.does_kitty_graphics(timeout=0.01)
-        assert result is False
+        result = getattr(term, method_name)(timeout=0.01)
+        assert result == expected
     child()
 
 
-def test_get_iterm2_capabilities_no_styling():
-    """get_iterm2_capabilities returns None when does_styling is False."""
-    @as_subprocess
-    def child():
-        term = TestTerminal(stream=io.StringIO(), force_styling=False)
-        result = term.get_iterm2_capabilities(timeout=0.01)
-        assert result is None
-    child()
-
-
-def test_does_kitty_graphics_cached_true():
-    """does_kitty_graphics returns cached True."""
+@pytest.mark.parametrize('method_name,cache_attr,cached_value,expected', [
+    ('does_kitty_graphics', '_kitty_graphics_supported', True, True),
+    ('does_kitty_graphics', '_kitty_graphics_supported', False, False),
+    ('does_kitty_notifications', '_kitty_notifications_supported', True, True),
+    ('does_kitty_notifications', '_kitty_notifications_supported', False, False),
+    ('does_kitty_clipboard', '_kitty_clipboard_supported', True, True),
+    ('does_kitty_clipboard', '_kitty_clipboard_supported', False, False),
+])
+def test_detection_cached_bool(method_name, cache_attr, cached_value, expected):
+    """Boolean detection methods return cached value."""
     @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
         term._is_a_tty = True
-        term._kitty_graphics_supported = True
-        assert term.does_kitty_graphics() is True
-    child()
-
-
-def test_does_kitty_graphics_cached_false():
-    """does_kitty_graphics returns cached False."""
-    @as_subprocess
-    def child():
-        stream = io.StringIO()
-        term = TestTerminal(stream=stream, force_styling=True)
-        term._is_a_tty = True
-        term._kitty_graphics_supported = False
-        assert term.does_kitty_graphics() is False
+        setattr(term, cache_attr, cached_value)
+        assert getattr(term, method_name)() is expected
     child()
 
 
@@ -100,40 +87,45 @@ def test_get_iterm2_capabilities_cached():
     child()
 
 
-def test_does_kitty_notifications_cached_true():
-    """does_kitty_notifications returns cached True."""
+def test_does_kitty_pointer_shapes_cached_supported():
+    """does_kitty_pointer_shapes returns cached shape string."""
     @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
         term._is_a_tty = True
-        term._kitty_notifications_supported = True
-        assert term.does_kitty_notifications() is True
+        term._kitty_pointer_shapes_result = (True, 'beam')
+        assert term.does_kitty_pointer_shapes() == 'beam'
     child()
 
 
-def test_does_kitty_notifications_cached_false():
-    """does_kitty_notifications returns cached False."""
+def test_does_kitty_pointer_shapes_cached_unsupported():
+    """does_kitty_pointer_shapes returns None when cached unsupported."""
     @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
         term._is_a_tty = True
-        term._kitty_notifications_supported = False
-        assert term.does_kitty_notifications() is False
+        term._kitty_pointer_shapes_result = (False, '')
+        assert term.does_kitty_pointer_shapes() is None
     child()
 
 
-def test_does_kitty_graphics_force_bypass():
-    """force=True bypasses kitty graphics cache."""
+@pytest.mark.parametrize('method_name,cache_attr,cached_value', [
+    ('does_kitty_graphics', '_kitty_graphics_supported', True),
+    ('does_kitty_notifications', '_kitty_notifications_supported', True),
+    ('does_kitty_clipboard', '_kitty_clipboard_supported', True),
+])
+def test_detection_force_bypass(method_name, cache_attr, cached_value):
+    """force=True bypasses detection cache."""
     def child(term):
-        term._kitty_graphics_supported = True
-        result = term.does_kitty_graphics(timeout=0.01, force=True)
+        setattr(term, cache_attr, cached_value)
+        result = getattr(term, method_name)(timeout=0.01, force=True)
         assert result is False
         return b'OK'
 
     output = pty_test(child, parent_func=None,
-                      test_name='test_does_kitty_graphics_force_bypass')
+                      test_name=f'test_detection_force_bypass_{method_name}')
     assert 'OK' in output
 
 
@@ -152,16 +144,16 @@ def test_get_iterm2_capabilities_force_bypass():
     assert 'OK' in output
 
 
-def test_does_kitty_notifications_force_bypass():
-    """force=True bypasses kitty notifications cache."""
+def test_does_kitty_pointer_shapes_force_bypass():
+    """force=True bypasses kitty pointer shapes cache."""
     def child(term):
-        term._kitty_notifications_supported = True
-        result = term.does_kitty_notifications(timeout=0.01, force=True)
-        assert result is False
+        term._kitty_pointer_shapes_result = (True, 'beam')
+        result = term.does_kitty_pointer_shapes(timeout=0.01, force=True)
+        assert result is None
         return b'OK'
 
     output = pty_test(child, parent_func=None,
-                      test_name='test_does_kitty_notifications_force_bypass')
+                      test_name='test_does_kitty_pointer_shapes_force_bypass')
     assert 'OK' in output
 
 
@@ -191,15 +183,21 @@ def test_does_kitty_graphics_error_response():
     assert 'OK' in output
 
 
-def test_does_kitty_graphics_timeout():
-    """does_kitty_graphics returns False on timeout."""
+@pytest.mark.parametrize('method_name,expected', [
+    ('does_kitty_graphics', False),
+    ('does_kitty_notifications', False),
+    ('does_kitty_clipboard', False),
+    ('does_kitty_pointer_shapes', None),
+])
+def test_detection_timeout(method_name, expected):
+    """Detection methods return falsy default on timeout."""
     def child(term):
-        result = term.does_kitty_graphics(timeout=0.01)
-        assert result is False
+        result = getattr(term, method_name)(timeout=0.01)
+        assert result == expected
         return b'OK'
 
     output = pty_test(child, parent_func=None,
-                      test_name='test_does_kitty_graphics_timeout')
+                      test_name=f'test_detection_timeout_{method_name}')
     assert 'OK' in output
 
 
@@ -247,64 +245,56 @@ def test_does_kitty_notifications_supported():
     assert 'OK' in output
 
 
-def test_does_kitty_notifications_timeout():
-    """does_kitty_notifications returns False on timeout."""
+@pytest.mark.parametrize('method_name,cached_supported', [
+    ('does_iterm2', True),
+    ('does_iterm2', False),
+    ('does_iterm2_graphics', True),
+    ('does_iterm2_graphics', False),
+])
+def test_does_iterm2_delegates_cached(method_name, cached_supported):
+    """does_iterm2 and does_iterm2_graphics return cached result."""
+    @as_subprocess
+    def child():
+        stream = io.StringIO()
+        term = TestTerminal(stream=stream, force_styling=True)
+        term._is_a_tty = True
+        term._iterm2_capabilities_cache = ITerm2Capabilities(
+            supported=cached_supported)
+        assert getattr(term, method_name)() is cached_supported
+    child()
+
+
+@pytest.mark.parametrize('ps,expected', [
+    (1, True),
+    (2, True),
+    (3, True),
+    (0, False),
+    (4, False),
+])
+def test_does_kitty_clipboard_decrqm_values(ps, expected):
+    """does_kitty_clipboard interprets DECRQM response values."""
     def child(term):
-        result = term.does_kitty_notifications(timeout=0.01)
-        assert result is False
+        term.ungetch(f'\x1b[?5522;{ps}$y\x1b[10;20R')
+        result = term.does_kitty_clipboard(timeout=0.01)
+        assert result is expected
         return b'OK'
 
     output = pty_test(child, parent_func=None,
-                      test_name='test_does_kitty_notifications_timeout')
+                      test_name=f'test_does_kitty_clipboard_decrqm_{ps}')
     assert 'OK' in output
 
 
-def test_does_iterm2_with_cached_supported():
-    """does_iterm2 returns True with cached supported result."""
-    @as_subprocess
-    def child():
-        stream = io.StringIO()
-        term = TestTerminal(stream=stream, force_styling=True)
-        term._is_a_tty = True
-        term._iterm2_capabilities_cache = ITerm2Capabilities(supported=True)
-        assert term.does_iterm2() is True
-    child()
+def test_does_kitty_pointer_shapes_supported():
+    """does_kitty_pointer_shapes returns shape name with OSC 22 response."""
+    def child(term):
+        term.ungetch('\x1b]22;default\x07\x1b[10;20R')
+        result = term.does_kitty_pointer_shapes(timeout=0.01)
+        assert result == 'default'
+        return b'OK'
 
-
-def test_does_iterm2_with_cached_unsupported():
-    """does_iterm2 returns False with cached unsupported result."""
-    @as_subprocess
-    def child():
-        stream = io.StringIO()
-        term = TestTerminal(stream=stream, force_styling=True)
-        term._is_a_tty = True
-        term._iterm2_capabilities_cache = ITerm2Capabilities(supported=False)
-        assert term.does_iterm2() is False
-    child()
-
-
-def test_does_iterm2_graphics_delegates():
-    """does_iterm2_graphics delegates to does_iterm2."""
-    @as_subprocess
-    def child():
-        stream = io.StringIO()
-        term = TestTerminal(stream=stream, force_styling=True)
-        term._is_a_tty = True
-        term._iterm2_capabilities_cache = ITerm2Capabilities(supported=True)
-        assert term.does_iterm2_graphics() is True
-    child()
-
-
-def test_does_iterm2_graphics_delegates_false():
-    """does_iterm2_graphics returns False when iterm2 unsupported."""
-    @as_subprocess
-    def child():
-        stream = io.StringIO()
-        term = TestTerminal(stream=stream, force_styling=True)
-        term._is_a_tty = True
-        term._iterm2_capabilities_cache = ITerm2Capabilities(supported=False)
-        assert term.does_iterm2_graphics() is False
-    child()
+    output = pty_test(child, parent_func=None,
+                      test_name='test_does_kitty_pointer_shapes_supported')
+    assert 'OK' in output
 
 
 def test_query_with_boundary_feature_supported():

--- a/tests/test_autoresponses.py
+++ b/tests/test_autoresponses.py
@@ -407,7 +407,8 @@ def test_text_sizing_result_eq_non_text_sizing():
 def test_text_sizing_result_repr():
     """TextSizingResult.__repr__ includes width and scale."""
     assert repr(TextSizingResult()) == "TextSizingResult(width=False, scale=False)"
-    assert repr(TextSizingResult(width=True, scale=True)) == "TextSizingResult(width=True, scale=True)"
+    assert repr(TextSizingResult(width=True, scale=True)
+                ) == "TextSizingResult(width=True, scale=True)"
 
 
 def test_does_text_sizing_both_supported():

--- a/tests/test_autoresponses.py
+++ b/tests/test_autoresponses.py
@@ -144,6 +144,34 @@ def test_get_iterm2_capabilities_force_bypass():
     assert 'OK' in output
 
 
+def test_does_text_sizing_cached():
+    """does_text_sizing returns cached result."""
+    @as_subprocess
+    def child():
+        stream = io.StringIO()
+        term = TestTerminal(stream=stream, force_styling=True)
+        term._is_a_tty = True
+        cached = TextSizingResult(width=True, scale=True)
+        term._text_sizing_cache = cached
+        assert term.does_text_sizing() is cached
+    child()
+
+
+def test_does_text_sizing_force_bypass():
+    """force=True bypasses text sizing cache."""
+    def child(term):
+        cached = TextSizingResult(width=True, scale=True)
+        term._text_sizing_cache = cached
+        result = term.does_text_sizing(timeout=0.01, force=True)
+        assert result is not cached
+        assert not result
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_does_text_sizing_force_bypass')
+    assert 'OK' in output
+
+
 def test_does_kitty_pointer_shapes_force_bypass():
     """force=True bypasses kitty pointer shapes cache."""
     def child(term):

--- a/tests/test_autoresponses.py
+++ b/tests/test_autoresponses.py
@@ -397,6 +397,19 @@ def test_query_with_boundary_requires_styling():
     assert 'OK' in output
 
 
+def test_text_sizing_result_eq_non_text_sizing():
+    """TextSizingResult.__eq__ returns NotImplemented for other types."""
+    result = TextSizingResult(width=True, scale=False)
+    assert result != (True, False)
+    assert result != "TextSizingResult(width=True, scale=False)"
+
+
+def test_text_sizing_result_repr():
+    """TextSizingResult.__repr__ includes width and scale."""
+    assert repr(TextSizingResult()) == "TextSizingResult(width=False, scale=False)"
+    assert repr(TextSizingResult(width=True, scale=True)) == "TextSizingResult(width=True, scale=True)"
+
+
 def test_does_text_sizing_both_supported():
     """does_text_sizing returns (True, True) when both width and scale detected."""
     def child(term):

--- a/tests/test_dec_modes.py
+++ b/tests/test_dec_modes.py
@@ -251,6 +251,41 @@ def test_dec_mode_response_repr():
     assert repr(response_unknown) == expected_unknown
 
 
+def test_dec_mode_response_to_dict():
+    """DecModeResponse.to_dict returns expected keys and values."""
+    response = DecModeResponse(_DPM.DECTCEM, DecModeResponse.SET)
+    result = response.to_dict()
+    assert result == {
+        'value': 1,
+        'value_description': 'SET',
+        'mode_description': response.description,
+        'mode_name': 'DECTCEM',
+        'supported': True,
+        'enabled': True,
+        'changeable': True,
+    }
+
+
+@pytest.mark.parametrize('value,expected_supported,expected_enabled,expected_changeable', [
+    (DecModeResponse.NOT_RECOGNIZED, False, False, False),
+    (DecModeResponse.RESET, True, False, True),
+    (DecModeResponse.PERMANENTLY_SET, True, True, False),
+    (DecModeResponse.PERMANENTLY_RESET, True, False, False),
+    (DecModeResponse.NO_RESPONSE, False, False, False),
+])
+def test_dec_mode_response_to_dict_values(
+    value, expected_supported, expected_enabled, expected_changeable
+):
+    """DecModeResponse.to_dict reflects computed properties for each value."""
+    response = DecModeResponse(_DPM.DECTCEM, value)
+    result = response.to_dict()
+    assert result['supported'] == expected_supported
+    assert result['enabled'] == expected_enabled
+    assert result['changeable'] == expected_changeable
+    assert result['value'] == value
+    assert result['mode_name'] == 'DECTCEM'
+
+
 def test_dec_mode_response_description_fallback():
     """Test DecModeResponse.description returns fallback for edge cases."""
     response = DecModeResponse(_DPM.DECTCEM, DecModeResponse.SET)

--- a/tests/test_full_keyboard.py
+++ b/tests/test_full_keyboard.py
@@ -643,8 +643,8 @@ def test_get_fgcolor_0s_reply_via_ungetch():
     child()
 
 
-def test_get_fgcolor_styling_indifferent():
-    """Ensure get_fgcolor() behavior is the same regardless of styling"""
+def test_get_fgcolor_requires_styling():
+    """get_fgcolor returns (-1, -1, -1) when does_styling is False."""
     @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
@@ -653,9 +653,8 @@ def test_get_fgcolor_styling_indifferent():
         assert rgb == (210, 180, 140)
 
         term = TestTerminal(stream=StringIO(), force_styling=False, is_a_tty=True)
-        term.ungetch('\x1b]10;rgb:40/e0/d0\x07')  # turquoise
         rgb = term.get_fgcolor(timeout=0.01, bits=8)
-        assert rgb == (64, 224, 208)
+        assert rgb == (-1, -1, -1)
     child()
 
 
@@ -696,8 +695,8 @@ def test_get_bgcolor_0s_reply_via_ungetch():
     child()
 
 
-def test_get_bgcolor_styling_indifferent():
-    """Ensure get_bgcolor() behavior is the same regardless of styling"""
+def test_get_bgcolor_requires_styling():
+    """get_bgcolor returns (-1, -1, -1) when does_styling is False."""
     @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
@@ -706,9 +705,8 @@ def test_get_bgcolor_styling_indifferent():
         assert rgb == (255, 228, 196)
 
         term = TestTerminal(stream=StringIO(), force_styling=False, is_a_tty=True)
-        term.ungetch('\x1b]11;rgb:de/b8/87\x07')  # burlywood
         rgb = term.get_bgcolor(timeout=0.01, bits=8)
-        assert rgb == (222, 184, 135)
+        assert rgb == (-1, -1, -1)
     child()
 
 


### PR DESCRIPTION
* bugfix: method ``Terminal.get_kitty_keyboard_state`` should not check for ``does_styling`` as a requirement.
* bugfix: method ``Terminal.get_fgcolor`` and ``get_bgcolor`` now return "no support" value, ``(-1, -1, -1)`` when ``does_styling`` is False.
* introduced: new methods ``Terminal.does_kitty_clipboard``, ``does_kitty_pointer_shapes``, and ``does_text_sizing``
* introduced: new method ``DecModeResponse.to_dict`` and ``DecPrivateMode.BRACKETED_PASTE_MIME`` constant (mode 5522).
