### PR TITLE
Bugfix kitty protocol on unmodified function keys (ghostty)

### DIFF
--- a/bin/keyboard_kitty_simple.py
+++ b/bin/keyboard_kitty_simple.py
@@ -4,7 +4,7 @@ from blessed import Terminal
 term = Terminal()
 
 print("Press and hold keys to see raw kitty keystrokes and their names (press 'q' to quit)")
-with term.enable_kitty_keyboard(report_events=True, report_all_keys=True):
+with term.enable_kitty_keyboard(report_events=True, report_all_keys=True, report_alternates=True):
     with term.cbreak():
         while True:
             key = term.inkey()

--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -15,4 +15,4 @@ else:
 from blessed.line_editor import LineEditor, LineHistory
 
 __all__ = ('Terminal', 'LineEditor', 'LineHistory')
-__version__ = "1.36.0"
+__version__ = "1.37.0"

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -301,15 +301,6 @@ class Keystroke(str):
             if getattr(self, f'_{mod_name}'):        # 'if self._shift'
                 mod_parts.append(mod_name.upper())   # -> 'SHIFT'
 
-        # For press events with no modifiers, check if this is a PUA functional
-        # key or a control character key (Escape, Tab, Enter, Backspace).
-        is_control_char_key = self._code in _KITTY_CONTROL_CHAR_TO_KEYCODE.values()
-        if (not mod_parts
-                and not (self.released or self.repeated)
-                and not _is_kitty_functional_key(self._code)
-                and not is_control_char_key):
-            return None
-
         # Build base result with modifiers (if any)
         return (f"KEY_{'_'.join(mod_parts)}_{base_name}"
                 if mod_parts

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,12 @@
 Version History
 ===============
 
+1.37
+
+  * bugfix: legacy CSI letter-form sequences with explicit modifiers and event type (e.g.,
+    ``\x1b[1;1:1A`` for arrow key press) were not resolved to key names, this affected only some
+    terminals, such as Ghostty.
+
 1.36
 
   * bugfix: ``[`` key returned :attr:`~.Keystroke.name` of value ``CSI`` in Kitty keyboard protocol

--- a/tests/test_kitty_protocol.py
+++ b/tests/test_kitty_protocol.py
@@ -975,6 +975,25 @@ def test_event_type_name_suffixes(sequence, expected_name, expected_value):
     assert ks.value == expected_value
 
 
+@pytest.mark.parametrize("sequence,expected_name", [
+    ('\x1b[1;1:1A', 'KEY_UP'),
+    ('\x1b[1;1:1B', 'KEY_DOWN'),
+    ('\x1b[1;1:1C', 'KEY_RIGHT'),
+    ('\x1b[1;1:1D', 'KEY_LEFT'),
+    ('\x1b[1;1:3A', 'KEY_UP_RELEASED'),
+    ('\x1b[1;1:3D', 'KEY_LEFT_RELEASED'),
+    ('\x1b[1;1:2A', 'KEY_UP_REPEATED'),
+    ('\x1b[1;1:1P', 'KEY_F1'),
+    ('\x1b[1;1:1H', 'KEY_HOME'),
+    ('\x1b[1;1:1F', 'KEY_END'),
+])
+def test_unmodified_press_legacy_csi_arrow_keys(sequence, expected_name):
+    """Test unmodified press events resolve names for legacy CSI sequences."""
+    ks = _match_legacy_csi_letter_form(sequence)
+    assert ks is not None
+    assert ks.name == expected_name
+
+
 def test_event_type_dynamic_predicates():
     """Test dynamic predicates with event types."""
     ks_release = _match_legacy_csi_letter_form('\x1b[1;2:3Q')

--- a/tests/test_modifiers_keyboard.py
+++ b/tests/test_modifiers_keyboard.py
@@ -1096,7 +1096,7 @@ def test_getattr_property_getter():
 
 
 def test_get_modified_keycode_name_no_modifiers():
-    """Test modified keycode name returns None when no modifiers present."""
+    """Test modified keycode name resolves for unmodified press events."""
     @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
@@ -1106,7 +1106,7 @@ def test_get_modified_keycode_name_no_modifiers():
         assert ks._mode == -3
         assert ks.modifiers == 1
         result = ks._get_modified_keycode_name()
-        assert result is None
+        assert result == 'KEY_UP'
 
     child()
 
@@ -1229,7 +1229,7 @@ def test_legacy_csi_modifiers_no_modifiers_integration():
         assert ks.modifiers == 1
         assert ks.code == curses.KEY_F1
         result = ks._get_modified_keycode_name()
-        assert result is None
+        assert result == 'KEY_F1'
         assert ks._ctrl is False
         assert ks._alt is False
         assert ks._shift is False


### PR DESCRIPTION
legacy CSI letter-form sequences with explicit modifiers and event type
(e.g., ``\x1b[1;1:1A`` for arrow key press) were not resolved to key
names, this affected only some terminals, such as Ghostty.
