### PR TITLE
Handle EOF when stdin is a pipe

### DIFF
--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -15,4 +15,4 @@ else:
 from blessed.line_editor import LineEditor, LineHistory
 
 __all__ = ('Terminal', 'LineEditor', 'LineHistory')
-__version__ = "1.37.0"
+__version__ = "1.38.0"

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -214,7 +214,7 @@ class Terminal():
             .. _CLICOLOR_FORCE: https://bixense.com/clicolors/
             .. _NO_COLOR: https://no-color.org/
         """
-        # pylint: disable=global-statement
+        # pylint: disable=global-statement,too-many-statements
         global _CUR_TERM
         self.errors = [
             f'parameters: kind={kind!r}, stream={stream!r}, force_styling={force_styling!r}',

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -226,6 +226,7 @@ class Terminal():
 
         self._stream = stream
         self._keyboard_fd = None
+        self._keyboard_eof = False
         self._init_descriptor = None
         self._is_a_tty = False
         self.__init__streams()
@@ -3099,6 +3100,7 @@ class Terminal():
         :rtype: unicode
         :returns: a single unicode character, or ``''`` if a multi-byte
             sequence has not yet been fully received.
+        :raises EOFError: When the keyboard stream has reached end-of-file.
 
         This method name and behavior mimics curses ``getch(void)``, and
         it supports :meth:`inkey`, reading only one byte from
@@ -3110,6 +3112,9 @@ class Terminal():
         """
         assert self._keyboard_fd is not None
         byte = os.read(self._keyboard_fd, 1)
+        if not byte:
+            self._keyboard_eof = True
+            raise EOFError
         if decode_latin1:
             # Latin-1 is a simple 1:1 byte-to-character mapping (0-255)
             # No incremental decoder needed
@@ -3143,6 +3148,9 @@ class Terminal():
             attached to this terminal.  When input is not a terminal, False is
             always returned.
         """
+        if self._keyboard_eof:
+            return False
+
         ready_r = [None, ]
         check_r = [self._keyboard_fd] if self._keyboard_fd is not None else []
 
@@ -3285,7 +3293,10 @@ class Terminal():
             # contain high bytes (≥0x80) for coordinates > 127. Only check for
             # '\x1b[M' when not already found (performance optimization).
             decode_latin1 = decode_latin1 or '\x1b[M' in ucs
-            ucs += self.getch(decode_latin1=decode_latin1)
+            try:
+                ucs += self.getch(decode_latin1=decode_latin1)
+            except EOFError:
+                break
         return ucs
 
     def _is_incomplete_keystroke(self, text: str) -> bool:

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,11 +3,15 @@
 Version History
 ===============
 
+1.38
+  * bugfix: ``EOF`` when stdin is connected to a Pipe (eg. pytest capture) caused infinite loop
+    :ghpull:`366`.
+
 1.37
 
   * bugfix: legacy CSI letter-form sequences with explicit modifiers and event type (e.g.,
     ``\x1b[1;1:1A`` for arrow key press) were not resolved to key names, this affected only some
-    terminals, such as Ghostty.
+    terminals, such as Ghostty. :ghpull:`363`.
 
 1.36
 

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -23,6 +23,100 @@ else:
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="no tty module")
+def test_getch_raises_eoferror_on_eof():
+    """getch() raises EOFError when keyboard fd is at EOF."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        read_fd, write_fd = os.pipe()
+        os.close(write_fd)
+        term._keyboard_fd = read_fd
+        try:
+            with pytest.raises(EOFError):
+                term.getch()
+        finally:
+            os.close(read_fd)
+    child()
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="no tty module")
+def test_flushinp_handles_eof():
+    """flushinp() returns buffered data when keyboard fd reaches EOF."""
+    @as_subprocess
+    def child():
+        import codecs
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        read_fd, write_fd = os.pipe()
+        os.write(write_fd, b'xy')
+        os.close(write_fd)
+        term._keyboard_fd = read_fd
+        term._keyboard_decoder = codecs.getincrementaldecoder('utf-8')()
+        try:
+            result = term.flushinp(timeout=1)
+            assert 'x' in result
+            assert 'y' in result
+        finally:
+            os.close(read_fd)
+    child()
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="no tty module")
+def test_getch_sets_eof_flag():
+    """getch() sets _keyboard_eof flag on EOF."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        read_fd, write_fd = os.pipe()
+        os.close(write_fd)
+        term._keyboard_fd = read_fd
+        try:
+            assert term._keyboard_eof is False
+            with pytest.raises(EOFError):
+                term.getch()
+            assert term._keyboard_eof is True
+        finally:
+            os.close(read_fd)
+    child()
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="no tty module")
+def test_kbhit_returns_false_after_eof():
+    """kbhit() returns False once _keyboard_eof is set."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        read_fd, write_fd = os.pipe()
+        os.close(write_fd)
+        term._keyboard_fd = read_fd
+        try:
+            term._keyboard_eof = True
+            assert term.kbhit(timeout=0) is False
+        finally:
+            os.close(read_fd)
+    child()
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="no tty module")
+def test_inkey_returns_empty_on_eof():
+    """inkey() returns empty Keystroke when keyboard fd is at EOF."""
+    @as_subprocess
+    def child():
+        import codecs
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        read_fd, write_fd = os.pipe()
+        os.close(write_fd)
+        term._keyboard_fd = read_fd
+        term._keyboard_decoder = codecs.getincrementaldecoder('utf-8')()
+        try:
+            ks = term.inkey(timeout=0)
+            assert ks == ''
+            assert term._keyboard_eof is True
+        finally:
+            os.close(read_fd)
+    child()
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="no tty module")
 def test_break_input_no_kb():
     """cbreak() should not call tty.setcbreak() without keyboard."""
     @as_subprocess


### PR DESCRIPTION
Bugfix EOF behavior when stdin is a Pipe

From https://github.com/vxgmichel/gambatte-terminal/pull/22#issuecomment-4155891223


When the keyboard fd reaches EOF (piped stdin eg. pytest capture), ``select()`` reports the fd as
readable but ``os.read()`` returns b''.

Previously this caused an infinite loop in ``flushinp()``/``inkey()`` since ``kbhit()`` kept
returning True while getch() kept returning empty strings  This bug existed since ``getch()`` was
first introduced.
