### PR TITLE
Two kitty-related fixes and new/improved kitty-related Keystroke methods

### DIFF
--- a/bin/keyboard_kitty_simple.py
+++ b/bin/keyboard_kitty_simple.py
@@ -4,16 +4,16 @@ from blessed import Terminal
 term = Terminal()
 
 print("Press and hold keys to see raw kitty keystrokes and their names (press 'q' to quit)")
+# disambiguate=True, report_events=True, report_alternates=True, report_all_keys=True
 with term.enable_kitty_keyboard(report_events=True):
     with term.cbreak():
         while True:
             key = term.inkey()
 
-            if key.pressed:
-                print(f"Key {key.name} pressed, value={key.value}, sequence={key!r}")
-                if key == 'q':
-                    break
-            elif key.repeated:
-                print(f"Key repeating, sequence={key!r}")
-            elif key.released:
-                print(f"Key released, sequence={key!r}")
+            kind = ("pressed" if key.pressed
+                    else "repeated" if key.repeated
+                    else "released" if key.released
+                    else "???")
+            if key.pressed and key.value == 'q':
+                break
+            print(f"Key name={key.name} kind={kind} value={key.value}, sequence={key!r}")

--- a/bin/keyboard_kitty_simple.py
+++ b/bin/keyboard_kitty_simple.py
@@ -4,8 +4,7 @@ from blessed import Terminal
 term = Terminal()
 
 print("Press and hold keys to see raw kitty keystrokes and their names (press 'q' to quit)")
-# disambiguate=True, report_events=True, report_alternates=True, report_all_keys=True
-with term.enable_kitty_keyboard(report_events=True):
+with term.enable_kitty_keyboard(report_events=True, report_all_keys=True):
     with term.cbreak():
         while True:
             key = term.inkey()
@@ -16,4 +15,10 @@ with term.enable_kitty_keyboard(report_events=True):
                     else "???")
             if key.pressed and key.value == 'q':
                 break
-            print(f"Key name={key.name} kind={kind} value={key.value}, sequence={key!r}")
+            print(
+                f"Key name={
+                    key.name} value={
+                    key.value}, key_name={
+                    key.key_name} key_value={
+                    key.key_value} kind={kind}, sequence={
+                        key!r}")

--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -15,4 +15,4 @@ else:
 from blessed.line_editor import LineEditor, LineHistory
 
 __all__ = ('Terminal', 'LineEditor', 'LineHistory')
-__version__ = "1.34.0"
+__version__ = "1.35.0"

--- a/blessed/formatters.py
+++ b/blessed/formatters.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # isort: off
 # curses
 if platform.system() == 'Windows':
-    import jinxed as curses   # pylint: disable=import-error
+    import jinxed as curses
 else:
     import curses
 

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -28,7 +28,6 @@ _T = TypeVar('_T', bound='Keystroke')
 # isort: off
 # curses
 if platform.system() == 'Windows':
-    # pylint: disable=import-error
     import jinxed as curses
     from jinxed.has_key import _capability_names as capability_names
 else:
@@ -321,11 +320,16 @@ class Keystroke(str):
             if getattr(self, f'_{mod_name}'):
                 mod_parts.append(mod_name.upper())
 
-        # Only synthesize name if at least one modifier is present
-        if not mod_parts:
+        # For press events, only synthesize name if modifiers are present
+        # (plain text presses like 'a' don't need a name, value suffices).
+        # For release/repeat events, always synthesize a name since value
+        # is empty for releases and name is the only way to identify the key.
+        if not mod_parts and not (self.released or self.repeated):
             return None
 
-        base_result = f"KEY_{'_'.join(mod_parts)}_{char}"
+        base_result = (f"KEY_{'_'.join(mod_parts)}_{char}"
+                       if mod_parts
+                       else f"KEY_{char}")
 
         # Append event type suffix if not a press event
         if self.repeated:

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -233,10 +233,10 @@ class Keystroke(str):
 
     def _get_modified_keycode_name(self) -> Optional[str]:
         """
-        Get name for modern/legacy CSI sequence with modifiers.
+        Get base name for modern/legacy CSI sequence with modifiers.
 
-        Returns name like 'KEY_CTRL_ALT_F1' or 'KEY_SHIFT_UP_RELEASED'. Also handles release/repeat
-        events for keys without modifiers.
+        Returns name like 'KEY_CTRL_ALT_F1' or 'KEY_SHIFT_UP' without
+        event-type suffix.  The suffix is applied by :attr:`name`.
         """
         # Check if this is a special keyboard protocol mode
         if not (self.uses_keyboard_protocol and self._code is not None):
@@ -274,22 +274,16 @@ class Keystroke(str):
             return None
 
         # Build base result with modifiers (if any)
-        base_result = (f"KEY_{'_'.join(mod_parts)}_{base_name}"
-                       if mod_parts
-                       else f"KEY_{base_name}")
-
-        # Append event type suffix if not a press event
-        if self.repeated:
-            return f"{base_result}_REPEATED"
-        if self.released:
-            return f"{base_result}_RELEASED"
-        return base_result  # pressed (no suffix)
+        return (f"KEY_{'_'.join(mod_parts)}_{base_name}"
+                if mod_parts
+                else f"KEY_{base_name}")
 
     def _get_kitty_protocol_name(self) -> Optional[str]:
         """
-        Get name for Kitty keyboard protocol letter/digit/symbol.
+        Get base name for Kitty keyboard protocol letter/digit/symbol.
 
-        Returns name like 'KEY_CTRL_ALT_A', 'KEY_ALT_SHIFT_5', 'KEY_CTRL_J_RELEASED', etc.
+        Returns name like 'KEY_CTRL_ALT_A', 'KEY_ALT_SHIFT_5' without
+        event-type suffix.  The suffix is applied by :attr:`name`.
         """
         if self._mode != DecPrivateMode.SpecialInternalKitty:
             return None
@@ -327,16 +321,9 @@ class Keystroke(str):
         if not mod_parts and not (self.released or self.repeated):
             return None
 
-        base_result = (f"KEY_{'_'.join(mod_parts)}_{char}"
-                       if mod_parts
-                       else f"KEY_{char}")
-
-        # Append event type suffix if not a press event
-        if self.repeated:
-            return f"{base_result}_REPEATED"
-        if self.released:
-            return f"{base_result}_RELEASED"
-        return base_result  # pressed (no suffix)
+        return (f"KEY_{'_'.join(mod_parts)}_{char}"
+                if mod_parts
+                else f"KEY_{char}")
 
     def _get_control_char_name(self) -> Optional[str]:
         """
@@ -467,8 +454,56 @@ class Keystroke(str):
             return 'BRACKETED_PASTE'
         return None
 
+    def _resolve_name(self) -> Optional[str]:
+        """
+        Resolve key name without event-type suffix.
+
+        Shared by :attr:`name` and :attr:`key_name`.  The two keyboard
+        protocol helpers (_get_modified_keycode_name, _get_kitty_protocol_name)
+        return the base name only; :attr:`name` appends the suffix.
+        """
+        # pylint: disable=too-many-return-statements
+        if self._name is not None:
+            return self._name
+
+        # DEC events first (never suffixed)
+        result = self._get_mouse_event_name()
+        if result is not None:
+            return result
+
+        result = self._get_focus_event_name()
+        if result is not None:
+            return result
+
+        result = self._get_bracketed_paste_name()
+        if result is not None:
+            return result
+
+        if self._mode == DecPrivateMode.IN_BAND_WINDOW_RESIZE:
+            return 'RESIZE_EVENT'
+
+        # Keyboard protocol events (suffix applied by .name)
+        result = self._get_modified_keycode_name()
+        if result is not None:
+            return result
+
+        result = self._get_kitty_protocol_name()
+        if result is not None:
+            return result
+
+        # Legacy events (never suffixed)
+        result = self._get_control_char_name()
+        if result is not None:
+            return result
+
+        result = self._get_meta_escape_name()
+        if result is not None:
+            return result
+
+        return self._name
+
     @property
-    def name(self) -> Optional[str]:  # pylint: disable=too-many-return-statements
+    def name(self) -> Optional[str]:
         r"""
         Special application key name.
 
@@ -479,6 +514,11 @@ class Keystroke(str):
 
         The name supports "modifiers", such as ``'KEY_CTRL_F1'``,
         ``'KEY_CTRL_ALT_F1'``, ``'KEY_CTRL_ALT_SHIFT_F1'``
+
+        When using a keyboard protocol with event reporting, names include an
+        event-type suffix: ``'KEY_CTRL_J_REPEATED'`` for repeat and
+        ``'KEY_CTRL_J_RELEASED'`` for release events.  Press events have no
+        suffix.  See :attr:`key_name` for the same name without the suffix.
 
         For mouse events, the name includes the ``'MOUSE_'`` prefix followed by the
         button/action name, such as ``'MOUSE_LEFT'``, ``'MOUSE_MOTION'``,
@@ -497,45 +537,27 @@ class Keystroke(str):
         If this value is None, then it can probably be assumed that the value is an unsurprising
         textual character without any modifiers, like the letter ``'a'``.
         """
-        if self._name is not None:
-            return self._name
+        result = self._resolve_name()
+        if result is not None and self.uses_keyboard_protocol:
+            if self.repeated:
+                return f"{result}_REPEATED"
+            if self.released:
+                return f"{result}_RELEASED"
+        return result
 
-        # Try each helper method in sequence
-        # DEC events first
-        result = self._get_mouse_event_name()
-        if result is not None:
-            return result
+    @property
+    def key_name(self) -> Optional[str]:
+        """
+        Key identity without event-type suffix.
 
-        result = self._get_focus_event_name()
-        if result is not None:
-            return result
+        Like :attr:`name`, but without ``_RELEASED`` and ``_REPEATED``
+        suffixes, so that press, repeat, and release events for the same
+        key all return the same value.  Useful for key-map lookups when
+        tracking press/release pairs.
 
-        result = self._get_bracketed_paste_name()
-        if result is not None:
-            return result
-
-        # Inline resize event check
-        if self._mode == DecPrivateMode.IN_BAND_WINDOW_RESIZE:
-            return 'RESIZE_EVENT'
-
-        # Keyboard events
-        result = self._get_modified_keycode_name()
-        if result is not None:
-            return result
-
-        result = self._get_kitty_protocol_name()
-        if result is not None:
-            return result
-
-        result = self._get_control_char_name()
-        if result is not None:
-            return result
-
-        result = self._get_meta_escape_name()
-        if result is not None:
-            return result
-
-        return self._name
+        :rtype: str or None
+        """
+        return self._resolve_name()
 
     @property
     def code(self) -> Optional[int]:
@@ -1010,6 +1032,26 @@ class Keystroke(str):
         if self.released:
             return ''
 
+        return (self._get_plain_char_value()
+                or self._get_escape_sequence_value()
+                or self._get_ctrl_sequence_value()
+                or self._get_protocol_value()
+                or self._get_ascii_value()
+                or '')
+
+    @property
+    def key_value(self) -> str:
+        r"""
+        Character for this key, even for release events.
+
+        Like :attr:`value`, but does not suppress the character for
+        release events.  For press and repeat events, identical to
+        :attr:`value`.
+
+        :rtype: str
+        """
+        if not self.released:
+            return self.value
         return (self._get_plain_char_value()
                 or self._get_escape_sequence_value()
                 or self._get_ctrl_sequence_value()

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -64,8 +64,8 @@ from ._capabilities import (CAPABILITY_DATABASE,
 HAS_TTY = True  # pylint: disable=invalid-name
 if platform.system() == 'Windows':
     IS_WINDOWS = True
-    import jinxed as curses  # pylint: disable=import-error
-    from jinxed.win32 import get_console_input_encoding  # pylint: disable=import-error
+    import jinxed as curses
+    from jinxed.win32 import get_console_input_encoding
 else:
     IS_WINDOWS = False
     import curses
@@ -87,9 +87,9 @@ else:
 
 _CUR_TERM = None  # See comments at end of file
 RE_GET_FGCOLOR_RESPONSE = re.compile(
-    '\x1b]10;rgb:([0-9a-fA-F]+)/([0-9a-fA-F]+)/([0-9a-fA-F]+)\x07')
+    '\x1b]10;rgb:([0-9a-fA-F]+)/([0-9a-fA-F]+)/([0-9a-fA-F]+)(?:\x07|\x1b\\\\)')
 RE_GET_BGCOLOR_RESPONSE = re.compile(
-    '\x1b]11;rgb:([0-9a-fA-F]+)/([0-9a-fA-F]+)/([0-9a-fA-F]+)\x07')
+    '\x1b]11;rgb:([0-9a-fA-F]+)/([0-9a-fA-F]+)/([0-9a-fA-F]+)(?:\x07|\x1b\\\\)')
 # XTSMGRAPHICS - Query sixel graphics geometry: ESC[?2;0;<width>;<height>S
 _RE_XTSMGRAPHICS_RESPONSE = re.compile(r'\x1b\[\?2;0;(\d+);(\d+)S')
 # XTSMGRAPHICS - Query sixel color registers: ESC[?1;0;<colors>S

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,15 @@
 Version History
 ===============
 
+1.35
+  * bugfix: :meth:`~.Terminal.get_fgcolor` and :meth:`~.Terminal.get_bgcolor` now correctly
+    interprets ST-terminated OSC responses in addition to BEL-terminated.
+  * improved: Synthesize :attr:`~.Keystroke.name` for "released" and "repeated" key states, when
+    using the kitty keyboard protocol.
+  * new: methods :meth:`~Keystroke.key_name` and :meth:`~Keystroke.key_value` allow for better key
+    and value tracking when using kitty keyboard protocol with pressed, released, and repeated
+    events.
+
 1.34
   * improved: Windows now supports :meth:`~.Terminal.does_mouse`,
     :meth:`~.Terminal.notify_on_resize`, and :meth:`~.Terminal.mouse_enabled`. More than 100x

--- a/docs/keyboard.rst
+++ b/docs/keyboard.rst
@@ -145,6 +145,15 @@ The :class:`~.Keystroke` class provides properties about key events:
 * :attr:`~.Keystroke.repeated` - ``True`` if this is a key repeat event
 * :attr:`~.Keystroke.released` - ``True`` if this is a key release event
 
+For press/release tracking, two additional properties provide stable identifiers
+across event types:
+
+* :attr:`~.Keystroke.key_name` - like :attr:`~.Keystroke.name`, but without the
+  ``_RELEASED`` or ``_REPEATED`` suffix, so that the same key always returns the
+  same name regardless of event type.
+* :attr:`~.Keystroke.key_value` - like :attr:`~.Keystroke.value`, but returns the
+  character even for release events (where :attr:`~.Keystroke.value` returns ``''``).
+
 **Note:** These event types can only be distinguished when using the :doc:`Kitty
 Keyboard Protocol <keyboard_kitty>`. Without it, all keystrokes will have
 ``pressed=True`` and ``repeated=False``, ``released=False``.

--- a/docs/keyboard_kitty.rst
+++ b/docs/keyboard_kitty.rst
@@ -72,6 +72,17 @@ The :attr:`~.Keystroke.name` attribute also includes event type suffixes:
 ``KEY_CTRL_J`` for press, ``KEY_CTRL_J_REPEATED`` for repeat, and
 ``KEY_CTRL_J_RELEASED`` for release events.
 
+For press/release tracking (e.g., key maps), use :attr:`~.Keystroke.key_name`
+instead -- it returns the same name regardless of event type (``KEY_CTRL_J``
+for press, repeat, and release).  Similarly, :attr:`~.Keystroke.key_value`
+returns the character even for release events, where :attr:`~.Keystroke.value`
+returns ``''``.
+
+**Note:** To distinguish press, repeat, and release for plain text keys like
+``a`` or ``5``, you must also enable ``report_all_keys=True``. Without it, only
+release events are encoded with the protocol -- press and repeat arrive as plain
+characters with no event-type information.
+
 Example use case - detect only initial key presses and ignore repeats:
 
 .. code-block:: python
@@ -174,3 +185,5 @@ See Also
 * :attr:`Keystroke.pressed` - Check if key was pressed
 * :attr:`Keystroke.repeated` - Check if key is repeating
 * :attr:`Keystroke.released` - Check if key was released
+* :attr:`Keystroke.key_name` - Key identity without event-type suffix
+* :attr:`Keystroke.key_value` - Character for the key, even for release events

--- a/tests/accessories.py
+++ b/tests/accessories.py
@@ -27,7 +27,7 @@ else:
 
 MAX_SUBPROC_TIME_SECONDS = 2  # no test should ever take over 2 seconds
 # extra time given for timeout-related tests for CI/slow machines, by percent
-PCT_MAXWAIT_KEYSTROKE = 1.2
+PCT_MAXWAIT_KEYSTROKE = 1.5
 
 test_kind = 'vtwin10' if IS_WINDOWS else 'xterm-256color'
 

--- a/tests/accessories.py
+++ b/tests/accessories.py
@@ -18,7 +18,7 @@ from .conftest import IS_WINDOWS
 
 if IS_WINDOWS:
     # 3rd party
-    import jinxed as curses  # pylint: disable=import-error
+    import jinxed as curses
 else:
     # std imports
     import pty

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -432,27 +432,27 @@ def test_on_color_hex():
     child()
 
 
-def test_get_fgcolor_hex():
+@pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
+def test_get_fgcolor_hex(terminator):
     """Test get_fgcolor_hex returns hex string."""
     from io import StringIO
 
     @as_subprocess
     def child():
         t = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
-        t.ungetch('\x1b]10;rgb:ffff/ffff/ffff\x07')
+        t.ungetch('\x1b]10;rgb:ffff/ffff/ffff' + terminator)
         assert t.get_fgcolor_hex(timeout=0.01) == '#ffffff'
 
-        t.ungetch('\x1b]10;rgb:2828/2c2c/3434\x07')
+        t.ungetch('\x1b]10;rgb:2828/2c2c/3434' + terminator)
         assert t.get_fgcolor_hex(timeout=0.01) == '#282c34'
 
-        # XParseColor shorthand formats (1, 2, 3 hex digits)
-        t.ungetch('\x1b]10;rgb:f/f/f\x07')
+        t.ungetch('\x1b]10;rgb:f/f/f' + terminator)
         assert t.get_fgcolor_hex(timeout=0.01) == '#ffffff'
 
-        t.ungetch('\x1b]10;rgb:e5/e5/e5\x07')
+        t.ungetch('\x1b]10;rgb:e5/e5/e5' + terminator)
         assert t.get_fgcolor_hex(timeout=0.01) == '#e5e5e5'
 
-        t.ungetch('\x1b]10;rgb:abc/abc/abc\x07')
+        t.ungetch('\x1b]10;rgb:abc/abc/abc' + terminator)
         assert t.get_fgcolor_hex(timeout=0.01) == '#ababab'
     child()
 
@@ -469,21 +469,22 @@ def test_get_fgcolor_hex_timeout():
     child()
 
 
-def test_get_bgcolor_hex():
+@pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
+def test_get_bgcolor_hex(terminator):
     """Test get_bgcolor_hex returns hex string."""
     from io import StringIO
 
     @as_subprocess
     def child():
         t = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
-        t.ungetch('\x1b]11;rgb:2828/2c2c/3434\x07')
+        t.ungetch('\x1b]11;rgb:2828/2c2c/3434' + terminator)
         assert t.get_bgcolor_hex(timeout=0.01) == '#282c34'
 
-        t.ungetch('\x1b]11;rgb:aaaa/bbbb/cccc\x07')
+        t.ungetch('\x1b]11;rgb:aaaa/bbbb/cccc' + terminator)
         assert t.get_bgcolor_hex(timeout=0.01, maybe_short=True) == '#abc'
 
         # XParseColor shorthand: 3 digits have nibble wrap (abc -> abca -> ab)
-        t.ungetch('\x1b]11;rgb:abc/de0/123\x07')
+        t.ungetch('\x1b]11;rgb:abc/de0/123' + terminator)
         assert t.get_bgcolor_hex(timeout=0.01) == '#abde12'
     child()
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -22,7 +22,7 @@ if platform.system() != 'Windows':
     import curses
 else:
     # 3rd party
-    import jinxed as curses  # pylint: disable=import-error
+    import jinxed as curses
 
 
 def fn_tparm(*args):

--- a/tests/test_full_keyboard.py
+++ b/tests/test_full_keyboard.py
@@ -629,13 +629,14 @@ def test_get_fgcolor_0s():
     child()
 
 
-def test_get_fgcolor_0s_reply_via_ungetch():
-    """0-second get_fgcolor call with response."""
+@pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
+def test_get_fgcolor_0s_reply_via_ungetch(terminator):
+    """0-second get_fgcolor call with BEL or ST terminated response."""
     @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
         stime = time.time()
-        term.ungetch('\x1b]10;rgb:a0/52/2d\x07')  # sienna
+        term.ungetch('\x1b]10;rgb:a0/52/2d' + terminator)  # sienna
 
         rgb = term.get_fgcolor(timeout=0.01, bits=8)
         assert math.floor(time.time() - stime) == 0.0
@@ -643,12 +644,13 @@ def test_get_fgcolor_0s_reply_via_ungetch():
     child()
 
 
-def test_get_fgcolor_requires_styling():
+@pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
+def test_get_fgcolor_requires_styling(terminator):
     """get_fgcolor returns (-1, -1, -1) when does_styling is False."""
     @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
-        term.ungetch('\x1b]10;rgb:d2/b4/8c\x07')  # tan
+        term.ungetch('\x1b]10;rgb:d2/b4/8c' + terminator)  # tan
         rgb = term.get_fgcolor(timeout=0.01, bits=8)
         assert rgb == (210, 180, 140)
 
@@ -658,12 +660,13 @@ def test_get_fgcolor_requires_styling():
     child()
 
 
-def test_get_fgcolor_16bit_reply_via_ungetch():
+@pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
+def test_get_fgcolor_16bit_reply_via_ungetch(terminator):
     """get_fgcolor call with default 16-bit response."""
     @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
-        term.ungetch('\x1b]10;rgb:a099/5277/2d44\x07')  # sienna-ish
+        term.ungetch('\x1b]10;rgb:a099/5277/2d44' + terminator)  # sienna-ish
         rgb = term.get_fgcolor(timeout=0.01)
         assert rgb == (0xa099, 0x5277, 0x2d44)
     child()
@@ -681,13 +684,14 @@ def test_get_bgcolor_0s():
     child()
 
 
-def test_get_bgcolor_0s_reply_via_ungetch():
-    """0-second get_bgcolor call with response."""
+@pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
+def test_get_bgcolor_0s_reply_via_ungetch(terminator):
+    """0-second get_bgcolor call with BEL or ST terminated response."""
     @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
         stime = time.time()
-        term.ungetch('\x1b]11;rgb:99/32/cc\x07')  # darkorchid
+        term.ungetch('\x1b]11;rgb:99/32/cc' + terminator)  # darkorchid
 
         rgb = term.get_bgcolor(timeout=0.01, bits=8)
         assert math.floor(time.time() - stime) == 0.0
@@ -695,12 +699,13 @@ def test_get_bgcolor_0s_reply_via_ungetch():
     child()
 
 
-def test_get_bgcolor_requires_styling():
+@pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
+def test_get_bgcolor_requires_styling(terminator):
     """get_bgcolor returns (-1, -1, -1) when does_styling is False."""
     @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
-        term.ungetch('\x1b]11;rgb:ff/e4/c4\x07')  # bisque
+        term.ungetch('\x1b]11;rgb:ff/e4/c4' + terminator)  # bisque
         rgb = term.get_bgcolor(timeout=0.01, bits=8)
         assert rgb == (255, 228, 196)
 
@@ -710,12 +715,13 @@ def test_get_bgcolor_requires_styling():
     child()
 
 
-def test_get_bgcolor_16bit_reply_via_ungetch():
+@pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
+def test_get_bgcolor_16bit_reply_via_ungetch(terminator):
     """get_bgcolor call with default 16-bit response."""
     @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
-        term.ungetch('\x1b]11;rgb:9988/3255/cc11\x07')  # darkorchid-ish
+        term.ungetch('\x1b]11;rgb:9988/3255/cc11' + terminator)  # darkorchid-ish
         rgb = term.get_bgcolor(timeout=0.01)
         assert rgb == (0x9988, 0x3255, 0xcc11)
     child()

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -19,7 +19,7 @@ if platform.system() != 'Windows':
     import tty  # pylint: disable=unused-import  # NOQA
     import curses
 else:
-    import jinxed as curses  # pylint: disable=import-error
+    import jinxed as curses
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="no tty module")

--- a/tests/test_kitty_protocol.py
+++ b/tests/test_kitty_protocol.py
@@ -1529,3 +1529,58 @@ def test_kitty_state_boundary_kitty_only_response(response, expected_flags):
         assert flags.value == expected_flags
         assert term._kitty_kb_first_query_failed is False
     child()
+
+
+@pytest.mark.parametrize("sequence,expected_key_name,expected_key_value", [
+    # Press: key_name == name, key_value == value
+    ('\x1b[97;5u', 'KEY_CTRL_A', 'a'),
+    ('\x1b[122;3u', 'KEY_ALT_Z', 'z'),
+
+    # Repeat: key_name strips _REPEATED
+    ('\x1b[97;1:2u', 'KEY_A', 'a'),
+    ('\x1b[97;3:2u', 'KEY_ALT_A', 'a'),
+    ('\x1b[106;5:2u', 'KEY_CTRL_J', 'j'),
+
+    # Release: key_name strips _RELEASED, key_value returns the character
+    ('\x1b[97;1:3u', 'KEY_A', 'a'),
+    ('\x1b[97;3:3u', 'KEY_ALT_A', 'a'),
+    ('\x1b[122;7:3u', 'KEY_CTRL_ALT_Z', 'z'),
+    ('\x1b[49;5:3u', 'KEY_CTRL_1', '1'),
+    ('\x1b[111;1:3u', 'KEY_O', 'o'),
+])
+def test_key_name_and_key_value(sequence, expected_key_name, expected_key_value):
+    """Test key_name strips event suffix and key_value works for releases."""
+    ks = _match_kitty_key(sequence)
+    assert ks.key_name == expected_key_name
+    assert ks.key_value == expected_key_value
+
+
+@pytest.mark.parametrize("sequence,expected_name,expected_key_value", [
+    # Control char keys: key_value returns the control character for releases
+    ('\x1b[27;1:3u', 'KEY_ESCAPE', '\x1b'),
+    ('\x1b[13;1:3u', 'KEY_ENTER', '\n'),
+    ('\x1b[9;1:3u', 'KEY_TAB', '\t'),
+])
+def test_key_value_control_keys_released(sequence, expected_name, expected_key_value):
+    """Test key_value returns control char for released control keys."""
+    ks = _match_kitty_key(sequence)
+    assert ks.released
+    assert ks.key_name == expected_name
+    assert ks.key_value == expected_key_value
+    assert ks.value == ''
+
+
+def test_key_name_plain_text():
+    """Test key_name is None for plain text press (no name synthesized)."""
+    ks = Keystroke('a')
+    assert ks.name is None
+    assert ks.key_name is None
+    assert ks.key_value == 'a'
+
+
+def test_key_name_key_value_press_identity():
+    """Test key_name == name and key_value == value for press events."""
+    ks = _match_kitty_key('\x1b[97;5u')
+    assert ks.pressed
+    assert ks.key_name == ks.name
+    assert ks.key_value == ks.value

--- a/tests/test_kitty_protocol.py
+++ b/tests/test_kitty_protocol.py
@@ -20,7 +20,6 @@ from tests.conftest import IS_WINDOWS, TEST_KEYBOARD
 # isort: off
 # curses
 if platform.system() == 'Windows':
-    # pylint: disable=import-error
     from jinxed import KEY_EXIT, KEY_ENTER, KEY_BACKSPACE
 else:
     from curses import KEY_EXIT, KEY_ENTER, KEY_BACKSPACE
@@ -702,6 +701,14 @@ def test_kitty_name_synthesis_edge_cases(sequence, expected_name, expected_value
     # Repeat event tests
     ('\x1b[106;5:2u', 'KEY_CTRL_J_REPEATED'),
     ('\x1b[97;3:2u', 'KEY_ALT_A_REPEATED'),
+
+    # Unmodified release/repeat events
+    ('\x1b[111;1:3u', 'KEY_O_RELEASED'),
+    ('\x1b[111;1:2u', 'KEY_O_REPEATED'),
+    ('\x1b[97;1:3u', 'KEY_A_RELEASED'),
+    ('\x1b[97;1:2u', 'KEY_A_REPEATED'),
+    ('\x1b[49;1:3u', 'KEY_1_RELEASED'),
+    ('\x1b[49;1:2u', 'KEY_1_REPEATED'),
 ])
 def test_kitty_name_synthesis_special_cases(sequence, expected_name):
     """Test special cases in Kitty protocol name synthesis including event types."""

--- a/tests/test_modifiers_keyboard.py
+++ b/tests/test_modifiers_keyboard.py
@@ -13,7 +13,7 @@ if platform.system() != 'Windows':
     import tty  # pylint: disable=unused-import  # NOQA
     import curses
 else:
-    import jinxed as curses  # pylint: disable=import-error
+    import jinxed as curses
 
 
 def assert_ctrl_alt_modifiers(ks):

--- a/tox.ini
+++ b/tox.ini
@@ -161,6 +161,7 @@ commands =
 
 [testenv:pylint]
 deps =
+    jinxed
     pylint
 commands =
     pylint {posargs} blessed


### PR DESCRIPTION
  * bugfix: :meth:`~.Terminal.get_fgcolor` and :meth:`~.Terminal.get_bgcolor` now correctly interprets ST-terminated OSC responses in addition to BEL-terminated.
  * improved: Synthesize :attr:`~.Keystroke.name` for "released" and "repeated" key states, when using the kitty keyboard protocol.
  * new: methods :meth:`~Keystroke.key_name` and :meth:`~Keystroke.key_value` allow for better key and value tracking when using kitty keyboard protocol with pressed, released, and repeated events.