### PR TITLE
kitty kb fix, improved synthesis and documentation

### DIFF
--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -15,4 +15,4 @@ else:
 from blessed.line_editor import LineEditor, LineHistory
 
 __all__ = ('Terminal', 'LineEditor', 'LineHistory')
-__version__ = "1.35.0"
+__version__ = "1.36.0"

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -120,7 +120,44 @@ ALT_CONTROL_NAMES = {
     0x7f: 'KEY_ALT_BACKSPACE',  # DEL
     0x0d: 'KEY_ALT_ENTER',      # CR
     0x09: 'KEY_ALT_TAB',        # TAB
-    0x5b: 'CSI'                 # CSI '['
+}
+
+# Human-readable names for ASCII punctuation and symbols, used by kitty
+# keyboard protocol name synthesis to produce names like KEY_LEFT_SQUARE_BRACKET.
+ASCII_SYMBOL_NAMES = {
+    32: 'SPACE',
+    33: 'EXCLAMATION_MARK',
+    34: 'DOUBLE_QUOTE',
+    35: 'HASH',
+    36: 'DOLLAR',
+    37: 'PERCENT',
+    38: 'AMPERSAND',
+    39: 'APOSTROPHE',
+    40: 'LEFT_PARENTHESIS',
+    41: 'RIGHT_PARENTHESIS',
+    42: 'ASTERISK',
+    43: 'PLUS',
+    44: 'COMMA',
+    45: 'MINUS',
+    46: 'PERIOD',
+    47: 'SLASH',
+    58: 'COLON',
+    59: 'SEMICOLON',
+    60: 'LESS_THAN',
+    61: 'EQUALS',
+    62: 'GREATER_THAN',
+    63: 'QUESTION_MARK',
+    64: 'AT',
+    91: 'LEFT_SQUARE_BRACKET',
+    92: 'BACKSLASH',
+    93: 'RIGHT_SQUARE_BRACKET',
+    94: 'CARET',
+    95: 'UNDERSCORE',
+    96: 'GRAVE_ACCENT',
+    123: 'LEFT_CURLY_BRACKET',
+    124: 'PIPE',
+    125: 'RIGHT_CURLY_BRACKET',
+    126: 'TILDE',
 }
 
 
@@ -282,8 +319,9 @@ class Keystroke(str):
         """
         Get base name for Kitty keyboard protocol letter/digit/symbol.
 
-        Returns name like 'KEY_CTRL_ALT_A', 'KEY_ALT_SHIFT_5' without
-        event-type suffix.  The suffix is applied by :attr:`name`.
+        Returns name like 'KEY_CTRL_ALT_A', 'KEY_ALT_SHIFT_5',
+        'KEY_LEFT_SQUARE_BRACKET' without event-type suffix.
+        The suffix is applied by :attr:`name`.
         """
         if self._mode != DecPrivateMode.SpecialInternalKitty:
             return None
@@ -292,34 +330,20 @@ class Keystroke(str):
         base_codepoint = (self._match.base_key if self._match.base_key is not None
                           else self._match.unicode_key)
 
-        # Special case: '[' always returns 'CSI' regardless of modifiers
-        if base_codepoint == 91:  # '['
-            return 'CSI'
-
-        # Only proceed if it's an ASCII letter or digit
-        if not ((65 <= base_codepoint <= 90) or   # A-Z
-                (97 <= base_codepoint <= 122) or  # a-z
-                (48 <= base_codepoint <= 57)):    # 0-9
+        # Determine the character name component (ASCII alphanumerics only)
+        if ((65 <= base_codepoint <= 90) or (97 <= base_codepoint <= 122)
+                or (48 <= base_codepoint <= 57)):
+            char = chr(base_codepoint).upper()
+        elif base_codepoint in ASCII_SYMBOL_NAMES:
+            char = ASCII_SYMBOL_NAMES[base_codepoint]
+        else:
             return None
-
-        # For letters: convert to uppercase for consistent naming
-        # For digits: use as-is
-        char = (chr(base_codepoint).upper()
-                if (65 <= base_codepoint <= 90 or 97 <= base_codepoint <= 122)
-                else chr(base_codepoint))
 
         # Build modifier prefix list in order: CTRL, ALT, SHIFT, SUPER, HYPER, META
         mod_parts = []
         for mod_name in KittyModifierBits.names_modifiers_only:
             if getattr(self, f'_{mod_name}'):
                 mod_parts.append(mod_name.upper())
-
-        # For press events, only synthesize name if modifiers are present
-        # (plain text presses like 'a' don't need a name, value suffices).
-        # For release/repeat events, always synthesize a name since value
-        # is empty for releases and name is the only way to identify the key.
-        if not mod_parts and not (self.released or self.repeated):
-            return None
 
         return (f"KEY_{'_'.join(mod_parts)}_{char}"
                 if mod_parts
@@ -531,8 +555,9 @@ class Keystroke(str):
 
         When non-None, all phrases begin with either 'KEY', 'MOUSE', 'FOCUS_IN', 'FOCUS_OUT',
         'BRACKETED_PASTE', or 'RESIZE_EVENT', with one exception: 'CSI' is returned for '\\x1b['
-        to indicate the beginning of a presumed unsupported input sequence. The phrase 'KEY_ALT_['
-        is never returned and unsupported.
+        in legacy (non-kitty-protocol) mode to indicate the beginning of a presumed unsupported
+        input sequence. In kitty keyboard protocol mode, the '[' key uses the name
+        'KEY_LEFT_SQUARE_BRACKET' (with modifier and event-type suffixes as appropriate).
 
         If this value is None, then it can probably be assumed that the value is an unsurprising
         textual character without any modifiers, like the letter ``'a'``.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,15 @@
 Version History
 ===============
 
+1.36
+
+  * bugfix: ``[`` key returned :attr:`~.Keystroke.name` of value ``CSI`` in Kitty keyboard protocol
+    mode, it now returns ``KEY_LEFT_SQUARE_BRACKET``.
+  * improved: Kitty keyboard protocol now synthesizes :attr:`~.Keystroke.name` for all ASCII
+    alphanumeric and punctuation keys, including unmodified press events (e.g., ``KEY_A``,
+    ``KEY_PERIOD``, ``KEY_LEFT_SQUARE_BRACKET``). Previously, only modified or released/repeated
+    keys received synthesized names.
+
 1.35
 
   * introduced: :meth:`~.Terminal.cursor_shape` context manager and
@@ -340,8 +349,7 @@ Version History
     curses errors are legitimate errors and should be reported as a bug.
   * enhancement: converted nose tests to pytest, merged travis and tox.
   * enhancement: pytest fixtures, paired with a new ``@as_subprocess``
-    decorator
-    are used to test a multitude of terminal types.
+    decorator are used to test a multitude of terminal types.
   * enhancement: test accessories ``@as_subprocess`` resolves various issues
     with different terminal types that previously went untested.
   * deprecation: python2.5 is no longer supported (as tox does not supported).

--- a/docs/keyboard.rst
+++ b/docs/keyboard.rst
@@ -85,7 +85,10 @@ Common key names include:
 * ``KEY_PGUP``, ``KEY_PGDOWN`` - Page Up and Page Down
 * ``KEY_HOME``, ``KEY_END`` - Home and End keys
 
-For regular characters without modifiers, :attr:`~.Keystroke.name` returns ``None``.
+For regular characters without modifiers, :attr:`~.Keystroke.name` returns
+``None`` in legacy mode. In :doc:`Kitty keyboard protocol <keyboard_kitty>`
+mode, all ASCII alphanumeric and punctuation keys receive synthesized names
+-- see :ref:`kitty_name_synthesis`.
 
 Feel free to try the demonstration program, :ref:`keymatrix.py` to experiment
 with possible keyboard inputs and combinations.
@@ -122,9 +125,8 @@ in the following order:
 - ``ALT``
 - ``SHIFT``
 
-The escape sequence, ``'\x1b['``, is always decoded as name ``CSI`` when it
-arrives without any known matching sequence. There are not any matches
-for Keystroke name ``KEY_ALT_[``.
+The escape sequence ``'\x1b['`` is always decoded as name ``CSI`` in legacy
+mode when it arrives without any known matching sequence.
 
 The :attr:`~.Keystroke.value` property returns the text character for keys that
 produce text, stripping away modifier information.

--- a/docs/keyboard_kitty.rst
+++ b/docs/keyboard_kitty.rst
@@ -33,11 +33,10 @@ The protocol is automatically detected and enabled when you use the
 doesn't support it, your code continues to work normally using standard
 keyboard input.
 
-Like standard keyboard input, Kitty protocol keystrokes provide a
-:attr:`~.Keystroke.name` attribute for special keys (``KEY_ESCAPE``, ``KEY_F1``,
-``KEY_UP``) and modified alphanumeric keys (``KEY_CTRL_A``, ``KEY_ALT_5``).
-Plain text input like typing 'a' or '5' has no name, making it easy to
-distinguish between commands and regular text.
+Unlike standard keyboard input where :attr:`~.Keystroke.name` is ``None``
+for plain characters, the Kitty protocol synthesizes names for all ASCII
+alphanumeric and punctuation keys. See :ref:`kitty_name_synthesis` for
+details.
 
 Getting Started
 ---------------
@@ -143,6 +142,81 @@ Feel free to try the demonstration program, :ref:`keymatrix.py` to experiment
 with combining any or all possible kitty protocol features using Shift+F1
 through Shift+F5.
 
+.. _kitty_name_synthesis:
+
+Key Name Synthesis
+------------------
+
+The :attr:`~.Keystroke.name` is synthesized for all ASCII alphanumeric keys, punctuation,
+and symbols while in kitty keyboard mode.
+
+Some example **Alphanumeric keys**::
+
+    KEY_A, KEY_Z, KEY_0, KEY_9
+    KEY_CTRL_A, KEY_ALT_5, KEY_CTRL_ALT_SHIFT_M
+
+**Punctuation and symbols** use descriptive names::
+
+    KEY_SPACE, KEY_PERIOD, KEY_COMMA, KEY_MINUS, KEY_EQUALS
+    KEY_LEFT_SQUARE_BRACKET, KEY_RIGHT_SQUARE_BRACKET
+    KEY_SLASH, KEY_BACKSLASH, KEY_SEMICOLON, KEY_APOSTROPHE
+    KEY_GRAVE_ACCENT, KEY_TILDE, KEY_EXCLAMATION_MARK
+    KEY_AT, KEY_HASH, KEY_DOLLAR, KEY_PERCENT, KEY_CARET
+    KEY_AMPERSAND, KEY_ASTERISK, KEY_PLUS, KEY_PIPE
+    KEY_LEFT_PARENTHESIS, KEY_RIGHT_PARENTHESIS
+    KEY_LEFT_CURLY_BRACKET, KEY_RIGHT_CURLY_BRACKET
+    KEY_LESS_THAN, KEY_GREATER_THAN, KEY_QUESTION_MARK
+    KEY_DOUBLE_QUOTE, KEY_COLON, KEY_UNDERSCORE
+
+Modifiers and event-type suffixes combine as expected::
+
+    KEY_ALT_LEFT_SQUARE_BRACKET
+    KEY_CTRL_PERIOD
+    KEY_SPACE_RELEASED
+    KEY_ALT_MINUS_REPEATED
+
+Shifted Key Reporting
+~~~~~~~~~~~~~~~~~~~~~
+
+The Kitty protocol reports the *base key* and modifiers separately rather
+than the resulting character. On a US keyboard layout, pressing Shift+3
+produces ``#``, but the terminal reports codepoint 51 (digit ``3``) with the
+Shift modifier. This means:
+
+- The name is ``KEY_SHIFT_3``, not ``KEY_HASH``
+- The :attr:`~.Keystroke.value` is the actual character ``#``
+
+Symbol names like ``KEY_HASH``, ``KEY_AMPERSAND``, and ``KEY_TILDE`` are
+still reachable when a terminal sends the symbol codepoint directly, but
+on most layouts Shift+digit combinations will produce names based on the
+base digit key.
+
+Layout-Independent Key Handling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, the protocol reports whichever key the current keyboard layout
+maps to a given position. This means the keys of a physical position on
+the keyboard will produce different codepoints on different layouts,
+QWERTY, Dvorak, AZERTY, or many non-US layouts.
+
+The ``report_alternates`` flag solves this by requesting the terminal to
+also report the *base layout key* -- the key identity independent of the
+active layout. When ``report_alternates=True``, blessed uses the base
+layout key for name synthesis, so a shortcut like ``KEY_CTRL_Z`` works
+regardless of whether the user's layout places ``Z`` in the QWERTY
+position or elsewhere.
+
+.. code-block:: python
+
+    with term.enable_kitty_keyboard(report_alternates=True):
+        with term.cbreak():
+            key = term.inkey()
+            if key.name == 'KEY_CTRL_Z':
+                undo()
+
+This is especially useful for applications that bind shortcuts to physical
+key positions (like Ctrl+Z for undo) rather than to specific characters.
+
 Compatibility
 -------------
 
@@ -153,9 +227,7 @@ You can optionally check for protocol support:
     from blessed import Terminal
 
     term = Terminal()
-
     state = term.get_kitty_keyboard_state()
-
     if state is not None:
         print("Kitty keyboard protocol is supported")
     else:

--- a/tests/test_full_keyboard.py
+++ b/tests/test_full_keyboard.py
@@ -420,7 +420,7 @@ def test_flushinp_timeout_with_continuous_input():
 
     assert int(count) >= 3
     assert 8 <= int(duration_ms) <= 20
-    assert_elapsed_range_ms(stime, 8, 25)
+    assert_elapsed_range_ms(stime, 8, 35)
 
 
 def test_get_location_0s():

--- a/tests/test_kitty_protocol.py
+++ b/tests/test_kitty_protocol.py
@@ -659,17 +659,21 @@ def test_kitty_letter_digit_name_synthesis(sequence, expected_name, expected_val
 
 
 @pytest.mark.parametrize("sequence,expected_name,expected_value", [
-    ('\x1b[49u', None, '1'),
-    ('\x1b[97;1u', None, 'a'),
-    ('\x1b[65;1u', None, 'A'),
-    ('\x1b[122;1u', None, 'z'),
-    ('\x1b[97u', None, 'a'),
-    ('\x1b[32;5u', None, ' '),
-    ('\x1b[33;3u', None, '!'),
-    ('\x1b[59;5u', None, ';'),
-    ('\x1b[46;3u', None, '.'),
-    ('\x1b[64;5u', None, '@'),
-    ('\x1b[91;3u', 'CSI', '['),
+    ('\x1b[49u', 'KEY_1', '1'),
+    ('\x1b[97;1u', 'KEY_A', 'a'),
+    ('\x1b[65;1u', 'KEY_A', 'A'),
+    ('\x1b[122;1u', 'KEY_Z', 'z'),
+    ('\x1b[97u', 'KEY_A', 'a'),
+    ('\x1b[32;5u', 'KEY_CTRL_SPACE', ' '),
+    ('\x1b[33;3u', 'KEY_ALT_EXCLAMATION_MARK', '!'),
+    ('\x1b[59;5u', 'KEY_CTRL_SEMICOLON', ';'),
+    ('\x1b[46;3u', 'KEY_ALT_PERIOD', '.'),
+    ('\x1b[64;5u', 'KEY_CTRL_AT', '@'),
+    ('\x1b[91;3u', 'KEY_ALT_LEFT_SQUARE_BRACKET', '['),
+    ('\x1b[233u', None, '\xe9'),  # e-acute, no name for non-ASCII
+    ('\x1b[12354u', None, '\u3042'),  # hiragana 'a', Japanese IME
+    ('\x1b[26159u', None, '\u662f'),  # han 'shi' (is), Chinese IME
+    ('\x1b[44032u', None, '\uac00'),  # hangul 'ga', Korean IME
 ])
 def test_kitty_name_synthesis_edge_cases(sequence, expected_name, expected_value):
     """Test name synthesis edge cases."""
@@ -807,10 +811,10 @@ def test_disambiguate_f1_f4_not_confused_with_alt():
 
 
 @pytest.mark.parametrize("sequence,expected_name", [
-    ('\x1b[91;5u', 'CSI'),
-    ('\x1b[64;5u', None),
-    ('\x1b[96;5u', None),
-    ('\x1b[123;5u', None),
+    ('\x1b[91;5u', 'KEY_CTRL_LEFT_SQUARE_BRACKET'),
+    ('\x1b[64;5u', 'KEY_CTRL_AT'),
+    ('\x1b[96;5u', 'KEY_CTRL_GRAVE_ACCENT'),
+    ('\x1b[123;5u', 'KEY_CTRL_LEFT_CURLY_BRACKET'),
     ('\x1b[65;5u', 'KEY_CTRL_A'),
     ('\x1b[90;5u', 'KEY_CTRL_Z'),
     ('\x1b[97;5u', 'KEY_CTRL_A'),
@@ -1584,3 +1588,106 @@ def test_key_name_key_value_press_identity():
     assert ks.pressed
     assert ks.key_name == ks.name
     assert ks.key_value == ks.value
+
+
+@pytest.mark.parametrize("sequence,expected_name,expected_value", [
+    ('\x1b[97u', 'KEY_A', 'a'),
+    ('\x1b[65u', 'KEY_A', 'A'),
+    ('\x1b[122u', 'KEY_Z', 'z'),
+    ('\x1b[90u', 'KEY_Z', 'Z'),
+    ('\x1b[49u', 'KEY_1', '1'),
+    ('\x1b[48u', 'KEY_0', '0'),
+    ('\x1b[57u', 'KEY_9', '9'),
+    ('\x1b[97;1u', 'KEY_A', 'a'),
+    ('\x1b[65;1u', 'KEY_A', 'A'),
+    ('\x1b[122;1u', 'KEY_Z', 'z'),
+])
+def test_kitty_plain_press_synthesizes_name(sequence, expected_name, expected_value):
+    """Test kitty protocol synthesizes names for unmodified press events."""
+    ks = _match_kitty_key(sequence)
+    assert ks.name == expected_name
+    assert ks.value == expected_value
+
+
+@pytest.mark.parametrize("sequence,expected_name,expected_value", [
+    ('\x1b[32u', 'KEY_SPACE', ' '),
+    ('\x1b[33u', 'KEY_EXCLAMATION_MARK', '!'),
+    ('\x1b[34u', 'KEY_DOUBLE_QUOTE', '"'),
+    ('\x1b[35u', 'KEY_HASH', '#'),
+    ('\x1b[36u', 'KEY_DOLLAR', '$'),
+    ('\x1b[37u', 'KEY_PERCENT', '%'),
+    ('\x1b[38u', 'KEY_AMPERSAND', '&'),
+    ('\x1b[39u', 'KEY_APOSTROPHE', "'"),
+    ('\x1b[40u', 'KEY_LEFT_PARENTHESIS', '('),
+    ('\x1b[41u', 'KEY_RIGHT_PARENTHESIS', ')'),
+    ('\x1b[42u', 'KEY_ASTERISK', '*'),
+    ('\x1b[43u', 'KEY_PLUS', '+'),
+    ('\x1b[44u', 'KEY_COMMA', ','),
+    ('\x1b[45u', 'KEY_MINUS', '-'),
+    ('\x1b[46u', 'KEY_PERIOD', '.'),
+    ('\x1b[47u', 'KEY_SLASH', '/'),
+    ('\x1b[58u', 'KEY_COLON', ':'),
+    ('\x1b[59u', 'KEY_SEMICOLON', ';'),
+    ('\x1b[60u', 'KEY_LESS_THAN', '<'),
+    ('\x1b[61u', 'KEY_EQUALS', '='),
+    ('\x1b[62u', 'KEY_GREATER_THAN', '>'),
+    ('\x1b[63u', 'KEY_QUESTION_MARK', '?'),
+    ('\x1b[64u', 'KEY_AT', '@'),
+    ('\x1b[91u', 'KEY_LEFT_SQUARE_BRACKET', '['),
+    ('\x1b[92u', 'KEY_BACKSLASH', '\\'),
+    ('\x1b[93u', 'KEY_RIGHT_SQUARE_BRACKET', ']'),
+    ('\x1b[94u', 'KEY_CARET', '^'),
+    ('\x1b[95u', 'KEY_UNDERSCORE', '_'),
+    ('\x1b[96u', 'KEY_GRAVE_ACCENT', '`'),
+    ('\x1b[123u', 'KEY_LEFT_CURLY_BRACKET', '{'),
+    ('\x1b[124u', 'KEY_PIPE', '|'),
+    ('\x1b[125u', 'KEY_RIGHT_CURLY_BRACKET', '}'),
+    ('\x1b[126u', 'KEY_TILDE', '~'),
+])
+def test_kitty_ascii_symbol_names(sequence, expected_name, expected_value):
+    """Test kitty protocol synthesizes names for all ASCII symbols."""
+    ks = _match_kitty_key(sequence)
+    assert ks.name == expected_name
+    assert ks.value == expected_value
+
+
+@pytest.mark.parametrize("sequence,expected_name,expected_value", [
+    ('\x1b[91;3u', 'KEY_ALT_LEFT_SQUARE_BRACKET', '['),
+    ('\x1b[91;5u', 'KEY_CTRL_LEFT_SQUARE_BRACKET', '['),
+    ('\x1b[91;7u', 'KEY_CTRL_ALT_LEFT_SQUARE_BRACKET', '['),
+    ('\x1b[91;1:3u', 'KEY_LEFT_SQUARE_BRACKET_RELEASED', ''),
+    ('\x1b[93;3u', 'KEY_ALT_RIGHT_SQUARE_BRACKET', ']'),
+    ('\x1b[93;5u', 'KEY_CTRL_RIGHT_SQUARE_BRACKET', ']'),
+    ('\x1b[32;3u', 'KEY_ALT_SPACE', ' '),
+    ('\x1b[32;5u', 'KEY_CTRL_SPACE', ' '),
+    ('\x1b[33;3u', 'KEY_ALT_EXCLAMATION_MARK', '!'),
+    ('\x1b[46;3u', 'KEY_ALT_PERIOD', '.'),
+    ('\x1b[46;5u', 'KEY_CTRL_PERIOD', '.'),
+    ('\x1b[64;5u', 'KEY_CTRL_AT', '@'),
+    ('\x1b[59;5u', 'KEY_CTRL_SEMICOLON', ';'),
+    ('\x1b[45;3u', 'KEY_ALT_MINUS', '-'),
+    ('\x1b[61;3u', 'KEY_ALT_EQUALS', '='),
+    ('\x1b[47;5u', 'KEY_CTRL_SLASH', '/'),
+    ('\x1b[92;5u', 'KEY_CTRL_BACKSLASH', '\\'),
+    ('\x1b[126;3u', 'KEY_ALT_TILDE', '~'),
+])
+def test_kitty_ascii_symbol_with_modifiers(sequence, expected_name, expected_value):
+    """Test kitty protocol synthesizes names for ASCII symbols with modifiers."""
+    ks = _match_kitty_key(sequence)
+    assert ks.name == expected_name
+    assert ks.value == expected_value
+
+
+@pytest.mark.parametrize("sequence,expected_name", [
+    ('\x1b[91;1:3u', 'KEY_LEFT_SQUARE_BRACKET_RELEASED'),
+    ('\x1b[91;1:2u', 'KEY_LEFT_SQUARE_BRACKET_REPEATED'),
+    ('\x1b[91;3:3u', 'KEY_ALT_LEFT_SQUARE_BRACKET_RELEASED'),
+    ('\x1b[32;1:3u', 'KEY_SPACE_RELEASED'),
+    ('\x1b[46;1:3u', 'KEY_PERIOD_RELEASED'),
+    ('\x1b[46;5:3u', 'KEY_CTRL_PERIOD_RELEASED'),
+    ('\x1b[33;3:2u', 'KEY_ALT_EXCLAMATION_MARK_REPEATED'),
+])
+def test_kitty_ascii_symbol_event_types(sequence, expected_name):
+    """Test kitty protocol event type suffixes for ASCII symbols."""
+    ks = _match_kitty_key(sequence)
+    assert ks.name == expected_name

--- a/tests/test_modifiers_keyboard.py
+++ b/tests/test_modifiers_keyboard.py
@@ -1196,20 +1196,6 @@ def test_alphanum_predicate_value_multi_char():
     assert ks.is_alt('a') is False
 
 
-def test_get_alt_only_control_name_csi():
-    """Test _get_alt_only_control_name returns CSI for bracket."""
-    ks = Keystroke('\x1b[')
-    result = ks._get_alt_only_control_name(0x5b)
-    assert result == 'CSI'
-
-
-def test_meta_escape_name_csi_special_case():
-    """Test metaSendsEscape correctly identifies CSI sequence."""
-    ks = Keystroke('\x1b[')
-    result = ks._get_meta_escape_name()
-    assert result == 'CSI'
-
-
 def test_terminal_inkey_csi_sequence():
     """Test term.inkey() returns single CSI keystroke for unmatched sequences."""
     @as_subprocess


### PR DESCRIPTION
* bugfix: ``[`` key returned ``Keystroke.name`` of ``CSI`` in Kitty keyboard protocol mode,
  it is now correctly identified as ``KEY_LEFT_SQUARE_BRACKET``.
* improved: Kitty keyboard protocol now synthesizes ``Keystroke.name`` for all ASCII
  alphanumeric and punctuation keys, including unmodified press events (e.g., ``KEY_A``,
  ``KEY_PERIOD``, ``KEY_LEFT_SQUARE_BRACKET``). Previously, only modified or released/repeated
  keys received synthesized names.

