### PR TITLE
bugfix limit w/yank in LineEditor

### DIFF
--- a/blessed/line_editor.py
+++ b/blessed/line_editor.py
@@ -563,7 +563,10 @@ class LineEditor:  # pylint: disable=too-many-instance-attributes
         if not self._kill_ring:
             return LineEditResult()
         self._save_undo()
-        self._insert_at_cursor(self._kill_ring[-1], check_limit=False)
+        n = self._insert_at_cursor(self._kill_ring[-1])
+        if n == 0:
+            self._undo_stack.pop()
+            return LineEditResult()
         return LineEditResult(changed=True)
 
     def _history_prev(self) -> LineEditResult:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,7 +93,7 @@ master_doc = 'index'
 # General information about the project.
 project = 'Blessed'
 
-copyright = '2011-{datetime.datetime.now().year} Erik Rose, Jeff Quast, Avram Lubkin'
+copyright = f'2011-{datetime.datetime.now().year} Erik Rose, Jeff Quast, Avram Lubkin'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,6 +2,8 @@
 
 Version History
 ===============
+1.33 (not yet released)
+  * bugfix: * :class:`blessed.line_editor.LineEditor` exceed limit when using Yank (Ctrl+Y).
 
 1.32
   * bugfix: :meth:`~.Terminal.get_kitty_keyboard_state` should not check for

--- a/tests/test_line_editor.py
+++ b/tests/test_line_editor.py
@@ -462,6 +462,7 @@ class TestLineEditorKillRing:
         assert ed.line == "hello world"
 
     def test_yank_respects_limit(self) -> None:
+        """Ensure Ctrl-Y respects maximum limit"""
         ed = _editor("hello", _HOME, _CTRL_K, limit=8)
         ed.feed_key(_CTRL_Y)
         assert ed.line == "hello"

--- a/tests/test_line_editor.py
+++ b/tests/test_line_editor.py
@@ -461,6 +461,16 @@ class TestLineEditorKillRing:
         ed.feed_key(_CTRL_Y)
         assert ed.line == "hello world"
 
+    def test_yank_respects_limit(self) -> None:
+        ed = _editor("hello", _HOME, _CTRL_K, limit=8)
+        ed.feed_key(_CTRL_Y)
+        assert ed.line == "hello"
+        r = ed.feed_key(_CTRL_Y)
+        assert len(ed.line) == 8
+        r = ed.feed_key(_CTRL_Y)
+        assert r.changed is False
+        assert len(ed.line) == 8
+
     def test_kill_line_at_position_zero(self) -> None:
         """Test Ctrl-U at position zero reports no change."""
         ed = _editor("ab", _HOME)


### PR DESCRIPTION
- bugfix limit not honored for yank Ctrl+Y
- and lint fix the copyright f-string
