### PR TITLE
New detection methods, clipboard support, and window title (XTWINOPS)

### DIFF
--- a/bin/clipboard.py
+++ b/bin/clipboard.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""Demonstrate OSC 52 clipboard copy and paste."""
+
+from blessed import Terminal
+
+term = Terminal()
+
+print('Checking OSC 52 clipboard support ...', end='', flush=True)
+
+if not term.does_osc52_clipboard():
+    print()
+    print(term.bright_red('OSC 52 clipboard not detected.'))
+    print('Your terminal may still support clipboard writes --')
+    print('many terminals accept OSC 52 set without advertising it.')
+    raise SystemExit(1)
+
+print(term.bright_green(' supported!'))
+print()
+
+# Copy text to clipboard
+message = 'Hello from blessed!'
+term.clipboard_copy(message)
+print(f'Copied to clipboard: {term.bold(repr(message))}')
+print()
+
+# Read clipboard back (may trigger a permission prompt)
+print('Reading clipboard (your terminal may ask for permission) ...',
+      end='', flush=True)
+result = term.clipboard_paste()
+
+if result is None:
+    print()
+    print(term.bright_yellow('No response -- clipboard read may be '
+                             'disabled or was denied.'))
+else:
+    print(term.bright_green(' OK'))
+    print(f'Clipboard contains: {term.bold(repr(result))}')

--- a/bin/display-modes.py
+++ b/bin/display-modes.py
@@ -12,7 +12,7 @@ Usage::
 import sys
 
 # local
-from blessed import Terminal, DecrqssSettings
+from blessed import Terminal
 
 
 def _yn(term, val):
@@ -142,18 +142,18 @@ def display_decrqss(term):
         return
 
     settings = [
-        (DecrqssSettings.SGR, 'SGR', 'Select Graphic Rendition'),
-        (DecrqssSettings.DECSCUSR, 'DECSCUSR', 'Cursor Style'),
-        (DecrqssSettings.DECSTBM, 'DECSTBM', 'Top/Bottom Margins'),
-        (DecrqssSettings.DECSLRM, 'DECSLRM', 'Left/Right Margins'),
-        (DecrqssSettings.DECSCL, 'DECSCL', 'Conformance Level'),
-        (DecrqssSettings.DECSCA, 'DECSCA', 'Character Protection'),
-        (DecrqssSettings.DECSCPP, 'DECSCPP', 'Columns Per Page'),
-        (DecrqssSettings.DECSLPP, 'DECSLPP', 'Lines Per Page'),
-        (DecrqssSettings.DECSNLS, 'DECSNLS', 'Lines Per Screen'),
-        (DecrqssSettings.DECSASD, 'DECSASD', 'Active Status Display'),
-        (DecrqssSettings.DECSSDT, 'DECSSDT', 'Status Line Type'),
-        (DecrqssSettings.DECSACE, 'DECSACE', 'Attribute Change Extent'),
+        (Terminal.Decrqss.SGR, 'SGR', 'Select Graphic Rendition'),
+        (Terminal.Decrqss.DECSCUSR, 'DECSCUSR', 'Cursor Style'),
+        (Terminal.Decrqss.DECSTBM, 'DECSTBM', 'Top/Bottom Margins'),
+        (Terminal.Decrqss.DECSLRM, 'DECSLRM', 'Left/Right Margins'),
+        (Terminal.Decrqss.DECSCL, 'DECSCL', 'Conformance Level'),
+        (Terminal.Decrqss.DECSCA, 'DECSCA', 'Character Protection'),
+        (Terminal.Decrqss.DECSCPP, 'DECSCPP', 'Columns Per Page'),
+        (Terminal.Decrqss.DECSLPP, 'DECSLPP', 'Lines Per Page'),
+        (Terminal.Decrqss.DECSNLS, 'DECSNLS', 'Lines Per Screen'),
+        (Terminal.Decrqss.DECSASD, 'DECSASD', 'Active Status Display'),
+        (Terminal.Decrqss.DECSSDT, 'DECSSDT', 'Status Line Type'),
+        (Terminal.Decrqss.DECSACE, 'DECSACE', 'Attribute Change Extent'),
     ]
 
     for setting_id, mnemonic, desc in settings:

--- a/bin/display-modes.py
+++ b/bin/display-modes.py
@@ -12,7 +12,7 @@ Usage::
 import sys
 
 # local
-from blessed import Terminal
+from blessed import Terminal, DecrqssSettings
 
 
 def _yn(term, val):
@@ -132,6 +132,40 @@ def display_sugar_methods(term):
           f"Kitty desktop notifications (OSC 99)" + term.clear_eol)
 
 
+def display_decrqss(term):
+    """Query and display terminal state via DECRQSS."""
+    print(term.bold("DECRQSS State Queries (DCS $ q):"))
+    print("-" * 40)
+
+    if not term.does_decrqss():
+        print("  " + term.bright_red("DECRQSS not supported"))
+        return
+
+    settings = [
+        (DecrqssSettings.SGR, 'SGR', 'Select Graphic Rendition'),
+        (DecrqssSettings.DECSCUSR, 'DECSCUSR', 'Cursor Style'),
+        (DecrqssSettings.DECSTBM, 'DECSTBM', 'Top/Bottom Margins'),
+        (DecrqssSettings.DECSLRM, 'DECSLRM', 'Left/Right Margins'),
+        (DecrqssSettings.DECSCL, 'DECSCL', 'Conformance Level'),
+        (DecrqssSettings.DECSCA, 'DECSCA', 'Character Protection'),
+        (DecrqssSettings.DECSCPP, 'DECSCPP', 'Columns Per Page'),
+        (DecrqssSettings.DECSLPP, 'DECSLPP', 'Lines Per Page'),
+        (DecrqssSettings.DECSNLS, 'DECSNLS', 'Lines Per Screen'),
+        (DecrqssSettings.DECSASD, 'DECSASD', 'Active Status Display'),
+        (DecrqssSettings.DECSSDT, 'DECSSDT', 'Status Line Type'),
+        (DecrqssSettings.DECSACE, 'DECSACE', 'Attribute Change Extent'),
+    ]
+
+    for setting_id, mnemonic, desc in settings:
+        print(f'  Testing {mnemonic}...' + term.clear_eol, end='\r', flush=True)
+        result = term.get_decrqss(setting_id)
+        if result is not None:
+            value = term.bright_cyan(repr(result))
+            print(f"  {mnemonic:<10} {value:<20} {desc}" + term.clear_eol)
+        else:
+            print(f"  {mnemonic:<10} {term.bright_black('--'):<20} {desc}" + term.clear_eol)
+
+
 def display_all_dec_modes(term):
     """Query and display all DEC Private Mode information."""
     print(term.bold("All DEC Private Modes:"))
@@ -200,6 +234,10 @@ def main():
 
     # Display sugar methods and advanced protocols
     display_sugar_methods(term)
+    print()
+
+    # Display DECRQSS state queries
+    display_decrqss(term)
     print()
 
     # Display all DEC Private Modes (only with --all)

--- a/bin/line_editor_form.py
+++ b/bin/line_editor_form.py
@@ -1,36 +1,57 @@
 #!/usr/bin/env python3
-"""Line editor demo with styled input, history, and horizontal scrolling."""
+"""Line editor demo with clipboard, bracketed paste, history, and scrolling."""
+from functools import partial
+
 from blessed import Terminal
-from blessed.line_editor import LineEditor, LineHistory
+from blessed.line_editor import LineEditor, LineHistory, LineEditResult
 
 term = Terminal()
 history = LineHistory()
-PROMPT = ">>> "
-PROMPT_W = len(PROMPT)
+echo = partial(print, end='\r\n', flush=True)
+
+has_clipboard = term.does_osc52_clipboard()
 
 
-def emit(text):
-    """Write text to stdout without newline."""
-    print(text, end="", flush=True)
+def copy_line(ed):
+    term.clipboard_copy(ed.line)
+    return LineEditResult()
 
 
-with term.cbreak(), term.hidden_cursor():
-    print("Line editor demo. Up/Down=history, Right=accept suggestion, "
-          "Ctrl+D=quit.\n")
+def paste_line(ed):
+    text = term.clipboard_paste()
+    return ed.insert_text(text) if text else LineEditResult()
+
+
+with term.raw(), term.hidden_cursor(), term.bracketed_paste():
+    if has_clipboard:
+        echo("press ^C and ^V for OS clipboard")
+    echo()
     while True:
-        width = min(term.width - PROMPT_W, 40)
-        ed = LineEditor(history=history, max_width=width, limit=200,
-                        bg_sgr=term.on_brown)
-        emit(PROMPT)
+        margin = max(1, term.width // 5)
+        width = term.width - margin * 2
+        prompt = "Prompt> "
+        col = margin
+        ed_width = width - len(prompt)
+        keymap = {}
+        if has_clipboard:
+            keymap['KEY_CTRL_C'] = copy_line
+            keymap['KEY_CTRL_V'] = paste_line
+        ed = LineEditor(history=history, max_width=ed_width, limit=200,
+                        bg_sgr=term.on_brown,
+                        keymap=keymap or None)
+        echo(term.move_x(col) + prompt, end='')
         row = term.get_location()[0]
-        emit(ed.render(term, row, width))
+        ed_col = col + len(prompt)
+        echo(ed.render(term, row, ed_width, col=ed_col), end='')
         while True:
             key = term.inkey()
-            result = ed.feed_key(key)
+            if key.name == 'BRACKETED_PASTE':
+                result = ed.insert_text(key.text)
+            else:
+                result = ed.feed_key(key)
             if result.bell:
-                emit(result.bell)
+                echo(result.bell, end='')
             if result.changed:
-                # try fast-path for common cases, fall back to full redraw
                 key_str = str(key)
                 out = None
                 if key_str and key_str.isprintable() and len(key_str) == 1:
@@ -38,16 +59,12 @@ with term.cbreak(), term.hidden_cursor():
                 elif getattr(key, "name", None) == "KEY_BACKSPACE":
                     out = ed.render_backspace(term, row)
                 if out is None:
-                    out = ed.render(term, row, width)
-                emit(out)
+                    out = ed.render(term, row, ed_width, col=ed_col)
+                echo(out, end='')
             if result.line is not None:
-                print()
+                echo()
                 if result.line:
-                    print(f"  => {result.line!r}")
+                    echo(term.move_x(col) + f"  => {result.line!r}")
                 break
-            if result.eof:
-                print()
-                raise SystemExit
-            if result.interrupt:
-                print("^C")
-                break
+        if (result.line or '').strip() == 'quit':
+            break

--- a/bin/line_editor_form.py
+++ b/bin/line_editor_form.py
@@ -22,9 +22,11 @@ def paste_line(ed):
     return ed.insert_text(text) if text else LineEditResult()
 
 
-with term.raw(), term.hidden_cursor(), term.bracketed_paste():
+with term.raw(), term.cursor_shape(term.CursorShape.BLINKING_BLOCK), term.bracketed_paste():
     if has_clipboard:
-        echo("press ^C and ^V for OS clipboard")
+        echo("press ^C and ^V for OS clipboard, type 'quit' to exit")
+    else:
+        echo("type 'quit' to exit")
     echo()
     while True:
         margin = max(1, term.width // 5)

--- a/bin/screen-scrape.py
+++ b/bin/screen-scrape.py
@@ -72,15 +72,13 @@ def build_lookup(term, cal_row, usable_cols):
 
     while offset < len(PRINTABLE):
         batch = PRINTABLE[offset:offset + usable_cols]
-
-        # write batch as a contiguous row, then spray DECRQCRA queries
-        s = f"\x1b[{cal_row};1H" + "".join(chr(c) for c in batch)
+        s = term.move_yx(cal_row - 1, 0) + "".join(chr(c) for c in batch)
         for i, code in enumerate(batch):
             s += DECRQCRA.format(pid=code, r=cal_row, c=i + 1)
         emit(s)
 
         results = blast_collect(fd, len(batch))
-        emit(f"\x1b[{cal_row};1H\x1b[2K")
+        emit(term.move_yx(cal_row - 1, 0) + term.clear_eol)
 
         if len(results) < len(batch):
             return {}
@@ -137,7 +135,7 @@ def main():
 
     with term.raw():
         cpr_match = term._query_response('\x1b[6n', CPR_RE, timeout=1)
-        start_row = int(cpr_match.group(1)) if cpr_match else rows
+        start_row = int(cpr_match.group(1)) - 1 if cpr_match else rows
 
         cal_row = rows
         # set XTerm-compatible checksum mode, then flush any response
@@ -145,24 +143,24 @@ def main():
         term.flushinp(timeout=0.1)
 
         # probe DECRQCRA support with a single-cell test
-        emit(f"\x1b[{cal_row};1HA")
+        emit(term.move_yx(cal_row - 1, 0) + "A")
         cksum = query_checksum(term, cal_row, 1, pid=9999, timeout=2.0)
-        emit(f"\x1b[{cal_row};1H\x1b[2K")
+        emit(term.move_yx(cal_row - 1, 0) + term.clear_eol)
         if cksum is None:
-            print("DECRQCRA not supported.", file=sys.stderr)
+            print("DECRQCRA not supported.", end='\r\n', file=sys.stderr)
             return 1
 
         lookup = build_lookup(term, cal_row, usable_cols)
         if not lookup:
-            print("Failed to build lookup table.", file=sys.stderr)
+            print("Failed to build lookup table.", end='\r\n', file=sys.stderr)
             return 1
 
         # verify round-trip
-        emit(f"\x1b[{cal_row};1HZ")
+        emit(term.move_yx(cal_row - 1, 0) + "Z")
         verify = query_checksum(term, cal_row, 1, pid=1, timeout=1)
-        emit(f"\x1b[{cal_row};1H\x1b[2K")
+        emit(term.move_yx(cal_row - 1, 0) + term.clear_eol)
         if lookup.get(verify) != "Z":
-            print("Lookup verification failed.", file=sys.stderr)
+            print("Lookup verification failed.", end='\r\n', file=sys.stderr)
             return 1
 
         normal = blast_scrape(term, rows, cols, lookup)
@@ -183,10 +181,9 @@ def main():
         with open(args.save_json, "w", encoding="utf-8") as f:
             json.dump(result, f, indent=2)
     else:
-        emit(f"\x1b[{start_row};1H\x1b[2K")
-        print(f"screen 0: {repr(normal)}", end='', flush=True)
-        print(f"\nscreen 1: {repr(alt)}", end='', flush=True)
-        print(flush=True)
+        emit(term.move_yx(start_row, 0) + term.clear_eol)
+        print(f"screen 0: {repr(normal)}")
+        print(f"screen 1: {repr(alt)}")
 
     return 0
 

--- a/bin/screen-scrape.py
+++ b/bin/screen-scrape.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+#
+# Demonstrates silent screen-reading via DECRQCRA (DEC Request Checksum of Rectangular Area).
+#
+# Only mlterm and WezTerm are known to be afflicted by default. This sequence is very useful for
+# automatic testing like with `vttest`, likely used while developing an emulator, but most make the
+# correct choice of using a disabled-by-default compile-time option. iTerm2 makes a runtime prompt
+# that clearly warns, "this allows screen scraping", while ghostty displays 'DECRQCRA' with
+# allow/deny.
+#
+# https://vt100.net/docs/vt510-rm/DECRQCRA.html allows to silently read the contents of the visible
+# screen as a "checksum", but we can pre-compute expected checksums for printable ASCII, building a
+# reverse lookup table that recovers the original characters.
+#
+import argparse
+import json
+import os
+import re
+import select
+import sys
+
+from blessed import Terminal
+
+DECRQCRA = "\x1b[{pid};1;{r};{c};{r};{c}*y"
+DECCKSR_RE = re.compile(r"\x1bP(\d+)!~([0-9A-Fa-f]{4})\x1b\\")
+CPR_RE = re.compile(r"\x1b\[(\d+);(\d+)R")
+# XTCHECKSUM mode 3: use XTerm-compatible positive checksums
+XTCHECKSUM = "\x1b[3#y"
+ALT_SCREEN_ON = "\x1b[?47h"
+ALT_SCREEN_OFF = "\x1b[?47l"
+PRINTABLE = range(32, 127)
+
+
+def emit(s):
+    sys.stdout.write(s)
+    sys.stdout.flush()
+
+
+def query_checksum(term, row, col, pid=1, timeout=1):
+    # uses private API for direct terminal query/response
+    match = term._query_response(
+        DECRQCRA.format(pid=pid, r=row, c=col), DECCKSR_RE, timeout=timeout
+    )
+    return int(match.group(2), 16) if match else None
+
+
+def blast_collect(fd, expected, timeout=1.0):
+    results = {}
+    buf = b""
+    while len(results) < expected:
+        ready, _, _ = select.select([fd], [], [], timeout)
+        if not ready:
+            break
+        chunk = os.read(fd, 65536)
+        if not chunk:
+            break
+        buf += chunk
+        # latin-1 is 1:1 byte-to-char, so regex indices match byte offsets
+        for match in DECCKSR_RE.finditer(buf.decode("latin-1", errors="replace")):
+            results[int(match.group(1))] = int(match.group(2), 16)
+        last_st = buf.rfind(b"\x1b\\")
+        if last_st >= 0:
+            buf = buf[last_st + 2:]
+    return results
+
+
+def build_lookup(term, cal_row, usable_cols):
+    """Build checksum-to-character lookup by calibrating printable ASCII."""
+    fd = sys.stdin.fileno()
+    table = {}
+    offset = 0
+
+    while offset < len(PRINTABLE):
+        batch = PRINTABLE[offset:offset + usable_cols]
+
+        # write batch as a contiguous row, then spray DECRQCRA queries
+        s = f"\x1b[{cal_row};1H" + "".join(chr(c) for c in batch)
+        for i, code in enumerate(batch):
+            s += DECRQCRA.format(pid=code, r=cal_row, c=i + 1)
+        emit(s)
+
+        results = blast_collect(fd, len(batch))
+        emit(f"\x1b[{cal_row};1H\x1b[2K")
+
+        if len(results) < len(batch):
+            return {}
+
+        for code in batch:
+            cksum = results.get(code)
+            if cksum is None:
+                return {}
+            table[cksum] = chr(code)
+
+        offset += usable_cols
+
+    return table
+
+
+def blast_scrape(term, rows, cols, lookup):
+    space_cksum = next((k for k, v in lookup.items() if v == " "), None)
+    fd = sys.stdin.fileno()
+
+    queries = []
+    for row in range(1, rows + 1):
+        for col in range(1, cols + 1):
+            pid = (row - 1) * cols + (col - 1)
+            queries.append(DECRQCRA.format(pid=pid, r=row, c=col))
+    emit("".join(queries))
+
+    results = blast_collect(fd, rows * cols)
+
+    lines = []
+    for row in range(1, rows + 1):
+        chars = []
+        for col in range(1, cols + 1):
+            pid = (row - 1) * cols + (col - 1)
+            cksum = results.get(pid)
+            if cksum is None or cksum == 0 or cksum == space_cksum:
+                chars.append(" ")
+            elif cksum in lookup:
+                chars.append(lookup[cksum])
+            else:
+                chars.append(f"?0x{cksum:04X}")
+        lines.append("".join(chars).rstrip())
+    return "\n".join(lines).strip()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--save-json", metavar="PATH",
+                        help="write results as JSON to PATH instead of stdout")
+    args = parser.parse_args()
+
+    term = Terminal()
+    rows, cols = term.height, term.width
+    usable_cols = cols - 1
+
+    with term.raw():
+        cpr_match = term._query_response('\x1b[6n', CPR_RE, timeout=1)
+        start_row = int(cpr_match.group(1)) if cpr_match else rows
+
+        cal_row = rows
+        # set XTerm-compatible checksum mode, then flush any response
+        emit(XTCHECKSUM)
+        term.flushinp(timeout=0.1)
+
+        # probe DECRQCRA support with a single-cell test
+        emit(f"\x1b[{cal_row};1HA")
+        cksum = query_checksum(term, cal_row, 1, pid=9999, timeout=2.0)
+        emit(f"\x1b[{cal_row};1H\x1b[2K")
+        if cksum is None:
+            print("DECRQCRA not supported.", file=sys.stderr)
+            return 1
+
+        lookup = build_lookup(term, cal_row, usable_cols)
+        if not lookup:
+            print("Failed to build lookup table.", file=sys.stderr)
+            return 1
+
+        # verify round-trip
+        emit(f"\x1b[{cal_row};1HZ")
+        verify = query_checksum(term, cal_row, 1, pid=1, timeout=1)
+        emit(f"\x1b[{cal_row};1H\x1b[2K")
+        if lookup.get(verify) != "Z":
+            print("Lookup verification failed.", file=sys.stderr)
+            return 1
+
+        normal = blast_scrape(term, rows, cols, lookup)
+
+        # the alt screen already has content from whatever was displayed before
+        # entering raw mode -- DECRQCRA reads it even from the normal screen
+        emit(ALT_SCREEN_ON)
+        alt = blast_scrape(term, rows, cols, lookup)
+        emit(ALT_SCREEN_OFF)
+
+    if args.save_json:
+        result = {
+            "screen_0": normal,
+            "screen_1": alt,
+            "rows": rows,
+            "cols": cols,
+        }
+        with open(args.save_json, "w", encoding="utf-8") as f:
+            json.dump(result, f, indent=2)
+    else:
+        emit(f"\x1b[{start_row};1H\x1b[2K")
+        print(f"screen 0: {repr(normal)}", end='', flush=True)
+        print(f"\nscreen 1: {repr(alt)}", end='', flush=True)
+        print(flush=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -13,7 +13,6 @@ else:
     from blessed.terminal import Terminal  # type: ignore[assignment]
 
 from blessed.line_editor import LineEditor, LineHistory
-from blessed._capabilities import DecrqssSettings
 
-__all__ = ('Terminal', 'LineEditor', 'LineHistory', 'DecrqssSettings')
+__all__ = ('Terminal', 'LineEditor', 'LineHistory')
 __version__ = "1.38.0"

--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -13,6 +13,7 @@ else:
     from blessed.terminal import Terminal  # type: ignore[assignment]
 
 from blessed.line_editor import LineEditor, LineHistory
+from blessed._capabilities import DecrqssSettings
 
-__all__ = ('Terminal', 'LineEditor', 'LineHistory')
+__all__ = ('Terminal', 'LineEditor', 'LineHistory', 'DecrqssSettings')
 __version__ = "1.38.0"

--- a/blessed/_capabilities.py
+++ b/blessed/_capabilities.py
@@ -250,6 +250,7 @@ XTGETTCAP_CAPABILITIES = (
     ("u8", "DA response format"),
     ("u9", "DA request"),
     # Extended capabilities -- modern terminal features
+    ("Ms", "Clipboard via OSC 52"),
     ("Smulx", "Set extended underline style"),
     ("Setulc", "Set underline color"),
 )

--- a/blessed/_capabilities.py
+++ b/blessed/_capabilities.py
@@ -249,6 +249,9 @@ XTGETTCAP_CAPABILITIES = (
     ("u7", "CPR request"),
     ("u8", "DA response format"),
     ("u9", "DA request"),
+    # Extended capabilities -- modern terminal features
+    ("Smulx", "Set extended underline style"),
+    ("Setulc", "Set underline color"),
 )
 
 

--- a/blessed/_capabilities.py
+++ b/blessed/_capabilities.py
@@ -12,7 +12,7 @@ __all__ = (
     'CAPABILITIES_HORIZONTAL_DISTANCE',
     'CAPABILITIES_CAUSE_MOVEMENT',
     'XTGETTCAP_CAPABILITIES',
-    'DecrqssSettings',
+    'Decrqss',
     'TermcapResponse',
     'ITerm2Capabilities',
 )
@@ -257,7 +257,7 @@ XTGETTCAP_CAPABILITIES = (
 )
 
 
-class DecrqssSettings:
+class Decrqss:
     """
     DECRQSS setting identifiers for querying terminal state.
 

--- a/blessed/_capabilities.py
+++ b/blessed/_capabilities.py
@@ -12,6 +12,7 @@ __all__ = (
     'CAPABILITIES_HORIZONTAL_DISTANCE',
     'CAPABILITIES_CAUSE_MOVEMENT',
     'XTGETTCAP_CAPABILITIES',
+    'DecrqssSettings',
     'TermcapResponse',
     'ITerm2Capabilities',
 )
@@ -254,6 +255,55 @@ XTGETTCAP_CAPABILITIES = (
     ("Smulx", "Set extended underline style"),
     ("Setulc", "Set underline color"),
 )
+
+
+class DecrqssSettings:
+    """
+    DECRQSS setting identifiers for querying terminal state.
+
+    Each attribute is the "final character(s)" sent inside
+    ``DCS $ q <setting_id> ST`` to request the current value
+    of a particular terminal setting.
+
+    .. seealso::
+
+        `DECRQSS specification
+        <https://vt100.net/docs/vt510-rm/DECRQSS.html>`_
+    """
+
+    # Display and rendering
+    SGR = 'm'                  # Select Graphic Rendition
+    DECSCUSR = ' q'            # Set Cursor Style
+    DECSTBM = 'r'              # Set Top and Bottom Margins
+    DECSLRM = 's'              # Set Left and Right Margins
+    DECSCL = '"p'              # Set Conformance Level
+    DECSCA = '"q'              # Set Character Protection Attribute
+    DECSCPP = '$|'             # Set Columns Per Page
+    DECSLPP = 't'              # Set Lines Per Page
+    DECSNLS = '*|'             # Set Number of Lines per Screen
+    DECSASD = '$}'             # Select Active Status Display
+    DECSSDT = '$~'             # Set Status Line Type
+
+    # Selection and extent
+    DECSACE = '*x'             # Select Attribute Change Extent
+
+    # Communication and hardware (VT510-specific)
+    DECSSL = 'p'               # Select Set-Up Language
+    DECSPRTT = '$s'            # Select Printer Type
+    DECSRFR = '"t'             # Select Refresh Rate
+    DECSDPT = '(p'             # Select Digital Printed Data Type
+    DECSPPCS = '*p'            # Select ProPrinter Character Set
+    DECSCS = '*r'              # Select Communication Speed
+    DECSCP = '*u'              # Select Communication Port
+    DECSSCLS = ' p'            # Set Scroll Speed
+    DECSKCV = ' r'             # Set Key Click Volume
+    DECSWBV = ' t'             # Set Warning Bell Volume
+    DECSMBV = ' u'             # Set Margin Bell Volume
+    DECSLCK = ' v'             # Set Lock Key Style
+    DECSFC = '*s'              # Select Flow Control Type
+    DECSDDT = '$q'             # Select Disconnect Delay Time
+    DECSTRL = '"u'             # Set Transmit Rate Limit
+    DECSPP = '+w'              # Set Port Parameter
 
 
 class TermcapResponse:

--- a/blessed/cursor_shape.py
+++ b/blessed/cursor_shape.py
@@ -1,8 +1,6 @@
 """Module providing DECSCUSR cursor shape support."""
 from __future__ import annotations
 
-# pylint: disable=too-few-public-methods
-
 
 class CursorShape:
     """

--- a/blessed/dec_modes.py
+++ b/blessed/dec_modes.py
@@ -74,14 +74,36 @@ class DecModeResponse:
         return self._value
 
     @property
-    def supported(self) -> bool:
+    def recognized(self) -> bool:
         """
-        Check if the mode is supported by the terminal.
+        Check if the terminal recognizes this mode.
+
+        True for any DECRPM response value > 0 (SET, RESET,
+        PERMANENTLY_SET, or PERMANENTLY_RESET).  This indicates
+        the terminal knows about the mode, but does not guarantee
+        the application can use or control it.
 
         :rtype: bool
-        :returns: True if terminal recognizes and supports this mode
+        :returns: True if terminal acknowledges this mode
         """
         return self.value > 0
+
+    @property
+    def supported(self) -> bool:
+        """
+        Check if the mode is supported and usable by the terminal.
+
+        True for values SET (1), RESET (2), and PERMANENTLY_SET (3).
+        PERMANENTLY_RESET (4) is excluded: the terminal acknowledges
+        the mode but it is permanently off and cannot be enabled, so
+        it is not usable by applications.  See also xterm patch #395
+        and the Contour synchronized-output spec which both treat
+        value 4 as effectively unsupported.
+
+        :rtype: bool
+        :returns: True if mode is usable (changeable or permanently enabled)
+        """
+        return self.value in {1, 2, 3}
 
     @property
     def enabled(self) -> bool:

--- a/blessed/dec_modes.py
+++ b/blessed/dec_modes.py
@@ -78,10 +78,9 @@ class DecModeResponse:
         """
         Check if the terminal recognizes this mode.
 
-        True for any DECRPM response value > 0 (SET, RESET,
-        PERMANENTLY_SET, or PERMANENTLY_RESET).  This indicates
-        the terminal knows about the mode, but does not guarantee
-        the application can use or control it.
+        True for any DECRPM response value > 0 (SET, RESET, PERMANENTLY_SET, or PERMANENTLY_RESET).
+        This indicates the terminal knows about the mode, but does not guarantee the application can
+        use or control it.
 
         :rtype: bool
         :returns: True if terminal acknowledges this mode
@@ -93,12 +92,10 @@ class DecModeResponse:
         """
         Check if the mode is supported and usable by the terminal.
 
-        True for values SET (1), RESET (2), and PERMANENTLY_SET (3).
-        PERMANENTLY_RESET (4) is excluded: the terminal acknowledges
-        the mode but it is permanently off and cannot be enabled, so
-        it is not usable by applications.  See also xterm patch #395
-        and the Contour synchronized-output spec which both treat
-        value 4 as effectively unsupported.
+        True for values SET (1), RESET (2), and PERMANENTLY_SET (3). PERMANENTLY_RESET (4) is
+        excluded: the terminal acknowledges the mode but it is permanently off and cannot be
+        enabled, so it is not usable by applications.  See also xterm patch #395 and the Contour
+        synchronized-output spec which both treat value 4 as effectively unsupported.
 
         :rtype: bool
         :returns: True if mode is usable (changeable or permanently enabled)

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -2180,6 +2180,19 @@ class DeviceAttribute():
         """
         return 4 in self.extensions
 
+    @property
+    def supports_osc52(self) -> bool:
+        """
+        Whether the terminal advertises OSC 52 clipboard support.
+
+        Extension 52 in DA1 indicates the terminal supports writing to the
+        system clipboard via the OSC 52 protocol.
+
+        :rtype: bool
+        :returns: True if extension 52 is present in device attributes
+        """
+        return 52 in self.extensions
+
     @classmethod
     def from_match(cls, match: Match[str]) -> 'DeviceAttribute':
         """
@@ -2205,7 +2218,8 @@ class DeviceAttribute():
     def __repr__(self) -> str:
         """String representation of DeviceAttribute."""
         return (f'DeviceAttribute(service_class={self.service_class}, '
-                f'extensions={self.extensions}, supports_sixel={self.supports_sixel})')
+                f'extensions={self.extensions}, supports_sixel={self.supports_sixel}, '
+                f'supports_osc52={self.supports_osc52})')
 
 
 class SoftwareVersion:

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -2185,8 +2185,8 @@ class DeviceAttribute():
         """
         Whether the terminal advertises OSC 52 clipboard support.
 
-        Extension 52 in DA1 indicates the terminal supports writing to the
-        system clipboard via the OSC 52 protocol.
+        Extension 52 in DA1 indicates the terminal supports writing to the system clipboard via the
+        OSC 52 protocol.
 
         :rtype: bool
         :returns: True if extension 52 is present in device attributes

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -163,7 +163,6 @@ ASCII_SYMBOL_NAMES = {
 
 class KittyModifierBits:
     """Standard modifier bit flags (compatible with Kitty keyboard protocol)."""
-    # pylint: disable=too-few-public-methods
 
     shift = 0b1
     alt = 0b10

--- a/blessed/line_editor.py
+++ b/blessed/line_editor.py
@@ -185,6 +185,7 @@ class LineEditor:  # pylint: disable=too-many-instance-attributes
         self.keymap: Dict[str, Optional[Callable[..., LineEditResult]]] = dict(DEFAULT_KEYMAP)
         if keymap:
             self.keymap.update(keymap)
+        self._col_offset: int = 0
         self._prev_cursor: int = 0
         self._prev_content_w: int = 0
         self._prev_overflow: Tuple[bool, bool] = (False, False)
@@ -240,18 +241,21 @@ class LineEditor:  # pylint: disable=too-many-instance-attributes
         self._prev_overflow = (cur.overflow_left, cur.overflow_right)
         self._prev_scroll_offset = self._scroll_offset
 
-    def render(self, term: Terminal, row: int, width: int) -> str:
+    def render(self, term: Terminal, row: int, width: int,
+               col: int = 0) -> str:
         """
         Build escape sequences to render the current display state.
 
         :param term: Blessed :class:`~.Terminal` instance for cursor/SGR.
         :param row: Terminal row for the input line.
         :param width: Available columns.
+        :param col: Starting column offset (default 0).
         :returns: Escape-sequence string; caller writes/encodes it.
         """
+        self._col_offset = col
         cur = self.display
         ellipsis_w = wcswidth(self.ellipsis)
-        parts: List[str] = [term.move_yx(row, 0), cur.bg_sgr]
+        parts: List[str] = [term.move_yx(row, col), cur.bg_sgr]
         rendered = 0
 
         if cur.overflow_left:
@@ -259,22 +263,22 @@ class LineEditor:  # pylint: disable=too-many-instance-attributes
             rendered += ellipsis_w
 
         if cur.text:
-            parts.extend((cur.text_sgr, cur.text))
+            parts.extend((cur.bg_sgr, cur.text_sgr, cur.text))
             rendered += wcswidth(cur.text)
 
         if cur.suggestion:
-            parts.extend((cur.suggestion_sgr, cur.suggestion))
+            parts.extend((cur.bg_sgr, cur.suggestion_sgr, cur.suggestion))
             rendered += wcswidth(cur.suggestion)
 
         if cur.overflow_right:
-            parts.extend((cur.ellipsis_sgr, self.ellipsis))
+            parts.extend((cur.bg_sgr, cur.ellipsis_sgr, self.ellipsis))
             rendered += ellipsis_w
 
         pad = width - rendered
         if pad > 0:
             parts.extend((cur.bg_sgr, " " * pad))
 
-        parts.extend((term.normal, term.move_yx(row, cur.cursor)))
+        parts.extend((term.normal, term.move_yx(row, col + cur.cursor)))
         self._update_render_state(cur, rendered)
         return "".join(parts)
 
@@ -296,15 +300,17 @@ class LineEditor:  # pylint: disable=too-many-instance-attributes
             return None
         if self._scroll_offset != self._prev_scroll_offset:
             return None
+        off = self._col_offset
         col = self._prev_cursor
-        parts: List[str] = [term.move_yx(row, col), cur.text_sgr, grapheme]
+        parts: List[str] = [term.move_yx(row, off + col),
+                            cur.bg_sgr, cur.text_sgr, grapheme]
         new_content_w = wcswidth(cur.text) + wcswidth(cur.suggestion)
         if cur.suggestion:
-            parts.extend((cur.suggestion_sgr, cur.suggestion))
+            parts.extend((cur.bg_sgr, cur.suggestion_sgr, cur.suggestion))
         trail = self._prev_content_w - new_content_w
         if trail > 0:
             parts.extend((cur.bg_sgr, " " * trail))
-        parts.extend((term.normal, term.move_yx(row, cur.cursor)))
+        parts.extend((term.normal, term.move_yx(row, off + cur.cursor)))
         self._update_render_state(cur, new_content_w)
         return "".join(parts)
 
@@ -323,15 +329,16 @@ class LineEditor:  # pylint: disable=too-many-instance-attributes
             return None
         if self._scroll_offset != self._prev_scroll_offset:
             return None
+        off = self._col_offset
         col = cur.cursor
         new_content_w = wcswidth(cur.text) + wcswidth(cur.suggestion)
         erase = self._prev_content_w - new_content_w
-        parts: List[str] = [term.move_yx(row, col)]
+        parts: List[str] = [term.move_yx(row, off + col)]
         if cur.suggestion:
-            parts.extend((cur.suggestion_sgr, cur.suggestion))
+            parts.extend((cur.bg_sgr, cur.suggestion_sgr, cur.suggestion))
         if erase > 0:
             parts.extend((cur.bg_sgr, " " * erase))
-        parts.extend((term.normal, term.move_yx(row, cur.cursor)))
+        parts.extend((term.normal, term.move_yx(row, off + cur.cursor)))
         self._update_render_state(cur, new_content_w)
         return "".join(parts)
 

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -12,6 +12,7 @@ import struct
 import asyncio
 import platform
 import warnings
+import base64
 import contextlib
 import collections
 from typing import IO, Dict, List, Match, Tuple, Union, Optional, Generator, SupportsIndex
@@ -1851,48 +1852,123 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
     def does_osc52_clipboard(self, timeout: Optional[float] = 1,
                              force: bool = False) -> bool:
         """
-        Detect OSC 52 clipboard access support.
+        Detect OSC 52 clipboard support without reading the clipboard.
 
-        Sends an OSC 52 clipboard read request and checks whether the terminal responds.  A response
-        (even with empty data) indicates the terminal supports the OSC 52 clipboard protocol.
+        This method uses two non-intrusive detection strategies that avoid triggering user-facing
+        clipboard permission prompts:
 
-        :arg float timeout: Timeout in seconds.
+        1. **DA1 extension 52**
+        2. **XTGETTCAP ``Ms``**
+
+        These methods are preferred over sending an actual OSC 52 read request
+        (``\\x1b]52;c;?\\a``), which may trigger a clipboard permission dialog in many modern
+        terminals.
+
+        .. note::
+
+            Detection indicates the terminal *understands* OSC 52, but not a guarantee that
+            clipboard access will succeed, the user may deny access.
+
+            If neither DA1 nor XTGETTCAP reports OSC 52 support, this method returns ``False`` --
+            but the terminal may still support OSC 52 via configuration.
+
+        :arg float timeout: Timeout in seconds for each sub-query.
         :arg bool force: Bypass cached result.
         :rtype: bool
         """
         if self._osc52_clipboard_supported is not None and not force:
             return self._osc52_clipboard_supported
+
+        # Strategy 1: DA1 extension 52
+        da = self.get_device_attributes(timeout=timeout)
+        if da is not None and da.supports_osc52:
+            self._osc52_clipboard_supported = True
+            return True
+
+        # Strategy 2: XTGETTCAP Ms capability
+        tcap = self.get_xtgettcap(timeout=timeout)
+        if tcap is not None and 'Ms' in tcap.capabilities:
+            self._osc52_clipboard_supported = True
+            return True
+
+        self._osc52_clipboard_supported = False
+        return False
+
+    def clipboard_copy(self, text: str, selection: str = 'c') -> None:
+        """
+        Copy text to the system clipboard via OSC 52.
+
+        Writes an OSC 52 set sequence to the terminal output stream.
+        Most modern terminals accept clipboard writes without any user
+        prompt.
+
+        The sequence is written unconditionally when :attr:`does_styling` is ``True``.  If the
+        terminal does not support OSC 52, the sequence should be ignored by the terminal.
+
+        :arg str text: The text to copy to the clipboard.
+        :arg str selection: The X11 selection target -- ``'c'`` for
+            clipboard (default), ``'p'`` for primary selection, or
+            ``'s'`` for secondary.  Most terminals only honor ``'c'``.
+        """
+        if not self.does_styling:
+            return
+        encoded = base64.b64encode(text.encode('utf-8')).decode('ascii')
+        self.stream.write(f'\x1b]52;{selection};{encoded}\x07')
+        self.stream.flush()
+
+    def clipboard_paste(self, timeout: Optional[float] = 10,
+                        selection: str = 'c') -> Optional[str]:
+        """
+        Read the system clipboard via OSC 52.
+
+        Sends an OSC 52 query (``\\x1b]52;c;?\\a``) and waits for
+        the terminal to respond with the clipboard contents.
+
+        .. warning::
+
+            Many modern terminals display a permission dialog when an application reads the
+            clipboard.  The user must approve the dialog before the terminal sends a response.
+
+            The default timeout of 10 seconds allows time for human interaction.  If the user denies
+            the dialog, or no response is received within given timeout, this method returns
+            ``None``.
+
+        :arg float timeout: Timeout in seconds.  A generous timeout
+            is recommended because the user may need to interact
+            with a permission dialog.
+        :arg str selection: The X11 selection target -- ``'c'`` for
+            clipboard (default), ``'p'`` for primary.
+        :rtype: str or None
+        :returns: The clipboard text, or ``None`` if the terminal did
+            not respond (unsupported, denied, or timed out).
+        """
         match = self._query_with_boundary(
-            '\x1b]52;c;?\x07', _RE_OSC52_RESPONSE, timeout)
-        supported = match is not None
-        self._osc52_clipboard_supported = supported
-        return supported
+            f'\x1b]52;{selection};?\x07', _RE_OSC52_RESPONSE, timeout)
+        if match is None:
+            return None
+        b64_data = match.group(1)
+        if not b64_data:
+            return ''
+        try:
+            return base64.b64decode(b64_data).decode('utf-8')
+        except (ValueError, UnicodeDecodeError):
+            return None
 
     def get_color_scheme(self, timeout: Optional[float] = 1,
                          force: bool = False) -> Optional[str]:
         """
         Query the terminal's color scheme preference (dark or light mode).
 
-        Sends a ``CSI ? 996 n`` Device Status Report query.  Terminals
-        that support color-scheme reporting respond with
-        ``CSI ? 997 ; Ps n`` where *Ps* is ``1`` for dark mode or ``2``
-        for light mode.  Uses a CPR boundary guard for fast negative
-        detection.
+        Sends a ``CSI ? 996 n`` Device Status Report query.  Terminals that support color-scheme
+        reporting respond with ``CSI ? 997 ; Ps n`` where *Ps* is ``1`` for dark mode or ``2`` for
+        light mode.  Uses a CPR boundary guard for fast negative detection.
 
-        The result is not cached because the color scheme can change at
-        any time (e.g. when the user toggles dark mode).  Only the
-        *supported* state is cached so that terminals that do not
-        respond incur the timeout delay only once.
-
-        Mode 2031 (``COLOR_PALETTE_UPDATES``) can be enabled separately
-        to receive unsolicited notifications when the scheme changes.
+        This relates to Mode 2031 (``COLOR_PALETTE_UPDATES``) (not implemented).
 
         .. seealso::
 
             `Color palette update notifications
             <https://contour-terminal.org/vt-extensions/color-palette-update-notifications/>`_
-
-        Supported by Contour, Ghostty, Kitty (0.38.1+), and VTE (0.82.0+).
 
         :arg float timeout: Timeout in seconds.
         :arg bool force: Bypass cached result.

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -57,7 +57,7 @@ from ._capabilities import (CAPABILITY_DATABASE,
                             CAPABILITIES_RAW_MIXIN,
                             XTGETTCAP_CAPABILITIES,
                             CAPABILITIES_HORIZONTAL_DISTANCE,
-                            DecrqssSettings,
+                            Decrqss,
                             TermcapResponse,
                             TextSizingResult,
                             ITerm2Capabilities)
@@ -174,6 +174,9 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
     #: DECSCUSR cursor shape constants accessible via Terminal.CursorShape or term.CursorShape
     CursorShape = _CursorShape
+
+    #: DECRQSS setting identifiers accessible via Terminal.Decrqss
+    Decrqss = Decrqss
 
     #: DEC Private Mode constants accessible via Terminal.DecPrivateMode or term.DecPrivateMode
     DecPrivateMode = _DecPrivateMode
@@ -2007,7 +2010,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         self._kitty_query_supported = supported
         return supported
 
-    def get_decrqss(self, setting_id: str = DecrqssSettings.SGR,
+    def get_decrqss(self, setting_id: str = Decrqss.SGR,
                     timeout: Optional[float] = 1) -> Optional[str]:
         """
         Query terminal state via DECRQSS (Request Status String).
@@ -2020,13 +2023,12 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         Results are not cached -- DECRQSS queries runtime state that
         may change between calls (cursor style, margins, SGR, etc.).
 
-        Use :class:`~blessed.DecrqssSettings` for setting
+        Use :class:`~blessed.Terminal.Decrqss` for setting
         identifiers::
 
-            from blessed import Terminal, DecrqssSettings
             term = Terminal()
-            term.get_decrqss(DecrqssSettings.DECSCUSR)  # cursor style
-            term.get_decrqss(DecrqssSettings.DECSTBM)   # scroll region
+            term.get_decrqss(term.Decrqss.DECSCUSR)  # cursor style
+            term.get_decrqss(term.Decrqss.DECSTBM)   # scroll region
 
         .. seealso::
 
@@ -2066,7 +2068,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         if self._decrqss_supported is not None and not force:
             return self._decrqss_supported
 
-        supported = self.get_decrqss(DecrqssSettings.SGR, timeout) is not None
+        supported = self.get_decrqss(Decrqss.SGR, timeout) is not None
         self._decrqss_supported = supported
         return supported
 

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -5,6 +5,7 @@ import os
 import re
 import sys
 import time
+import base64
 import codecs
 import locale
 import select
@@ -12,7 +13,6 @@ import struct
 import asyncio
 import platform
 import warnings
-import base64
 import contextlib
 import collections
 from typing import IO, Dict, List, Match, Tuple, Union, Optional, Generator, SupportsIndex
@@ -1851,7 +1851,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
     def does_osc52_clipboard(self, timeout: Optional[float] = 1,
                              force: bool = False) -> bool:
-        """
+        r"""
         Detect OSC 52 clipboard support without reading the clipboard.
 
         This method uses two non-intrusive detection strategies that avoid triggering user-facing
@@ -1861,7 +1861,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         2. **XTGETTCAP ``Ms``**
 
         These methods are preferred over sending an actual OSC 52 read request
-        (``\\x1b]52;c;?\\a``), which may trigger a clipboard permission dialog in many modern
+        (``\x1b]52;c;?\a``), which may trigger a clipboard permission dialog in many modern
         terminals.
 
         .. note::
@@ -1869,8 +1869,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             Detection indicates the terminal *understands* OSC 52, but not a guarantee that
             clipboard access will succeed, the user may deny access.
 
-            If neither DA1 nor XTGETTCAP reports OSC 52 support, this method returns ``False`` --
-            but the terminal may still support OSC 52 via configuration.
+            If neither DA1 nor XTGETTCAP reports OSC 52 support, this method returns ``False``.
 
         :arg float timeout: Timeout in seconds for each sub-query.
         :arg bool force: Bypass cached result.
@@ -1918,11 +1917,11 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
     def clipboard_paste(self, timeout: Optional[float] = 10,
                         selection: str = 'c') -> Optional[str]:
-        """
+        r"""
         Read the system clipboard via OSC 52.
 
-        Sends an OSC 52 query (``\\x1b]52;c;?\\a``) and waits for
-        the terminal to respond with the clipboard contents.
+        Sends an OSC 52 query (``\x1b]52;c;?\a``) and waits for the terminal to respond with the
+        clipboard contents.
 
         .. warning::
 
@@ -1933,14 +1932,12 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             the dialog, or no response is received within given timeout, this method returns
             ``None``.
 
-        :arg float timeout: Timeout in seconds.  A generous timeout
-            is recommended because the user may need to interact
-            with a permission dialog.
-        :arg str selection: The X11 selection target -- ``'c'`` for
-            clipboard (default), ``'p'`` for primary.
+        :arg float timeout: Timeout in seconds.  A generous timeout is recommended because the user
+            may need to interact with a permission dialog.
+        :arg str selection: The X11 selection target -- ``'c'`` for clipboard (default),
+            ``'p'`` for primary.
         :rtype: str or None
-        :returns: The clipboard text, or ``None`` if the terminal did
-            not respond (unsupported, denied, or timed out).
+        :returns: The clipboard text, or ``None`` if denied or timeout is reached.
         """
         match = self._query_with_boundary(
             f'\x1b]52;{selection};?\x07', _RE_OSC52_RESPONSE, timeout)

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -112,6 +112,10 @@ _RE_CPR_BOUNDARY = re.compile(r'\x1b\[[0-9]+;[0-9]+R')
 _RE_KITTY_CLIPBOARD = re.compile(r'\x1b\[\?5522;(\d+)\$y')
 _RE_KITTY_POINTER = re.compile(r'\x1b\]22;([^\x07\x1b]+)[\x07\x1b]')
 _RE_OSC52_RESPONSE = re.compile(r'\x1b\]52;[a-z]*;([^\x07\x1b]*)[\x07\x1b]')
+# Color scheme (dark/light mode): CSI ? 997 ; Ps n
+_RE_COLOR_SCHEME_MODE_RESPONSE = re.compile(r'\x1b\[\?997;([12])n')
+# DECRQSS: DCS Ps $ r Pt ST (Ps=1 means valid)
+_RE_DECRQSS_RESPONSE = re.compile(r'\x1bP([01])\$r([^\x1b]*)\x1b\\')
 
 
 class Terminal():
@@ -318,6 +322,15 @@ class Terminal():
 
         # OSC 52 clipboard detection cache
         self._osc52_clipboard_supported: Optional[bool] = None
+
+        # Color scheme (dark/light mode) detection cache
+        self._color_scheme_cache: Optional[str] = None
+
+        # Kitty XTGETTCAP query extensions detection cache
+        self._kitty_query_supported: Optional[bool] = None
+
+        # DECRQSS detection cache
+        self._decrqss_supported: Optional[bool] = None
 
     def __init_set_styling(self, force_styling: bool) -> None:
         self._does_styling = False
@@ -1850,6 +1863,109 @@ class Terminal():
             '\x1b]52;c;?\x07', _RE_OSC52_RESPONSE, timeout)
         supported = match is not None
         self._osc52_clipboard_supported = supported
+        return supported
+
+    def get_color_scheme(self, timeout: Optional[float] = 1,
+                         force: bool = False) -> Optional[str]:
+        """
+        Query the terminal's color scheme preference (dark or light mode).
+
+        Sends a ``CSI ? 996 n`` Device Status Report query.  Terminals
+        that support color-scheme reporting respond with
+        ``CSI ? 997 ; Ps n`` where *Ps* is ``1`` for dark mode or ``2``
+        for light mode.  Uses a CPR boundary guard for fast negative
+        detection.
+
+        Mode 2031 (``COLOR_PALETTE_UPDATES``) can be enabled separately
+        to receive unsolicited notifications when the scheme changes.
+
+        .. seealso::
+
+            `Color palette update notifications
+            <https://contour-terminal.org/vt-extensions/color-palette-update-notifications/>`_
+
+        Supported by Contour, Ghostty, Kitty (0.38.1+), and VTE (0.82.0+).
+
+        :arg float timeout: Timeout in seconds.
+        :arg bool force: Bypass cached result.
+        :rtype: str or None
+        :returns: ``'dark'``, ``'light'``, or ``None`` if unsupported.
+        """
+        if self._color_scheme_cache is not None and not force:
+            return self._color_scheme_cache
+
+        match = self._query_with_boundary(
+            '\x1b[?996n', _RE_COLOR_SCHEME_MODE_RESPONSE, timeout)
+        if match:
+            ps = match.group(1)
+            scheme = 'dark' if ps == '1' else 'light'
+            self._color_scheme_cache = scheme
+            return scheme
+        return None
+
+    def does_kitty_query(self, timeout: Optional[float] = 1,
+                         force: bool = False) -> bool:
+        """
+        Detect Kitty XTGETTCAP query extensions.
+
+        Kitty extends the standard ``XTGETTCAP`` (``DCS +q``) mechanism
+        with ``kitty-query-*`` keys that expose runtime metadata such as
+        the terminal name, version, font family, DPI, and clipboard
+        control policy.
+
+        This method probes for ``kitty-query-name`` support.  A
+        successful response indicates the full set of Kitty query
+        extensions is available.
+
+        .. seealso::
+
+            `Query terminal -- kitty
+            <https://sw.kovidgoyal.net/kitty/kittens/query_terminal/>`_
+
+        :arg float timeout: Timeout in seconds.
+        :arg bool force: Bypass cached result.
+        :rtype: bool
+        """
+        if self._kitty_query_supported is not None and not force:
+            return self._kitty_query_supported
+
+        from blessed._capabilities import TermcapResponse
+        capname = 'kitty-query-name'
+        query = f'\x1bP+q{TermcapResponse.hex_encode(capname)}\x1b\\'
+        match = self._query_with_boundary(
+            query, _RE_XTGETTCAP_RESPONSE, timeout)
+        supported = match is not None and match.group(1) == '1'
+        self._kitty_query_supported = supported
+        return supported
+
+    def does_decrqss(self, timeout: Optional[float] = 1,
+                     force: bool = False) -> bool:
+        """
+        Detect DECRQSS (Request Status String) support.
+
+        Sends a ``DECRQSS`` query for the current SGR (Select Graphic
+        Rendition) state (``DCS $ q m ST``).  A valid response
+        (``DCS 1 $ r ... ST``) indicates the terminal supports status
+        string queries for SGR, DECSCL, DECSCUSR, and other attributes.
+
+        .. seealso::
+
+            `DECRQSS specification
+            <https://vt100.net/docs/vt510-rm/DECRQSS.html>`_
+
+        Supported by xterm, Contour, kitty, VTE, and others.
+
+        :arg float timeout: Timeout in seconds.
+        :arg bool force: Bypass cached result.
+        :rtype: bool
+        """
+        if self._decrqss_supported is not None and not force:
+            return self._decrqss_supported
+
+        match = self._query_with_boundary(
+            '\x1bP$qm\x1b\\', _RE_DECRQSS_RESPONSE, timeout)
+        supported = match is not None and match.group(1) == '1'
+        self._decrqss_supported = supported
         return supported
 
     def does_styled_underlines(self, timeout: Optional[float] = 1,

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -107,13 +107,13 @@ _RE_XTGETTCAP_RESPONSE = re.compile(
     r'\x1bP([01])\+r([0-9a-fA-F]+)(?:=([0-9a-fA-F]*))?\x1b\\')
 _RE_KITTY_GRAPHICS_RESPONSE = re.compile(r'\x1b_Gi=31;(.+?)\x1b\\')
 _RE_ITERM2_CAPABILITIES_RESPONSE = re.compile(
-    r'\x1b\]1337;Capabilities=([^\x07\x1b]+)[\x07\x1b]')
+    r'\x1b\]1337;Capabilities=([^\x07\x1b]+)(?:\x07|\x1b\\)')
 _RE_KITTY_NOTIFICATIONS_RESPONSE = re.compile(
-    r'\x1b\]99;([^\x07\x1b]*?)[\x07\x1b]')
+    r'\x1b\]99;([^\x07\x1b]*?)(?:\x07|\x1b\\)')
 _RE_CPR_BOUNDARY = re.compile(r'\x1b\[[0-9]+;[0-9]+R')
 _RE_KITTY_CLIPBOARD = re.compile(r'\x1b\[\?5522;(\d+)\$y')
-_RE_KITTY_POINTER = re.compile(r'\x1b\]22;([^\x07\x1b]+)[\x07\x1b]')
-_RE_OSC52_RESPONSE = re.compile(r'\x1b\]52;[a-z]*;([^\x07\x1b]*)[\x07\x1b]')
+_RE_KITTY_POINTER = re.compile(r'\x1b\]22;([^\x07\x1b]+)(?:\x07|\x1b\\)')
+_RE_OSC52_RESPONSE = re.compile(r'\x1b\]52;[a-z]*;([^\x07\x1b]*)(?:\x07|\x1b\\)')
 # Color scheme (dark/light mode): CSI ? 997 ; Ps n
 _RE_COLOR_SCHEME_MODE_RESPONSE = re.compile(r'\x1b\[\?997;([12])n')
 # DECRQSS: DCS Ps $ r Pt ST (Ps=1 means valid)
@@ -1928,8 +1928,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         :rtype: str or None
         :returns: The clipboard text, or ``None`` if denied or timeout is reached.
         """
-        match = self._query_with_boundary(
-            f'\x1b]52;{selection};?\x07', _RE_OSC52_RESPONSE, timeout)
+        match = self._query_response(
+            f'\x1b]52;{selection};?\x07', _RE_OSC52_RESPONSE.pattern, timeout)
         if match is None:
             return None
         b64_data = match.group(1)

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -111,6 +111,7 @@ _RE_KITTY_NOTIFICATIONS_RESPONSE = re.compile(
 _RE_CPR_BOUNDARY = re.compile(r'\x1b\[[0-9]+;[0-9]+R')
 _RE_KITTY_CLIPBOARD = re.compile(r'\x1b\[\?5522;(\d+)\$y')
 _RE_KITTY_POINTER = re.compile(r'\x1b\]22;([^\x07\x1b]+)[\x07\x1b]')
+_RE_OSC52_RESPONSE = re.compile(r'\x1b\]52;[a-z]*;([^\x07\x1b]*)[\x07\x1b]')
 
 
 class Terminal():
@@ -314,6 +315,9 @@ class Terminal():
 
         # Text sizing (OSC 66) detection cache
         self._text_sizing_cache: Optional[TextSizingResult] = None
+
+        # OSC 52 clipboard detection cache
+        self._osc52_clipboard_supported: Optional[bool] = None
 
     def __init_set_styling(self, force_styling: bool) -> None:
         self._does_styling = False
@@ -1826,6 +1830,57 @@ class Terminal():
             return shape
         self._kitty_pointer_shapes_result = (False, '')
         return None
+
+    def does_osc52_clipboard(self, timeout: Optional[float] = 1,
+                             force: bool = False) -> bool:
+        """
+        Detect OSC 52 clipboard access support.
+
+        Sends an OSC 52 clipboard read request and checks whether the
+        terminal responds.  A response (even with empty data) indicates
+        the terminal supports the OSC 52 clipboard protocol.
+
+        :arg float timeout: Timeout in seconds.
+        :arg bool force: Bypass cached result.
+        :rtype: bool
+        """
+        if self._osc52_clipboard_supported is not None and not force:
+            return self._osc52_clipboard_supported
+        match = self._query_with_boundary(
+            '\x1b]52;c;?\x07', _RE_OSC52_RESPONSE, timeout)
+        supported = match is not None
+        self._osc52_clipboard_supported = supported
+        return supported
+
+    def does_styled_underlines(self, timeout: Optional[float] = 1,
+                               force: bool = False) -> bool:
+        """
+        Detect extended underline style support (curly, dotted, dashed).
+
+        Queries the terminal's ``Smulx`` terminfo capability via XTGETTCAP.
+        When supported, the terminal can render underline styles beyond the
+        standard single underline, such as ``CSI 4:3 m`` (curly).
+
+        :arg float timeout: Timeout in seconds for XTGETTCAP query.
+        :arg bool force: Bypass cached result.
+        :rtype: bool
+        """
+        tc = self.get_xtgettcap(timeout=timeout, force=force)
+        return tc is not None and 'Smulx' in tc
+
+    def does_colored_underlines(self, timeout: Optional[float] = 1,
+                                force: bool = False) -> bool:
+        """
+        Detect colored underline support (``CSI 58;2;r;g;b m``).
+
+        Queries the terminal's ``Setulc`` terminfo capability via XTGETTCAP.
+
+        :arg float timeout: Timeout in seconds for XTGETTCAP query.
+        :arg bool force: Bypass cached result.
+        :rtype: bool
+        """
+        tc = self.get_xtgettcap(timeout=timeout, force=force)
+        return tc is not None and 'Setulc' in tc
 
     def does_text_sizing(self, timeout: float = 1,
                          force: bool = False) -> TextSizingResult:

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -118,7 +118,7 @@ _RE_COLOR_SCHEME_MODE_RESPONSE = re.compile(r'\x1b\[\?997;([12])n')
 _RE_DECRQSS_RESPONSE = re.compile(r'\x1bP([01])\$r([^\x1b]*)\x1b\\')
 
 
-class Terminal():
+class Terminal():  # pylint: disable=attribute-defined-outside-init
     """
     An abstraction for color, style, positioning, and input in the terminal.
 
@@ -273,6 +273,9 @@ class Terminal():
         self.__init__keycodes()
         self.__init__dec_private_modes()
 
+        self.__init__query_caches()
+
+    def __init__query_caches(self) -> None:
         # Initialize Kitty keyboard protocol tracking
         self._kitty_kb_first_query_failed = False
 
@@ -1934,7 +1937,6 @@ class Terminal():
         if self._kitty_query_supported is not None and not force:
             return self._kitty_query_supported
 
-        from blessed._capabilities import TermcapResponse
         capname = 'kitty-query-name'
         query = f'\x1bP+q{TermcapResponse.hex_encode(capname)}\x1b\\'
         match = self._query_with_boundary(
@@ -2989,6 +2991,51 @@ class Terminal():
         if not self.does_styling:
             return text
         return f'\x1b]8;{params};{url}\x1b\\{text}\x1b]8;;\x1b\\'
+
+    def set_window_title(self, title: str, mode: int = 0) -> str:
+        """
+        Return sequence to set the terminal title.
+
+        Uses xterm OSC (Operating System Command) sequences to set the
+        window and/or icon title.
+
+        :param str title: Title text. Any embedded escape or BEL characters
+            are stripped to prevent sequence injection.
+        :param int mode: OSC mode -- 0 sets both icon name and window title,
+            1 sets icon name only, 2 sets window title only.
+        :rtype: str
+        :returns: Escape sequence string that sets the terminal title,
+            or empty string when :attr:`does_styling` is ``False``.
+        """
+        assert mode in {0, 1, 2}, f"mode must be 0, 1, or 2, got {mode!r}"
+        if not self.does_styling:
+            return ''
+        sanitized = title.replace('\x1b', '').replace('\x07', '')
+        return f'\x1b]{mode};{sanitized}\x07'
+
+    @contextlib.contextmanager
+    def window_title(self, title: str, mode: int = 0) -> Generator[None, None, None]:
+        """
+        Context manager that sets terminal title, restoring on exit.
+
+        Uses the xterm title stack (XTWINOPS push/pop) to save and
+        restore the previous title. Not all terminals support the title
+        stack -- those that do not will simply set the title without
+        restoring it on exit.
+
+        :param str title: Title text.
+        :param int mode: OSC mode -- 0 sets both icon name and window title,
+            1 sets icon name only, 2 sets window title only.
+        """
+        if self.does_styling:
+            self.stream.write(f'\x1b[22;0t{self.set_window_title(title, mode)}')
+            self.stream.flush()
+        try:
+            yield
+        finally:
+            if self.does_styling:
+                self.stream.write('\x1b[23;0t')
+                self.stream.flush()
 
     @property
     def stream(self) -> IO[str]:

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -1855,22 +1855,10 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         r"""
         Detect OSC 52 clipboard support without reading the clipboard.
 
-        This method uses two non-intrusive detection strategies that avoid triggering user-facing
-        clipboard permission prompts:
-
-        1. **DA1 extension 52**
-        2. **XTGETTCAP ``Ms``**
-
-        These methods are preferred over sending an actual OSC 52 read request
-        (``\x1b]52;c;?\a``), which may trigger a clipboard permission dialog in many modern
-        terminals.
-
-        .. note::
-
-            Detection indicates the terminal *understands* OSC 52, but not a guarantee that
-            clipboard access will succeed, the user may deny access.
-
-            If neither DA1 nor XTGETTCAP reports OSC 52 support, this method returns ``False``.
+        This method uses non-intrusive detection to avoid triggering user-facing clipboard
+        permission prompts, **DA1 extension 52** and **XTGETTCAP ``Ms``** fields.  These methods are
+        preferred over sending an actual OSC 52 read request (``\x1b]52;c;?\a``), which may trigger
+        a clipboard permission dialog in many modern terminals.
 
         :arg float timeout: Timeout in seconds for each sub-query.
         :arg bool force: Bypass cached result.

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -52,12 +52,12 @@ from .formatters import (COLORS,
                          resolve_attribute,
                          resolve_capability)
 from .cursor_shape import CursorShape as _CursorShape
-from ._capabilities import (DecrqssSettings,
-                            CAPABILITY_DATABASE,
+from ._capabilities import (CAPABILITY_DATABASE,
                             CAPABILITIES_ADDITIVES,
                             CAPABILITIES_RAW_MIXIN,
                             XTGETTCAP_CAPABILITIES,
                             CAPABILITIES_HORIZONTAL_DISTANCE,
+                            DecrqssSettings,
                             TermcapResponse,
                             TextSizingResult,
                             ITerm2Capabilities)

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -220,7 +220,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             .. _CLICOLOR_FORCE: https://bixense.com/clicolors/
             .. _NO_COLOR: https://no-color.org/
         """
-        # pylint: disable=global-statement,too-many-statements
+        # pylint: disable=global-statement
         global _CUR_TERM
         self.errors = [
             f'parameters: kind={kind!r}, stream={stream!r}, force_styling={force_styling!r}',
@@ -1948,7 +1948,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             return ''
         try:
             return base64.b64decode(b64_data).decode('utf-8')
-        except (ValueError, UnicodeDecodeError):
+        except ValueError:
             return None
 
     def get_color_scheme(self, timeout: Optional[float] = 1,

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -1849,9 +1849,8 @@ class Terminal():
         """
         Detect OSC 52 clipboard access support.
 
-        Sends an OSC 52 clipboard read request and checks whether the
-        terminal responds.  A response (even with empty data) indicates
-        the terminal supports the OSC 52 clipboard protocol.
+        Sends an OSC 52 clipboard read request and checks whether the terminal responds.  A response
+        (even with empty data) indicates the terminal supports the OSC 52 clipboard protocol.
 
         :arg float timeout: Timeout in seconds.
         :arg bool force: Bypass cached result.

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -323,8 +323,8 @@ class Terminal():
         # OSC 52 clipboard detection cache
         self._osc52_clipboard_supported: Optional[bool] = None
 
-        # Color scheme (dark/light mode) detection cache
-        self._color_scheme_cache: Optional[str] = None
+        # Color scheme (dark/light mode) -- whether query is supported
+        self._color_scheme_supported: Optional[bool] = None
 
         # Kitty XTGETTCAP query extensions detection cache
         self._kitty_query_supported: Optional[bool] = None
@@ -1876,6 +1876,11 @@ class Terminal():
         for light mode.  Uses a CPR boundary guard for fast negative
         detection.
 
+        The result is not cached because the color scheme can change at
+        any time (e.g. when the user toggles dark mode).  Only the
+        *supported* state is cached so that terminals that do not
+        respond incur the timeout delay only once.
+
         Mode 2031 (``COLOR_PALETTE_UPDATES``) can be enabled separately
         to receive unsolicited notifications when the scheme changes.
 
@@ -1891,16 +1896,16 @@ class Terminal():
         :rtype: str or None
         :returns: ``'dark'``, ``'light'``, or ``None`` if unsupported.
         """
-        if self._color_scheme_cache is not None and not force:
-            return self._color_scheme_cache
+        if self._color_scheme_supported is False and not force:
+            return None
 
         match = self._query_with_boundary(
             '\x1b[?996n', _RE_COLOR_SCHEME_MODE_RESPONSE, timeout)
         if match:
+            self._color_scheme_supported = True
             ps = match.group(1)
-            scheme = 'dark' if ps == '1' else 'light'
-            self._color_scheme_cache = scheme
-            return scheme
+            return 'dark' if ps == '1' else 'light'
+        self._color_scheme_supported = False
         return None
 
     def does_kitty_query(self, timeout: Optional[float] = 1,

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -52,7 +52,8 @@ from .formatters import (COLORS,
                          resolve_attribute,
                          resolve_capability)
 from .cursor_shape import CursorShape as _CursorShape
-from ._capabilities import (CAPABILITY_DATABASE,
+from ._capabilities import (DecrqssSettings,
+                            CAPABILITY_DATABASE,
                             CAPABILITIES_ADDITIVES,
                             CAPABILITIES_RAW_MIXIN,
                             XTGETTCAP_CAPABILITIES,
@@ -2018,22 +2019,57 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         self._kitty_query_supported = supported
         return supported
 
-    def does_decrqss(self, timeout: Optional[float] = 1,
-                     force: bool = False) -> bool:
+    def get_decrqss(self, setting_id: str = DecrqssSettings.SGR,
+                    timeout: Optional[float] = 1) -> Optional[str]:
         """
-        Detect DECRQSS (Request Status String) support.
+        Query terminal state via DECRQSS (Request Status String).
 
-        Sends a ``DECRQSS`` query for the current SGR (Select Graphic
-        Rendition) state (``DCS $ q m ST``).  A valid response
-        (``DCS 1 $ r ... ST``) indicates the terminal supports status
-        string queries for SGR, DECSCL, DECSCUSR, and other attributes.
+        Sends ``DCS $ q <setting_id> ST`` and decodes the response.
+        Returns the parameter value string on success, with the echoed
+        setting identifier stripped.  Returns ``None`` when the terminal
+        does not support DECRQSS or the setting is invalid.
+
+        Results are not cached -- DECRQSS queries runtime state that
+        may change between calls (cursor style, margins, SGR, etc.).
+
+        Use :class:`~blessed.DecrqssSettings` for setting
+        identifiers::
+
+            from blessed import Terminal, DecrqssSettings
+            term = Terminal()
+            term.get_decrqss(DecrqssSettings.DECSCUSR)  # cursor style
+            term.get_decrqss(DecrqssSettings.DECSTBM)   # scroll region
 
         .. seealso::
 
             `DECRQSS specification
             <https://vt100.net/docs/vt510-rm/DECRQSS.html>`_
 
-        Supported by xterm, Contour, kitty, VTE, and others.
+        :arg str setting_id: Setting identifier to query (default: SGR).
+        :arg float timeout: Timeout in seconds.
+        :rtype: str or None
+        """
+        query = f'\x1bP$q{setting_id}\x1b\\'
+        match = self._query_with_boundary(query, _RE_DECRQSS_RESPONSE, timeout)
+        if match is not None and match.group(1) == '1':
+            pt = match.group(2)
+            if pt.endswith(setting_id):
+                return pt[:-len(setting_id)]
+            return pt
+        return None
+
+    def does_decrqss(self, timeout: Optional[float] = 1,
+                     force: bool = False) -> bool:
+        """
+        Detect DECRQSS (Request Status String) support.
+
+        Sends a ``DECRQSS`` query for the current SGR state.  A valid
+        response indicates the terminal supports status string queries.
+
+        .. seealso::
+
+            `DECRQSS specification
+            <https://vt100.net/docs/vt510-rm/DECRQSS.html>`_
 
         :arg float timeout: Timeout in seconds.
         :arg bool force: Bypass cached result.
@@ -2042,9 +2078,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         if self._decrqss_supported is not None and not force:
             return self._decrqss_supported
 
-        match = self._query_with_boundary(
-            '\x1bP$qm\x1b\\', _RE_DECRQSS_RESPONSE, timeout)
-        supported = match is not None and match.group(1) == '1'
+        supported = self.get_decrqss(DecrqssSettings.SGR, timeout) is not None
         self._decrqss_supported = supported
         return supported
 

--- a/blessed/win_terminal.py
+++ b/blessed/win_terminal.py
@@ -104,7 +104,7 @@ def _win32_resize_to_seq(fd: int) -> str:
     return f'\x1b[48;{size.lines};{size.columns};0;0t'
 
 
-class Terminal(_Terminal):  # pylint: disable=attribute-defined-outside-init
+class Terminal(_Terminal):
     """Windows subclass of :class:`Terminal`."""
 
     def __init__(self,

--- a/blessed/win_terminal.py
+++ b/blessed/win_terminal.py
@@ -104,7 +104,7 @@ def _win32_resize_to_seq(fd: int) -> str:
     return f'\x1b[48;{size.lines};{size.columns};0;0t'
 
 
-class Terminal(_Terminal):
+class Terminal(_Terminal):  # pylint: disable=attribute-defined-outside-init
     """Windows subclass of :class:`Terminal`."""
 
     def __init__(self,
@@ -423,7 +423,7 @@ class Terminal(_Terminal):
             self._event_buf.clear()
             del self._dec_mode_cache[
                 _DecPrivateMode.IN_BAND_WINDOW_RESIZE]
-            self._preferred_size_cache = None
+            self._preferred_size_cache = None  # pylint: disable=attribute-defined-outside-init
             win32.set_console_mode(filehandle, save_mode)
 
     def does_inband_resize(self, timeout: float = 1.0) -> bool:

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -6,7 +6,7 @@ Version History
 1.38
 
   * introduced: :meth:`~.Terminal.does_osc52_clipboard`, :meth:`~.Terminal.clipboard_copy`, and
-    :meth:`~.Terminal.clipboard_paste` to detect, copy, and read form clipboard.
+    :meth:`~.Terminal.clipboard_paste` to detect, copy, and read from clipboard.
   * introduced: :meth:`~.Terminal.get_color_scheme`.
   * introduced: :meth:`~.Terminal.does_kitty_query` for Kitty's XTGETTCAP query extensions.
   * introduced: :meth:`~.Terminal.does_decrqss` for DECRQSS (Request Status String).
@@ -23,7 +23,8 @@ Version History
     :ghpull:`366`.
   * bugfix: Background SGR not applying to text/suggestion content in
     :class:`blessed.line_editor.LineEditor`, now prepend bg_sgr before each content SGR sequence.
-  * bugfix: OSC responses to iTerm2 capabilities, Kitty notifications, Kitty pointer shape responses
+  * bugfix: OSC responses for 'ST' in addition to 'BEL' terminated iTerm2 capabilities,
+    Kitty notifications, Kitty pointer shapes responses
 
 1.37
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -15,6 +15,11 @@ Version History
   * introduced: :meth:`~.Terminal.does_styled_underlines` and
     :meth:`~.Terminal.does_colored_underlines` -- detect extended underline styles (``Smulx``) and
     colored underlines (``Setulc``) via XTGETTCAP.
+  * introduced: :meth:`~.Terminal.set_window_title` and :meth:`~.Terminal.window_title` -- set the
+    terminal window and/or icon title via xterm OSC sequences, with a context manager that pushes
+    and pops the title stack (XTWINOPS).
+  * introduced: :attr:`DecModeResponse.recognized` and :attr:`DecModeResponse.supported`
+    properties -- distinguish modes the terminal acknowledges from those it can actually use.
   * improved: ``Smulx`` and ``Setulc`` added to XTGETTCAP capability list.
   * bugfix: ``EOF`` when stdin is connected to a Pipe (eg. pytest capture) caused infinite loop
     :ghpull:`366`.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,7 +5,9 @@ Version History
 
 1.38
 
-  * introduced: :meth:`~.Terminal.does_osc52_clipboard` -- detect OSC 52 clipboard protocol support.
+  * introduced: :meth:`~.Terminal.does_osc52_clipboard`, :meth:`~.Terminal.clipboard_copy`, and
+    :meth:`~.Terminal.clipboard_paste` -- detect, copy to, and read from the system clipboard
+    via OSC 52. Detection avoids triggering clipboard permission dialogs.
   * introduced: :meth:`~.Terminal.get_color_scheme` -- query dark or light mode preference via
     ``CSI ? 996 n`` DSR. Supported by Contour, Ghostty, Kitty (0.38.1+), and VTE (0.82.0+).
   * introduced: :meth:`~.Terminal.does_kitty_query` -- detect Kitty XTGETTCAP query extensions

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,14 @@
 Version History
 ===============
 
+1.38
+
+  * introduced: :meth:`~.Terminal.does_osc52_clipboard` -- detect OSC 52 clipboard protocol support.
+  * introduced: :meth:`~.Terminal.does_styled_underlines` and
+    :meth:`~.Terminal.does_colored_underlines` -- detect extended underline styles (``Smulx``) and
+    colored underlines (``Setulc``) via XTGETTCAP.
+  * improved: ``Smulx`` and ``Setulc`` added to XTGETTCAP capability list.
+
 1.37
 
   * bugfix: legacy CSI letter-form sequences with explicit modifiers and event type (e.g.,

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -6,14 +6,10 @@ Version History
 1.38
 
   * introduced: :meth:`~.Terminal.does_osc52_clipboard`, :meth:`~.Terminal.clipboard_copy`, and
-    :meth:`~.Terminal.clipboard_paste` -- detect, copy to, and read from the system clipboard
-    via OSC 52. Detection avoids triggering clipboard permission dialogs.
-  * introduced: :meth:`~.Terminal.get_color_scheme` -- query dark or light mode preference via
-    ``CSI ? 996 n`` DSR. Supported by Contour, Ghostty, Kitty (0.38.1+), and VTE (0.82.0+).
-  * introduced: :meth:`~.Terminal.does_kitty_query` -- detect Kitty XTGETTCAP query extensions
-    (``kitty-query-*`` keys for terminal name, version, font, DPI, etc.).
-  * introduced: :meth:`~.Terminal.does_decrqss` -- detect DECRQSS (Request Status String) support
-    for querying SGR, DECSCUSR, DECSCL, and other terminal attributes.
+    :meth:`~.Terminal.clipboard_paste` to detect, copy, and read form clipboard.
+  * introduced: :meth:`~.Terminal.get_color_scheme`.
+  * introduced: :meth:`~.Terminal.does_kitty_query` for Kitty's XTGETTCAP query extensions.
+  * introduced: :meth:`~.Terminal.does_decrqss` for DECRQSS (Request Status String).
   * introduced: :meth:`~.Terminal.does_styled_underlines` and
     :meth:`~.Terminal.does_colored_underlines` -- detect extended underline styles (``Smulx``) and
     colored underlines (``Setulc``) via XTGETTCAP.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -23,6 +23,7 @@ Version History
     :ghpull:`366`.
   * bugfix: Background SGR not applying to text/suggestion content in
     :class:`blessed.line_editor.LineEditor`, now prepend bg_sgr before each content SGR sequence.
+  * bugfix: OSC responses to iTerm2 capabilities, Kitty notifications, Kitty pointer shape responses
 
 1.37
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -6,6 +6,12 @@ Version History
 1.38
 
   * introduced: :meth:`~.Terminal.does_osc52_clipboard` -- detect OSC 52 clipboard protocol support.
+  * introduced: :meth:`~.Terminal.get_color_scheme` -- query dark or light mode preference via
+    ``CSI ? 996 n`` DSR. Supported by Contour, Ghostty, Kitty (0.38.1+), and VTE (0.82.0+).
+  * introduced: :meth:`~.Terminal.does_kitty_query` -- detect Kitty XTGETTCAP query extensions
+    (``kitty-query-*`` keys for terminal name, version, font, DPI, etc.).
+  * introduced: :meth:`~.Terminal.does_decrqss` -- detect DECRQSS (Request Status String) support
+    for querying SGR, DECSCUSR, DECSCL, and other terminal attributes.
   * introduced: :meth:`~.Terminal.does_styled_underlines` and
     :meth:`~.Terminal.does_colored_underlines` -- detect extended underline styles (``Smulx``) and
     colored underlines (``Setulc``) via XTGETTCAP.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -21,6 +21,8 @@ Version History
   * improved: ``Smulx`` and ``Setulc`` added to XTGETTCAP capability list.
   * bugfix: ``EOF`` when stdin is connected to a Pipe (eg. pytest capture) caused infinite loop
     :ghpull:`366`.
+  * bugfix: Background SGR not applying to text/suggestion content in
+    :class:`blessed.line_editor.LineEditor`, now prepend bg_sgr before each content SGR sequence.
 
 1.37
 

--- a/docs/terminal.rst
+++ b/docs/terminal.rst
@@ -154,6 +154,60 @@ You can detect these capabilities via XTGETTCAP:
 These methods query the terminal's ``Smulx`` and ``Setulc`` terminfo
 capabilities, respectively. Default ``timeout`` argument of 1 second is used.
 
+Color Scheme Detection
+----------------------
+
+Some terminals can report whether they are in dark or light mode via the
+color-scheme DSR query (``CSI ? 996 n``). This is supported by Contour,
+Ghostty, Kitty (0.38.1+), and VTE (0.82.0+).
+
+Use :meth:`~.Terminal.get_color_scheme` to query the current preference:
+
+    >>> scheme = term.get_color_scheme()
+    >>> if scheme == 'dark':
+    ...     use_dark_palette()
+    ... elif scheme == 'light':
+    ...     use_light_palette()
+    ... else:
+    ...     use_default_palette()
+
+Returns ``'dark'``, ``'light'``, or ``None`` if the terminal does not support
+the query. Default ``timeout`` argument of 1 second is used.
+
+Unlike most detection methods, the result value is not cached -- only whether
+the terminal *supports* the query is remembered. This means repeated calls
+always return the current scheme, while terminals that do not respond only incur
+the timeout delay once.
+
+To receive unsolicited notifications when the color scheme changes, enable DEC
+private mode 2031 (``COLOR_PALETTE_UPDATES``) separately.
+
+Kitty Query Extensions
+----------------------
+
+Kitty extends the standard XTGETTCAP (``DCS +q``) mechanism with
+``kitty-query-*`` keys that expose runtime metadata such as the terminal name,
+version, font family, DPI, and clipboard control policy.
+
+You can detect whether these extensions are available using
+:meth:`~.Terminal.does_kitty_query`:
+
+    >>> if term.does_kitty_query():
+    ...     print("Kitty query extensions available")
+
+DECRQSS Support
+---------------
+
+DECRQSS (Request Status String) allows applications to query the current state
+of terminal attributes such as SGR (Select Graphic Rendition), cursor style
+(DECSCUSR), and conformance level (DECSCL). This is supported by xterm,
+Contour, kitty, VTE, and others.
+
+You can detect DECRQSS support using :meth:`~.Terminal.does_decrqss`:
+
+    >>> if term.does_decrqss():
+    ...     print("DECRQSS queries supported")
+
 Terminal Software Version
 -------------------------
 

--- a/docs/terminal.rst
+++ b/docs/terminal.rst
@@ -100,6 +100,28 @@ Hover your cursor over ``documentation``, and it should highlight as a clickable
 .. figure:: https://dxtz6bzwq9sxx.cloudfront.net/demo_basic_hyperlink.gif
    :alt: Animation of running code example and clicking a hyperlink
 
+Window Title
+------------
+
+You can set the terminal window title using
+:meth:`~.Terminal.set_window_title`, which returns the appropriate xterm OSC
+escape sequence:
+
+    >>> print(term.set_window_title('My Application'))
+
+The ``mode`` parameter controls what is set: 0 (default) sets both icon name
+and window title, 1 sets icon name only, 2 sets window title only.
+
+For temporary title changes, use the :meth:`~.Terminal.window_title` context
+manager, which pushes the current title onto the xterm title stack and restores
+it on exit:
+
+.. code-block:: python
+
+    with term.window_title('Working...'):
+        do_long_task()
+    # previous title is restored
+
 Sixel Graphics Support
 ----------------------
 

--- a/docs/terminal.rst
+++ b/docs/terminal.rst
@@ -148,14 +148,52 @@ system clipboard without requiring platform-specific clipboard tools. Many
 modern terminals support this protocol, including xterm, kitty, WezTerm, and
 iTerm2.
 
-You can check whether your terminal supports OSC 52 clipboard access using the
-:meth:`~.Terminal.does_osc52_clipboard` method:
+Detection
+~~~~~~~~~
+
+Use :meth:`~.Terminal.does_osc52_clipboard` to check whether your terminal
+advertises OSC 52 support:
 
     >>> if term.does_osc52_clipboard():
     ...     print("Terminal supports clipboard access")
 
-Default ``timeout`` argument of 1 second is used to avoid blocking indefinitely
-when the terminal fails to respond. Results are cached after the first query.
+Detection uses DA1 extension 52 and XTGETTCAP ``Ms`` queries, which do not
+trigger user-facing clipboard permission dialogs. Detection indicates the
+terminal *understands* OSC 52, not that any particular read will succeed.
+
+Copying to Clipboard
+~~~~~~~~~~~~~~~~~~~~
+
+Use :meth:`~.Terminal.clipboard_copy` to copy text to the system clipboard:
+
+    >>> term.clipboard_copy('Hello from blessed!')
+
+Most modern terminals accept clipboard writes without any user prompt, even
+when clipboard reads are restricted. No detection query is needed for
+write-only use -- the sequence is silently ignored by terminals that do not
+support it.
+
+Reading from Clipboard
+~~~~~~~~~~~~~~~~~~~~~~
+
+Use :meth:`~.Terminal.clipboard_paste` to read the clipboard contents:
+
+    >>> text = term.clipboard_paste()
+    >>> if text is not None:
+    ...     print(f"Clipboard: {text}")
+
+.. warning::
+
+    Many modern terminals display a permission dialog when an application
+    reads the clipboard. The user must approve the dialog before the
+    terminal sends a response. The default timeout of 10 seconds allows
+    time for this interaction. If the user denies the dialog or the
+    terminal does not support clipboard reads, ``None`` is returned.
+
+Example program demonstrating clipboard copy and paste:
+
+.. literalinclude:: ../bin/clipboard.py
+   :language: python
 
 Styled and Colored Underlines
 ------------------------------

--- a/docs/terminal.rst
+++ b/docs/terminal.rst
@@ -118,6 +118,42 @@ You can check whether your terminal supports sixel graphics using the
 Default ``timeout`` argument of 1 second is used to avoid blocking indefinitely
 when the terminal fails to respond to DA1 queries.
 
+OSC 52 Clipboard
+-----------------
+
+The OSC 52 protocol allows terminal applications to read from and write to the
+system clipboard without requiring platform-specific clipboard tools. Many
+modern terminals support this protocol, including xterm, kitty, WezTerm, and
+iTerm2.
+
+You can check whether your terminal supports OSC 52 clipboard access using the
+:meth:`~.Terminal.does_osc52_clipboard` method:
+
+    >>> if term.does_osc52_clipboard():
+    ...     print("Terminal supports clipboard access")
+
+Default ``timeout`` argument of 1 second is used to avoid blocking indefinitely
+when the terminal fails to respond. Results are cached after the first query.
+
+Styled and Colored Underlines
+------------------------------
+
+Modern terminals can render underline styles beyond the standard single
+underline, such as curly (``CSI 4:3 m``), dotted, and dashed underlines.
+Some also support colored underlines (``CSI 58;2;r;g;b m``), where the
+underline color differs from the text color.
+
+You can detect these capabilities via XTGETTCAP:
+
+    >>> if term.does_styled_underlines():
+    ...     print("Curly, dotted, and dashed underlines supported")
+
+    >>> if term.does_colored_underlines():
+    ...     print("Colored underlines supported")
+
+These methods query the terminal's ``Smulx`` and ``Setulc`` terminfo
+capabilities, respectively. Default ``timeout`` argument of 1 second is used.
+
 Terminal Software Version
 -------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ disable= [
     'suppressed-message',
     'wrong-import-order',
     'wrong-import-position',
+    'too-few-public-methods',
     'use-implicit-booleaness-not-comparison-to-zero',
 ]
 

--- a/tests/accessories.py
+++ b/tests/accessories.py
@@ -80,7 +80,7 @@ def init_subproc_coverage(run_note):
     return cov
 
 
-class as_subprocess():  # pylint: disable=too-few-public-methods
+class as_subprocess():
     """This helper executes test cases in a child process, avoiding a python-internal bug of
     _curses: setupterm() may not be called more than once per process."""
     _CHILD_PID = 0
@@ -414,7 +414,7 @@ def pty_test(child_func, parent_func=None, test_name=None, rows=24, cols=80):
     return output
 
 
-class MockTigetstr():  # pylint: disable=too-few-public-methods
+class MockTigetstr():
     """
     Wraps curses.tigetstr() to override specific capnames
 

--- a/tests/test_autoresponses.py
+++ b/tests/test_autoresponses.py
@@ -229,10 +229,11 @@ def test_detection_timeout(method_name, expected):
     assert 'OK' in output
 
 
-def test_get_iterm2_capabilities_full():
+@pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
+def test_get_iterm2_capabilities_full(terminator):
     """get_iterm2_capabilities parses Capabilities response."""
     def child(term):
-        term.ungetch('\x1b]1337;Capabilities=T2CwBF\x07\x1b[10;20R')
+        term.ungetch('\x1b]1337;Capabilities=T2CwBF' + terminator + '\x1b[10;20R')
         result = term.get_iterm2_capabilities(timeout=0.01)
         assert result is not None
         assert result.supported is True
@@ -260,10 +261,11 @@ def test_get_iterm2_capabilities_timeout():
     assert 'OK' in output
 
 
-def test_does_kitty_notifications_supported():
+@pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
+def test_does_kitty_notifications_supported(terminator):
     """does_kitty_notifications returns True with OSC 99 response."""
     def child(term):
-        term.ungetch('\x1b]99;i=blessed\x1b\\\x1b[10;20R')
+        term.ungetch('\x1b]99;i=blessed' + terminator + '\x1b[10;20R')
         result = term.does_kitty_notifications(timeout=0.01)
         assert result is True
         return b'OK'
@@ -312,10 +314,11 @@ def test_does_kitty_clipboard_decrqm_values(ps, expected):
     assert 'OK' in output
 
 
-def test_does_kitty_pointer_shapes_supported():
+@pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
+def test_does_kitty_pointer_shapes_supported(terminator):
     """does_kitty_pointer_shapes returns shape name with OSC 22 response."""
     def child(term):
-        term.ungetch('\x1b]22;default\x07\x1b[10;20R')
+        term.ungetch('\x1b]22;default' + terminator + '\x1b[10;20R')
         result = term.does_kitty_pointer_shapes(timeout=0.01)
         assert result == 'default'
         return b'OK'

--- a/tests/test_dec_modes.py
+++ b/tests/test_dec_modes.py
@@ -157,6 +157,7 @@ def test_dec_private_mode_descriptions_consistency():
 
 @pytest.mark.parametrize("value,expected", [
     (DecModeResponse.SET, {
+        "recognized": True,
         "supported": True,
         "enabled": True,
         "disabled": False,
@@ -165,6 +166,7 @@ def test_dec_private_mode_descriptions_consistency():
         "failed": False
     }),
     (DecModeResponse.RESET, {
+        "recognized": True,
         "supported": True,
         "enabled": False,
         "disabled": True,
@@ -173,6 +175,7 @@ def test_dec_private_mode_descriptions_consistency():
         "failed": False
     }),
     (DecModeResponse.PERMANENTLY_SET, {
+        "recognized": True,
         "supported": True,
         "enabled": True,
         "disabled": False,
@@ -181,7 +184,8 @@ def test_dec_private_mode_descriptions_consistency():
         "failed": False
     }),
     (DecModeResponse.PERMANENTLY_RESET, {
-        "supported": True,
+        "recognized": True,
+        "supported": False,
         "enabled": False,
         "disabled": True,
         "permanent": True,
@@ -189,6 +193,7 @@ def test_dec_private_mode_descriptions_consistency():
         "failed": False
     }),
     (DecModeResponse.NOT_RECOGNIZED, {
+        "recognized": False,
         "supported": False,
         "enabled": False,
         "disabled": False,
@@ -197,6 +202,7 @@ def test_dec_private_mode_descriptions_consistency():
         "failed": False
     }),
     (DecModeResponse.NO_RESPONSE, {
+        "recognized": False,
         "supported": False,
         "enabled": False,
         "disabled": False,
@@ -205,6 +211,7 @@ def test_dec_private_mode_descriptions_consistency():
         "failed": True
     }),
     (DecModeResponse.NOT_QUERIED, {
+        "recognized": False,
         "supported": False,
         "enabled": False,
         "disabled": False,
@@ -217,6 +224,7 @@ def test_dec_mode_response_predicates(value, expected):
     """Test predicates for all possible response values (-2 through 4)."""
     response = DecModeResponse(_DPM.DECTCEM, value)
 
+    assert response.recognized is expected["recognized"]
     assert response.supported is expected["supported"]
     assert response.enabled is expected["enabled"]
     assert response.disabled is expected["disabled"]
@@ -271,7 +279,7 @@ def test_dec_mode_response_to_dict():
     (DecModeResponse.NOT_RECOGNIZED, False, False, False),
     (DecModeResponse.RESET, True, False, True),
     (DecModeResponse.PERMANENTLY_SET, True, True, False),
-    (DecModeResponse.PERMANENTLY_RESET, True, False, False),
+    (DecModeResponse.PERMANENTLY_RESET, False, False, False),
     (DecModeResponse.NO_RESPONSE, False, False, False),
 ])
 def test_dec_mode_response_to_dict_values(

--- a/tests/test_length_sequence.py
+++ b/tests/test_length_sequence.py
@@ -483,6 +483,97 @@ def test_hyperlink_with_id():
     child()
 
 
+def test_set_window_title_nostyling():
+    """Test set_window_title returns empty when styling is disabled."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(force_styling=None)
+        result = term.set_window_title('hello')
+        assert result == ''
+
+    child()
+
+
+def test_set_window_title_default():
+    """Test set_window_title returns OSC 0 sequence."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(force_styling=True)
+        result = term.set_window_title('My Title')
+        assert result == '\x1b]0;My Title\x07'
+
+    child()
+
+
+@pytest.mark.parametrize("mode,expected_prefix", [
+    (0, '\x1b]0;'),
+    (1, '\x1b]1;'),
+    (2, '\x1b]2;'),
+])
+def test_set_window_title_modes(mode, expected_prefix):
+    """Test set_window_title OSC mode parameter."""
+    @as_subprocess
+    def child(mode=mode, expected_prefix=expected_prefix):
+        term = TestTerminal(force_styling=True)
+        result = term.set_window_title('test', mode=mode)
+        assert result == f'{expected_prefix}test\x07'
+
+    child()
+
+
+def test_set_window_title_sanitizes():
+    """Test set_window_title strips ESC and BEL from title text."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(force_styling=True)
+        result = term.set_window_title('bad\x1b[31mtitle\x07end')
+        assert result == '\x1b]0;bad[31mtitleend\x07'
+
+    child()
+
+
+def test_set_window_title_invalid_mode():
+    """Test set_window_title rejects invalid mode values."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(force_styling=True)
+        try:
+            term.set_window_title('test', mode=3)
+            assert False
+        except AssertionError:
+            pass
+
+    child()
+
+
+def test_window_title_context_manager():
+    """Test title context manager writes push/pop sequences."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(force_styling=True, stream=StringIO())
+        with term.window_title('My App'):
+            pass
+        output = term.stream.getvalue()
+        assert '\x1b[22;0t' in output
+        assert '\x1b]0;My App\x07' in output
+        assert '\x1b[23;0t' in output
+
+    child()
+
+
+def test_window_title_context_manager_nostyling():
+    """Test title context manager is a no-op without styling."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(force_styling=None, stream=StringIO())
+        with term.window_title('My App'):
+            pass
+        output = term.stream.getvalue()
+        assert output == ''
+
+    child()
+
+
 def test_sequence_is_movement_false(all_terms):
     """Test parser about sequences that do not move the cursor."""
     @as_subprocess

--- a/tests/test_line_editor.py
+++ b/tests/test_line_editor.py
@@ -13,7 +13,7 @@ from blessed.line_editor import (DisplayState,
                                  _apply_hscroll)
 
 
-class MockTerminal:  # pylint: disable=too-few-public-methods
+class MockTerminal:
     """Minimal terminal stub for render method tests."""
 
     normal = "<NORMAL>"

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -815,7 +815,7 @@ def test_supports_index(all_terms):
         from blessed.terminal import Terminal
         from blessed.sequences import Sequence
 
-        class Indexable:  # pylint: disable=too-few-public-methods
+        class Indexable:
             """Custom class implementing __index__()"""
 
             def __index__(self):

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -6,7 +6,7 @@ import io
 import pytest
 
 # local
-from blessed import DecrqssSettings
+from blessed._capabilities import Decrqss
 from blessed._capabilities import TermcapResponse, ITerm2Capabilities
 from .conftest import IS_WINDOWS
 from .accessories import TestTerminal, as_subprocess, pty_test
@@ -480,27 +480,27 @@ class TestGetDecrqss:
         def child():
             term = TestTerminal(stream=io.StringIO(), force_styling=True,
                                 is_a_tty=False)
-            assert DecrqssSettings.SGR == 'm'
+            assert Decrqss.SGR == 'm'
             assert term.get_decrqss() is None
         child()
 
 
-class TestDecrqssSettings:
-    """DecrqssSettings constant values."""
+class TestDecrqss:
+    """Decrqss constant values."""
 
     def test_common_settings(self):
         """Common setting identifiers match VT510 spec."""
-        assert DecrqssSettings.SGR == 'm'
-        assert DecrqssSettings.DECSCUSR == ' q'
-        assert DecrqssSettings.DECSTBM == 'r'
-        assert DecrqssSettings.DECSLRM == 's'
-        assert DecrqssSettings.DECSCL == '"p'
-        assert DecrqssSettings.DECSCA == '"q'
-        assert DecrqssSettings.DECSCPP == '$|'
-        assert DecrqssSettings.DECSLPP == 't'
-        assert DecrqssSettings.DECSNLS == '*|'
-        assert DecrqssSettings.DECSASD == '$}'
-        assert DecrqssSettings.DECSSDT == '$~'
+        assert Decrqss.SGR == 'm'
+        assert Decrqss.DECSCUSR == ' q'
+        assert Decrqss.DECSTBM == 'r'
+        assert Decrqss.DECSLRM == 's'
+        assert Decrqss.DECSCL == '"p'
+        assert Decrqss.DECSCA == '"q'
+        assert Decrqss.DECSCPP == '$|'
+        assert Decrqss.DECSLPP == 't'
+        assert Decrqss.DECSNLS == '*|'
+        assert Decrqss.DECSASD == '$}'
+        assert Decrqss.DECSSDT == '$~'
 
 
 pytestmark_pty = pytest.mark.skipif(
@@ -906,7 +906,7 @@ def test_get_decrqss_sgr():
         resp = '\x1bP1$r0m\x1b\\'
         cpr = '\x1b[10;20R'
         term.ungetch(resp + cpr)
-        result = term.get_decrqss(DecrqssSettings.SGR, timeout=1)
+        result = term.get_decrqss(Decrqss.SGR, timeout=1)
         assert result == '0'
         return b'OK'
 
@@ -922,7 +922,7 @@ def test_get_decrqss_sgr_with_attrs():
         resp = '\x1bP1$r1;4;38;5;12m\x1b\\'
         cpr = '\x1b[10;20R'
         term.ungetch(resp + cpr)
-        result = term.get_decrqss(DecrqssSettings.SGR, timeout=1)
+        result = term.get_decrqss(Decrqss.SGR, timeout=1)
         assert result == '1;4;38;5;12'
         return b'OK'
 
@@ -938,7 +938,7 @@ def test_get_decrqss_cursor_style():
         resp = '\x1bP1$r2 q\x1b\\'
         cpr = '\x1b[10;20R'
         term.ungetch(resp + cpr)
-        result = term.get_decrqss(DecrqssSettings.DECSCUSR, timeout=1)
+        result = term.get_decrqss(Decrqss.DECSCUSR, timeout=1)
         assert result == '2'
         return b'OK'
 
@@ -954,7 +954,7 @@ def test_get_decrqss_scroll_region():
         resp = '\x1bP1$r1;24r\x1b\\'
         cpr = '\x1b[10;20R'
         term.ungetch(resp + cpr)
-        result = term.get_decrqss(DecrqssSettings.DECSTBM, timeout=1)
+        result = term.get_decrqss(Decrqss.DECSTBM, timeout=1)
         assert result == '1;24'
         return b'OK'
 
@@ -969,7 +969,7 @@ def test_get_decrqss_unsupported():
     def child(term):
         cpr = '\x1b[10;20R'
         term.ungetch(cpr)
-        result = term.get_decrqss(DecrqssSettings.SGR, timeout=1)
+        result = term.get_decrqss(Decrqss.SGR, timeout=1)
         assert result is None
         return b'OK'
 
@@ -985,7 +985,7 @@ def test_get_decrqss_invalid():
         resp = '\x1bP0$r\x1b\\'
         cpr = '\x1b[10;20R'
         term.ungetch(resp + cpr)
-        result = term.get_decrqss(DecrqssSettings.SGR, timeout=1)
+        result = term.get_decrqss(Decrqss.SGR, timeout=1)
         assert result is None
         return b'OK'
 

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -547,28 +547,58 @@ def test_get_xtgettcap_batch_empty_flushinp():
 
 
 @pytestmark_pty
-def test_does_osc52_clipboard_supported():
-    """OSC 52 clipboard detected when terminal responds."""
+def test_does_osc52_clipboard_via_da1():
+    """OSC 52 detected via DA1 extension 52."""
     def child(term):
-        osc52_resp = '\x1b]52;c;SGVsbG8=\x07'
+        # DA1 with extension 52 (OSC 52 support)
+        da1_resp = '\x1b[?64;1;4;52c'
         cpr = '\x1b[10;20R'
-        term.ungetch(osc52_resp + cpr)
+        term.ungetch(da1_resp + cpr)
         result = term.does_osc52_clipboard(timeout=1)
         assert result is True
         assert term._osc52_clipboard_supported is True
         return b'OK'
 
     output = pty_test(child, parent_func=None,
-                      test_name='test_does_osc52_clipboard_supported')
+                      test_name='test_does_osc52_clipboard_via_da1')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_does_osc52_clipboard_via_xtgettcap():
+    """OSC 52 detected via XTGETTCAP Ms capability."""
+    def child(term):
+        hex_tn = TermcapResponse.hex_encode('TN')
+        hex_ms = TermcapResponse.hex_encode('Ms')
+        ms_val = TermcapResponse.hex_encode(r'\e]52;%p1%s;%p2%s\007')
+        # DA1 without extension 52, so DA1 path returns False
+        da1_resp = '\x1b[?64;1;4c'
+        da1_cpr = '\x1b[10;20R'
+        # XTGETTCAP probe + batch with Ms
+        probe_resp = f'\x1bP1+r{hex_tn}=787465726d\x1b\\'
+        tcap_cpr = '\x1b[11;21R'
+        batch_resp = f'\x1bP1+r{hex_ms}={ms_val}\x1b\\'
+        term.ungetch(da1_resp + da1_cpr + probe_resp + tcap_cpr + batch_resp)
+        result = term.does_osc52_clipboard(timeout=1)
+        assert result is True
+        assert term._osc52_clipboard_supported is True
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_does_osc52_clipboard_via_xtgettcap')
     assert 'OK' in output
 
 
 @pytestmark_pty
 def test_does_osc52_clipboard_unsupported():
-    """OSC 52 clipboard not detected when only CPR arrives."""
+    """OSC 52 not detected when neither DA1 nor XTGETTCAP report it."""
     def child(term):
-        cpr = '\x1b[10;20R'
-        term.ungetch(cpr)
+        # DA1 without extension 52
+        da1_resp = '\x1b[?64;1;4c'
+        da1_cpr = '\x1b[10;20R'
+        # XTGETTCAP probe fails (no DCS response)
+        tcap_cpr = '\x1b[11;21R'
+        term.ungetch(da1_resp + da1_cpr + tcap_cpr)
         result = term.does_osc52_clipboard(timeout=1)
         assert result is False
         assert term._osc52_clipboard_supported is False
@@ -580,18 +610,86 @@ def test_does_osc52_clipboard_unsupported():
 
 
 @pytestmark_pty
-def test_does_osc52_clipboard_empty_response():
-    """OSC 52 with empty data still indicates support."""
+def test_clipboard_copy():
+    """clipboard_copy writes base64-encoded OSC 52 set sequence."""
+    def child(term):
+        term.clipboard_copy('Hello')
+        return b''
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_clipboard_copy')
+    assert '\x1b]52;c;SGVsbG8=\x07' in output
+
+
+@pytestmark_pty
+def test_clipboard_copy_primary_selection():
+    """clipboard_copy with selection='p' uses primary selection."""
+    def child(term):
+        term.clipboard_copy('test', selection='p')
+        return b''
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_clipboard_copy_primary_selection')
+    assert '\x1b]52;p;dGVzdA==\x07' in output
+
+
+@pytestmark_pty
+def test_clipboard_copy_nostyling():
+    """clipboard_copy is a no-op without styling."""
+    def child(term):
+        term._does_styling = False
+        term.clipboard_copy('Hello')
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_clipboard_copy_nostyling')
+    assert '\x1b]52' not in output
+
+
+@pytestmark_pty
+def test_clipboard_paste_success():
+    """clipboard_paste decodes base64 clipboard response."""
+    def child(term):
+        osc52_resp = '\x1b]52;c;SGVsbG8=\x07'
+        cpr = '\x1b[10;20R'
+        term.ungetch(osc52_resp + cpr)
+        result = term.clipboard_paste(timeout=1)
+        assert result == 'Hello'
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_clipboard_paste_success')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_clipboard_paste_empty():
+    """clipboard_paste returns empty string for empty clipboard."""
     def child(term):
         osc52_resp = '\x1b]52;c;\x07'
         cpr = '\x1b[10;20R'
         term.ungetch(osc52_resp + cpr)
-        result = term.does_osc52_clipboard(timeout=1)
-        assert result is True
+        result = term.clipboard_paste(timeout=1)
+        assert result == ''
         return b'OK'
 
     output = pty_test(child, parent_func=None,
-                      test_name='test_does_osc52_clipboard_empty_response')
+                      test_name='test_clipboard_paste_empty')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_clipboard_paste_no_response():
+    """clipboard_paste returns None when terminal does not respond."""
+    def child(term):
+        cpr = '\x1b[10;20R'
+        term.ungetch(cpr)
+        result = term.clipboard_paste(timeout=0.1)
+        assert result is None
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_clipboard_paste_no_response')
     assert 'OK' in output
 
 

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -694,6 +694,22 @@ def test_clipboard_paste_no_response():
 
 
 @pytestmark_pty
+def test_clipboard_paste_invalid_base64():
+    """clipboard_paste returns None for invalid base64 data."""
+    def child(term):
+        osc52_resp = '\x1b]52;c;!!!not-base64!!!\x07'
+        cpr = '\x1b[10;20R'
+        term.ungetch(osc52_resp + cpr)
+        result = term.clipboard_paste(timeout=1)
+        assert result is None
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_clipboard_paste_invalid_base64')
+    assert 'OK' in output
+
+
+@pytestmark_pty
 def test_get_color_scheme_dark():
     """Dark mode detected from CSI ? 997 ; 1 n response."""
     def child(term):

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -485,24 +485,6 @@ class TestGetDecrqss:
         child()
 
 
-class TestDecrqss:
-    """Decrqss constant values."""
-
-    def test_common_settings(self):
-        """Common setting identifiers match VT510 spec."""
-        assert Decrqss.SGR == 'm'
-        assert Decrqss.DECSCUSR == ' q'
-        assert Decrqss.DECSTBM == 'r'
-        assert Decrqss.DECSLRM == 's'
-        assert Decrqss.DECSCL == '"p'
-        assert Decrqss.DECSCA == '"q'
-        assert Decrqss.DECSCPP == '$|'
-        assert Decrqss.DECSLPP == 't'
-        assert Decrqss.DECSNLS == '*|'
-        assert Decrqss.DECSASD == '$}'
-        assert Decrqss.DECSSDT == '$~'
-
-
 pytestmark_pty = pytest.mark.skipif(
     IS_WINDOWS, reason="ungetch and PTY testing not supported on Windows")
 

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -252,6 +252,107 @@ class TestGetXtgettcap:
         child()
 
 
+class TestStyledUnderlines:
+    """Terminal.does_styled_underlines() and does_colored_underlines()."""
+
+    def test_styled_underlines_supported(self):
+        """Returns True when Smulx is in XTGETTCAP capabilities."""
+        @as_subprocess
+        def child():
+            stream = io.StringIO()
+            term = TestTerminal(stream=stream, force_styling=True)
+            term._is_a_tty = True
+            term._xtgettcap_cache = TermcapResponse(
+                supported=True,
+                capabilities={'TN': 'xterm', 'Smulx': '\x1b[4:%p1%dm'})
+            assert term.does_styled_underlines() is True
+        child()
+
+    def test_styled_underlines_unsupported(self):
+        """Returns False when Smulx is not in capabilities."""
+        @as_subprocess
+        def child():
+            stream = io.StringIO()
+            term = TestTerminal(stream=stream, force_styling=True)
+            term._is_a_tty = True
+            term._xtgettcap_cache = TermcapResponse(
+                supported=True, capabilities={'TN': 'xterm'})
+            assert term.does_styled_underlines() is False
+        child()
+
+    def test_styled_underlines_no_xtgettcap(self):
+        """Returns False when XTGETTCAP is not supported."""
+        @as_subprocess
+        def child():
+            stream = io.StringIO()
+            term = TestTerminal(stream=stream, force_styling=True)
+            term._is_a_tty = True
+            term._xtgettcap_first_query_failed = True
+            assert term.does_styled_underlines() is False
+        child()
+
+    def test_colored_underlines_supported(self):
+        """Returns True when Setulc is in XTGETTCAP capabilities."""
+        @as_subprocess
+        def child():
+            stream = io.StringIO()
+            term = TestTerminal(stream=stream, force_styling=True)
+            term._is_a_tty = True
+            term._xtgettcap_cache = TermcapResponse(
+                supported=True,
+                capabilities={'Setulc': '\x1b[58;2;%p1%d;%p2%d;%p3%dm'})
+            assert term.does_colored_underlines() is True
+        child()
+
+    def test_colored_underlines_unsupported(self):
+        """Returns False when Setulc is not in capabilities."""
+        @as_subprocess
+        def child():
+            stream = io.StringIO()
+            term = TestTerminal(stream=stream, force_styling=True)
+            term._is_a_tty = True
+            term._xtgettcap_cache = TermcapResponse(
+                supported=True, capabilities={'TN': 'xterm'})
+            assert term.does_colored_underlines() is False
+        child()
+
+
+class TestOsc52Clipboard:
+    """Terminal.does_osc52_clipboard() detection."""
+
+    def test_not_a_tty(self):
+        """Returns False when not a TTY."""
+        @as_subprocess
+        def child():
+            term = TestTerminal(stream=io.StringIO(), force_styling=True,
+                                is_a_tty=False)
+            assert term.does_osc52_clipboard(timeout=0.01) is False
+        child()
+
+    def test_cached_result(self):
+        """Returns cached result without re-querying."""
+        @as_subprocess
+        def child():
+            stream = io.StringIO()
+            term = TestTerminal(stream=stream, force_styling=True)
+            term._is_a_tty = True
+            term._osc52_clipboard_supported = True
+            assert term.does_osc52_clipboard() is True
+        child()
+
+    def test_force_bypasses_cache(self):
+        """force=True bypasses cached result."""
+        @as_subprocess
+        def child():
+            stream = io.StringIO()
+            term = TestTerminal(stream=stream, force_styling=True)
+            term._is_a_tty = True
+            term._osc52_clipboard_supported = True
+            result = term.does_osc52_clipboard(timeout=0.01, force=True)
+            assert result is False
+        child()
+
+
 pytestmark_pty = pytest.mark.skipif(
     IS_WINDOWS, reason="ungetch and PTY testing not supported on Windows")
 
@@ -334,4 +435,53 @@ def test_get_xtgettcap_batch_empty_flushinp():
 
     output = pty_test(child, parent_func=None,
                       test_name='test_get_xtgettcap_batch_empty_flushinp')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_does_osc52_clipboard_supported():
+    """OSC 52 clipboard detected when terminal responds."""
+    def child(term):
+        osc52_resp = '\x1b]52;c;SGVsbG8=\x07'
+        cpr = '\x1b[10;20R'
+        term.ungetch(osc52_resp + cpr)
+        result = term.does_osc52_clipboard(timeout=1)
+        assert result is True
+        assert term._osc52_clipboard_supported is True
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_does_osc52_clipboard_supported')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_does_osc52_clipboard_unsupported():
+    """OSC 52 clipboard not detected when only CPR arrives."""
+    def child(term):
+        cpr = '\x1b[10;20R'
+        term.ungetch(cpr)
+        result = term.does_osc52_clipboard(timeout=1)
+        assert result is False
+        assert term._osc52_clipboard_supported is False
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_does_osc52_clipboard_unsupported')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_does_osc52_clipboard_empty_response():
+    """OSC 52 with empty data still indicates support."""
+    def child(term):
+        osc52_resp = '\x1b]52;c;\x07'
+        cpr = '\x1b[10;20R'
+        term.ungetch(osc52_resp + cpr)
+        result = term.does_osc52_clipboard(timeout=1)
+        assert result is True
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_does_osc52_clipboard_empty_response')
     assert 'OK' in output

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -6,6 +6,7 @@ import io
 import pytest
 
 # local
+from blessed import DecrqssSettings
 from blessed._capabilities import TermcapResponse, ITerm2Capabilities
 from .conftest import IS_WINDOWS
 from .accessories import TestTerminal, as_subprocess, pty_test
@@ -461,6 +462,47 @@ class TestDecrqss:
         child()
 
 
+class TestGetDecrqss:
+    """Terminal.get_decrqss() state queries."""
+
+    def test_not_a_tty(self):
+        """Returns None when not a TTY."""
+        @as_subprocess
+        def child():
+            term = TestTerminal(stream=io.StringIO(), force_styling=True,
+                                is_a_tty=False)
+            assert term.get_decrqss(timeout=0.01) is None
+        child()
+
+    def test_default_setting_is_sgr(self):
+        """Default setting_id is SGR ('m')."""
+        @as_subprocess
+        def child():
+            term = TestTerminal(stream=io.StringIO(), force_styling=True,
+                                is_a_tty=False)
+            assert DecrqssSettings.SGR == 'm'
+            assert term.get_decrqss() is None
+        child()
+
+
+class TestDecrqssSettings:
+    """DecrqssSettings constant values."""
+
+    def test_common_settings(self):
+        """Common setting identifiers match VT510 spec."""
+        assert DecrqssSettings.SGR == 'm'
+        assert DecrqssSettings.DECSCUSR == ' q'
+        assert DecrqssSettings.DECSTBM == 'r'
+        assert DecrqssSettings.DECSLRM == 's'
+        assert DecrqssSettings.DECSCL == '"p'
+        assert DecrqssSettings.DECSCA == '"q'
+        assert DecrqssSettings.DECSCPP == '$|'
+        assert DecrqssSettings.DECSLPP == 't'
+        assert DecrqssSettings.DECSNLS == '*|'
+        assert DecrqssSettings.DECSASD == '$}'
+        assert DecrqssSettings.DECSSDT == '$~'
+
+
 pytestmark_pty = pytest.mark.skipif(
     IS_WINDOWS, reason="ungetch and PTY testing not supported on Windows")
 
@@ -856,4 +898,99 @@ def test_does_decrqss_invalid():
 
     output = pty_test(child, parent_func=None,
                       test_name='test_does_decrqss_invalid')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_get_decrqss_sgr():
+    """get_decrqss returns SGR parameter value with setting_id stripped."""
+    def child(term):
+        resp = '\x1bP1$r0m\x1b\\'
+        cpr = '\x1b[10;20R'
+        term.ungetch(resp + cpr)
+        result = term.get_decrqss(DecrqssSettings.SGR, timeout=1)
+        assert result == '0'
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_get_decrqss_sgr')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_get_decrqss_sgr_with_attrs():
+    """get_decrqss returns compound SGR values."""
+    def child(term):
+        resp = '\x1bP1$r1;4;38;5;12m\x1b\\'
+        cpr = '\x1b[10;20R'
+        term.ungetch(resp + cpr)
+        result = term.get_decrqss(DecrqssSettings.SGR, timeout=1)
+        assert result == '1;4;38;5;12'
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_get_decrqss_sgr_with_attrs')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_get_decrqss_cursor_style():
+    """get_decrqss returns cursor style value for DECSCUSR."""
+    def child(term):
+        resp = '\x1bP1$r2 q\x1b\\'
+        cpr = '\x1b[10;20R'
+        term.ungetch(resp + cpr)
+        result = term.get_decrqss(DecrqssSettings.DECSCUSR, timeout=1)
+        assert result == '2'
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_get_decrqss_cursor_style')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_get_decrqss_scroll_region():
+    """get_decrqss returns top/bottom margins for DECSTBM."""
+    def child(term):
+        resp = '\x1bP1$r1;24r\x1b\\'
+        cpr = '\x1b[10;20R'
+        term.ungetch(resp + cpr)
+        result = term.get_decrqss(DecrqssSettings.DECSTBM, timeout=1)
+        assert result == '1;24'
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_get_decrqss_scroll_region')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_get_decrqss_unsupported():
+    """get_decrqss returns None when terminal does not respond."""
+    def child(term):
+        cpr = '\x1b[10;20R'
+        term.ungetch(cpr)
+        result = term.get_decrqss(DecrqssSettings.SGR, timeout=1)
+        assert result is None
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_get_decrqss_unsupported')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_get_decrqss_invalid():
+    """get_decrqss returns None on DCS 0 $ r (invalid request)."""
+    def child(term):
+        resp = '\x1bP0$r\x1b\\'
+        cpr = '\x1b[10;20R'
+        term.ungetch(resp + cpr)
+        result = term.get_decrqss(DecrqssSettings.SGR, timeout=1)
+        assert result is None
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_get_decrqss_invalid')
     assert 'OK' in output

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -365,25 +365,25 @@ class TestColorScheme:
             assert term.get_color_scheme(timeout=0.01) is None
         child()
 
-    def test_cached_result(self):
-        """Returns cached result without re-querying."""
+    def test_negative_cache(self):
+        """Returns None immediately when previously unsupported."""
         @as_subprocess
         def child():
             stream = io.StringIO()
             term = TestTerminal(stream=stream, force_styling=True)
             term._is_a_tty = True
-            term._color_scheme_cache = 'dark'
-            assert term.get_color_scheme() == 'dark'
+            term._color_scheme_supported = False
+            assert term.get_color_scheme() is None
         child()
 
-    def test_force_bypasses_cache(self):
-        """force=True bypasses cached result."""
+    def test_force_bypasses_negative_cache(self):
+        """force=True bypasses negative cache."""
         @as_subprocess
         def child():
             stream = io.StringIO()
             term = TestTerminal(stream=stream, force_styling=True)
             term._is_a_tty = True
-            term._color_scheme_cache = 'dark'
+            term._color_scheme_supported = False
             result = term.get_color_scheme(timeout=0.01, force=True)
             assert result is None
         child()
@@ -604,7 +604,7 @@ def test_get_color_scheme_dark():
         term.ungetch(resp + cpr)
         result = term.get_color_scheme(timeout=1)
         assert result == 'dark'
-        assert term._color_scheme_cache == 'dark'
+        assert term._color_scheme_supported is True
         return b'OK'
 
     output = pty_test(child, parent_func=None,
@@ -621,7 +621,7 @@ def test_get_color_scheme_light():
         term.ungetch(resp + cpr)
         result = term.get_color_scheme(timeout=1)
         assert result == 'light'
-        assert term._color_scheme_cache == 'light'
+        assert term._color_scheme_supported is True
         return b'OK'
 
     output = pty_test(child, parent_func=None,

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -689,12 +689,12 @@ def test_clipboard_copy_nostyling():
 
 
 @pytestmark_pty
-def test_clipboard_paste_success():
+@pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
+def test_clipboard_paste_success(terminator):
     """clipboard_paste decodes base64 clipboard response."""
     def child(term):
-        osc52_resp = '\x1b]52;c;SGVsbG8=\x07'
-        cpr = '\x1b[10;20R'
-        term.ungetch(osc52_resp + cpr)
+        osc52_resp = '\x1b]52;c;SGVsbG8=' + terminator
+        term.ungetch(osc52_resp)
         result = term.clipboard_paste(timeout=1)
         assert result == 'Hello'
         return b'OK'
@@ -705,12 +705,12 @@ def test_clipboard_paste_success():
 
 
 @pytestmark_pty
-def test_clipboard_paste_empty():
+@pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
+def test_clipboard_paste_empty(terminator):
     """clipboard_paste returns empty string for empty clipboard."""
     def child(term):
-        osc52_resp = '\x1b]52;c;\x07'
-        cpr = '\x1b[10;20R'
-        term.ungetch(osc52_resp + cpr)
+        osc52_resp = '\x1b]52;c;' + terminator
+        term.ungetch(osc52_resp)
         result = term.clipboard_paste(timeout=1)
         assert result == ''
         return b'OK'
@@ -724,8 +724,6 @@ def test_clipboard_paste_empty():
 def test_clipboard_paste_no_response():
     """clipboard_paste returns None when terminal does not respond."""
     def child(term):
-        cpr = '\x1b[10;20R'
-        term.ungetch(cpr)
         result = term.clipboard_paste(timeout=0.1)
         assert result is None
         return b'OK'
@@ -736,12 +734,12 @@ def test_clipboard_paste_no_response():
 
 
 @pytestmark_pty
-def test_clipboard_paste_invalid_base64():
+@pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
+def test_clipboard_paste_invalid_base64(terminator):
     """clipboard_paste returns None for invalid base64 data."""
     def child(term):
-        osc52_resp = '\x1b]52;c;!!!not-base64!!!\x07'
-        cpr = '\x1b[10;20R'
-        term.ungetch(osc52_resp + cpr)
+        osc52_resp = '\x1b]52;c;!!!not-base64!!!' + terminator
+        term.ungetch(osc52_resp)
         result = term.clipboard_paste(timeout=1)
         assert result is None
         return b'OK'

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -353,6 +353,114 @@ class TestOsc52Clipboard:
         child()
 
 
+class TestColorScheme:
+    """Terminal.get_color_scheme() detection."""
+
+    def test_not_a_tty(self):
+        """Returns None when not a TTY."""
+        @as_subprocess
+        def child():
+            term = TestTerminal(stream=io.StringIO(), force_styling=True,
+                                is_a_tty=False)
+            assert term.get_color_scheme(timeout=0.01) is None
+        child()
+
+    def test_cached_result(self):
+        """Returns cached result without re-querying."""
+        @as_subprocess
+        def child():
+            stream = io.StringIO()
+            term = TestTerminal(stream=stream, force_styling=True)
+            term._is_a_tty = True
+            term._color_scheme_cache = 'dark'
+            assert term.get_color_scheme() == 'dark'
+        child()
+
+    def test_force_bypasses_cache(self):
+        """force=True bypasses cached result."""
+        @as_subprocess
+        def child():
+            stream = io.StringIO()
+            term = TestTerminal(stream=stream, force_styling=True)
+            term._is_a_tty = True
+            term._color_scheme_cache = 'dark'
+            result = term.get_color_scheme(timeout=0.01, force=True)
+            assert result is None
+        child()
+
+
+class TestKittyQuery:
+    """Terminal.does_kitty_query() detection."""
+
+    def test_not_a_tty(self):
+        """Returns False when not a TTY."""
+        @as_subprocess
+        def child():
+            term = TestTerminal(stream=io.StringIO(), force_styling=True,
+                                is_a_tty=False)
+            assert term.does_kitty_query(timeout=0.01) is False
+        child()
+
+    def test_cached_result(self):
+        """Returns cached result without re-querying."""
+        @as_subprocess
+        def child():
+            stream = io.StringIO()
+            term = TestTerminal(stream=stream, force_styling=True)
+            term._is_a_tty = True
+            term._kitty_query_supported = True
+            assert term.does_kitty_query() is True
+        child()
+
+    def test_force_bypasses_cache(self):
+        """force=True bypasses cached result."""
+        @as_subprocess
+        def child():
+            stream = io.StringIO()
+            term = TestTerminal(stream=stream, force_styling=True)
+            term._is_a_tty = True
+            term._kitty_query_supported = True
+            result = term.does_kitty_query(timeout=0.01, force=True)
+            assert result is False
+        child()
+
+
+class TestDecrqss:
+    """Terminal.does_decrqss() detection."""
+
+    def test_not_a_tty(self):
+        """Returns False when not a TTY."""
+        @as_subprocess
+        def child():
+            term = TestTerminal(stream=io.StringIO(), force_styling=True,
+                                is_a_tty=False)
+            assert term.does_decrqss(timeout=0.01) is False
+        child()
+
+    def test_cached_result(self):
+        """Returns cached result without re-querying."""
+        @as_subprocess
+        def child():
+            stream = io.StringIO()
+            term = TestTerminal(stream=stream, force_styling=True)
+            term._is_a_tty = True
+            term._decrqss_supported = True
+            assert term.does_decrqss() is True
+        child()
+
+    def test_force_bypasses_cache(self):
+        """force=True bypasses cached result."""
+        @as_subprocess
+        def child():
+            stream = io.StringIO()
+            term = TestTerminal(stream=stream, force_styling=True)
+            term._is_a_tty = True
+            term._decrqss_supported = True
+            result = term.does_decrqss(timeout=0.01, force=True)
+            assert result is False
+        child()
+
+
 pytestmark_pty = pytest.mark.skipif(
     IS_WINDOWS, reason="ungetch and PTY testing not supported on Windows")
 
@@ -484,4 +592,156 @@ def test_does_osc52_clipboard_empty_response():
 
     output = pty_test(child, parent_func=None,
                       test_name='test_does_osc52_clipboard_empty_response')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_get_color_scheme_dark():
+    """Dark mode detected from CSI ? 997 ; 1 n response."""
+    def child(term):
+        resp = '\x1b[?997;1n'
+        cpr = '\x1b[10;20R'
+        term.ungetch(resp + cpr)
+        result = term.get_color_scheme(timeout=1)
+        assert result == 'dark'
+        assert term._color_scheme_cache == 'dark'
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_get_color_scheme_dark')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_get_color_scheme_light():
+    """Light mode detected from CSI ? 997 ; 2 n response."""
+    def child(term):
+        resp = '\x1b[?997;2n'
+        cpr = '\x1b[10;20R'
+        term.ungetch(resp + cpr)
+        result = term.get_color_scheme(timeout=1)
+        assert result == 'light'
+        assert term._color_scheme_cache == 'light'
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_get_color_scheme_light')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_get_color_scheme_unsupported():
+    """Returns None when terminal does not respond to CSI ? 996 n."""
+    def child(term):
+        cpr = '\x1b[10;20R'
+        term.ungetch(cpr)
+        result = term.get_color_scheme(timeout=1)
+        assert result is None
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_get_color_scheme_unsupported')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_does_kitty_query_supported():
+    """Kitty query extensions detected from DCS 1+r response."""
+    def child(term):
+        from blessed._capabilities import TermcapResponse
+        capname = 'kitty-query-name'
+        hex_cap = TermcapResponse.hex_encode(capname)
+        hex_val = TermcapResponse.hex_encode('kitty')
+        resp = f'\x1bP1+r{hex_cap}={hex_val}\x1b\\'
+        cpr = '\x1b[10;20R'
+        term.ungetch(resp + cpr)
+        result = term.does_kitty_query(timeout=1)
+        assert result is True
+        assert term._kitty_query_supported is True
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_does_kitty_query_supported')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_does_kitty_query_unsupported():
+    """Kitty query not detected when only CPR arrives."""
+    def child(term):
+        cpr = '\x1b[10;20R'
+        term.ungetch(cpr)
+        result = term.does_kitty_query(timeout=1)
+        assert result is False
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_does_kitty_query_unsupported')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_does_kitty_query_rejected():
+    """Kitty query returns False on DCS 0+r (not recognized)."""
+    def child(term):
+        from blessed._capabilities import TermcapResponse
+        capname = 'kitty-query-name'
+        hex_cap = TermcapResponse.hex_encode(capname)
+        resp = f'\x1bP0+r{hex_cap}\x1b\\'
+        cpr = '\x1b[10;20R'
+        term.ungetch(resp + cpr)
+        result = term.does_kitty_query(timeout=1)
+        assert result is False
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_does_kitty_query_rejected')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_does_decrqss_supported():
+    """DECRQSS detected from DCS 1 $ r response."""
+    def child(term):
+        resp = '\x1bP1$r0m\x1b\\'
+        cpr = '\x1b[10;20R'
+        term.ungetch(resp + cpr)
+        result = term.does_decrqss(timeout=1)
+        assert result is True
+        assert term._decrqss_supported is True
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_does_decrqss_supported')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_does_decrqss_unsupported():
+    """DECRQSS not detected when only CPR arrives."""
+    def child(term):
+        cpr = '\x1b[10;20R'
+        term.ungetch(cpr)
+        result = term.does_decrqss(timeout=1)
+        assert result is False
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_does_decrqss_unsupported')
+    assert 'OK' in output
+
+
+@pytestmark_pty
+def test_does_decrqss_invalid():
+    """DECRQSS returns False on DCS 0 $ r (invalid request)."""
+    def child(term):
+        resp = '\x1bP0$r\x1b\\'
+        cpr = '\x1b[10;20R'
+        term.ungetch(resp + cpr)
+        result = term.does_decrqss(timeout=1)
+        assert result is False
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_does_decrqss_invalid')
     assert 'OK' in output

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -648,7 +648,6 @@ def test_get_color_scheme_unsupported():
 def test_does_kitty_query_supported():
     """Kitty query extensions detected from DCS 1+r response."""
     def child(term):
-        from blessed._capabilities import TermcapResponse
         capname = 'kitty-query-name'
         hex_cap = TermcapResponse.hex_encode(capname)
         hex_val = TermcapResponse.hex_encode('kitty')
@@ -684,7 +683,6 @@ def test_does_kitty_query_unsupported():
 def test_does_kitty_query_rejected():
     """Kitty query returns False on DCS 0+r (not recognized)."""
     def child(term):
-        from blessed._capabilities import TermcapResponse
         capname = 'kitty-query-name'
         hex_cap = TermcapResponse.hex_encode(capname)
         resp = f'\x1bP0+r{hex_cap}\x1b\\'


### PR DESCRIPTION
* introduced: `does_osc52_clipboard`, `clipboard_copy()`, and `clipboard_paste()` to detect, copy to, and read from the system clipboard (OSC 52).
* introduced: `Terminal.get_color_scheme` 
* introduced: `Terminal.does_kitty_query` to detect Kitty XTGETTCAP query extensions
* introduced: `Terminal.does_styled_underlines` and `does_colored_underlines` using extended underline styles (``Smulx``) and colored underlines (``Setulc``) via XTGETTCAP.
* introduced: `Terminal.set_window_title` and `window_title()` context manager to set (and reset) the terminal window and/or icon title (XTWINOPS).
* introduced: `DecModeResponse.recognized` to distinguish modes the terminal acknowledges but can't actually use.
* introduced: `Terminal.does_decrqss` to detect DECRQSS (Request Status String) support

Example output from xterm which responds to nearly all common ones,
```
DECRQSS State Queries (DCS $ q):
----------------------------------------
  SGR        '0'      Select Graphic Rendition
  DECSCUSR   '2'      Cursor Style
  DECSTBM    '1;24'   Top/Bottom Margins
  DECSLRM    '1;80'   Left/Right Margins
  DECSCL     '64;1'   Conformance Level
  DECSCA     '0'      Character Protection
  DECSCPP    '80'     Columns Per Page
  DECSLPP    '24'     Lines Per Page
  DECSNLS    '24'     Lines Per Screen
  DECSASD    --        Active Status Display
  DECSSDT    --        Status Line Type
  DECSACE    '0'      Attribute Change Extent
```

This might be pretty useful, we can build a get_sgr(), get_cursor_style() or some such like get_bgcolor() or get_location().

- Also included is a new example program, bin/screen-scrape.py which shows a vulnerability found only in mlterm and wezterm
- also updated line_editor_form.py for slightly better styling and clipboard ^C and ^V demo / support