### PR TITLE
Add Terminal.text_sized() kitty text sizing

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: jquast

--- a/.spelling-ignore-words.txt
+++ b/.spelling-ignore-words.txt
@@ -5,3 +5,4 @@ THIRDPARTY
 claus
 hel
 rin
+nd

--- a/bin/benchmark_sequences.py
+++ b/bin/benchmark_sequences.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Benchmark blessed text manipulation functions."""
+
 import timeit
 from blessed import Terminal
 

--- a/bin/bounce.py
+++ b/bin/bounce.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Classic game of tennis."""
+
 # std imports
 from math import floor
 

--- a/bin/screen-scrape.py
+++ b/bin/screen-scrape.py
@@ -178,7 +178,7 @@ def main():
     alt_clean = UNKNOWN_CKSUM_RE.sub(" ", alt)
 
     # If both screens are identical, the terminal doesn't support
-    # alternate buffer — store only screen 0.
+    # alternate buffer: store only screen 0.
     if normal_clean == alt_clean:
         alt_clean = None
         alt = None

--- a/bin/screen-scrape.py
+++ b/bin/screen-scrape.py
@@ -2,16 +2,17 @@
 #
 # Demonstrates silent screen-reading via DECRQCRA (DEC Request Checksum of Rectangular Area).
 #
-# Only mlterm and WezTerm are known to be afflicted by default. This sequence is very useful for
-# automatic testing like with `vttest`, likely used while developing an emulator, but most make the
-# correct choice of using a disabled-by-default compile-time option. iTerm2 makes a runtime prompt
-# that clearly warns, "this allows screen scraping", while ghostty displays 'DECRQCRA' with
-# allow/deny.
+# Only mlterm, WezTerm (fixed in HEAD), and SyncTERM (fixed in HEAD) are known to be afflicted by
+# default. This sequence is very useful for automatic testing like with `vttest`, likely used while
+# developing an emulator, but most make the correct choice of using a disabled-by-default
+# compile-time option. iTerm2 makes a runtime prompt that clearly warns, "this allows screen
+# scraping", while ghostty displays only "DECRQCRA" with an allow/deny.
 #
 # https://vt100.net/docs/vt510-rm/DECRQCRA.html allows to silently read the contents of the visible
 # screen as a "checksum", but we can pre-compute expected checksums for printable ASCII, building a
 # reverse lookup table that recovers the original characters.
 #
+from blessed import Terminal
 import argparse
 import json
 import os
@@ -19,7 +20,8 @@ import re
 import select
 import sys
 
-from blessed import Terminal
+UNKNOWN_CKSUM_RE = re.compile(r"\?0x[0-9A-Fa-f]{4}")
+
 
 DECRQCRA = "\x1b[{pid};1;{r};{c};{r};{c}*y"
 DECCKSR_RE = re.compile(r"\x1bP(\d+)!~([0-9A-Fa-f]{4})\x1b\\")
@@ -172,19 +174,34 @@ def main():
         alt = blast_scrape(term, rows, cols, lookup)
         emit(ALT_SCREEN_OFF)
 
+    normal_clean = UNKNOWN_CKSUM_RE.sub(" ", normal)
+    alt_clean = UNKNOWN_CKSUM_RE.sub(" ", alt)
+
+    # If both screens are identical, the terminal doesn't support
+    # alternate buffer — store only screen 0.
+    if normal_clean == alt_clean:
+        alt_clean = None
+        alt = None
+
     if args.save_json:
         result = {
-            "screen_0": normal,
-            "screen_1": alt,
+            "screen_0": normal_clean,
+            "screen_0_with_unknown_checksums": normal,
             "rows": rows,
             "cols": cols,
         }
+        if alt_clean is not None:
+            result["screen_1"] = alt_clean
+            result["screen_1_with_unknown_checksums"] = alt
         with open(args.save_json, "w", encoding="utf-8") as f:
             json.dump(result, f, indent=2)
     else:
         emit(term.move_yx(start_row, 0) + term.clear_eol)
-        print(f"screen 0: {repr(normal)}")
-        print(f"screen 1: {repr(alt)}")
+        print(f"screen 0: {repr(normal_clean)}")
+        if alt_clean is not None:
+            print(f"screen 1: {repr(alt_clean)}")
+        else:
+            print("screen 1: (same as screen 0, no alternate buffer)")
 
     return 0
 

--- a/bin/scroller.py
+++ b/bin/scroller.py
@@ -66,8 +66,8 @@ _MESSAGE = (
 )
 
 
-def _sized_char(ch, target, v_align=0, h_align=0, sizing_supported=True):
-    if not sizing_supported:
+def _sized_char(ch, target, term, v_align=0, h_align=0):
+    if not term.does_text_sizing().scale:
         return ch, wcswidth(ch)
     s, w, n, d = _scale_params(target)
     if s == 1 and n == 0:
@@ -85,8 +85,6 @@ def main():
     screen_w = term.width
     screen_h = term.height
     vert_amp = screen_h // 3
-
-    sizing_supported = bool(term.does_text_sizing())
 
     graphemes = list(iter_graphemes(_MESSAGE))
     graph_len = len(graphemes)
@@ -145,7 +143,7 @@ def main():
                 else:
                     v = 2
 
-                seq, cw = _sized_char(gr, target, v, v, sizing_supported)
+                seq, cw = _sized_char(gr, target, term, v, v)
                 if col + cw > screen_w:
                     break
 

--- a/bin/scroller.py
+++ b/bin/scroller.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+"""Demoscene sine-wave scroller with per-character text sizing."""
+import math
+import time
+import blessed
+from wcwidth import TextSizing, TextSizingParams, iter_graphemes, wcswidth
+
+FRACTIONS = [(n, d) for d in range(1, 16) for n in range(0, d)]
+
+
+def _nearest_fraction(numerator, denominator, fractions):
+    target = numerator / denominator
+    return min(fractions, key=lambda f: abs(target - f[0] / f[1]))
+
+
+def _scale_params(target):
+    if 0.97 <= target <= 1.03:
+        return 1, 0, 0, 0
+    if target < 1.0:
+        n, d = _nearest_fraction(round(target * 100), 100, FRACTIONS)
+        if n >= d or n == 0:
+            return 1, 0, 0, 0
+        return 1, 0, n, d
+    s = min(7, max(1, math.ceil(target)))
+    if target >= s - 0.03:
+        return s, 0, 0, 0
+    ratio = target / s
+    n, d = _nearest_fraction(round(ratio * 100), 100, FRACTIONS)
+    if n >= d:
+        return s, 0, 0, 0
+    return s, 0, n, d
+
+
+def _lerp(a, b, t):
+    return int(a + (b - a) * t)
+
+
+def _fire_color(t):
+    t = max(0.0, min(1.0, t))
+    if t < 0.5:
+        u = t / 0.5
+        r, g, b = _lerp(255, 255, u), _lerp(40, 160, u), _lerp(0, 0, u)
+    else:
+        u = (t - 0.5) / 0.5
+        r, g, b = _lerp(255, 255, u), _lerp(160, 240, u), _lerp(0, 32, u)
+    return f'\x1b[38;2;{r};{g};{b}m'
+
+
+_BLOCKS = (
+    '\u2588\u258c\u2590'
+    '\u2580\u2584'
+    '\u2591\u2592\u2593'
+    '\u2596\u2597\u2598\u259d'
+    '\u259a\u259e'
+)
+
+_MESSAGE = (
+    f'{_BLOCKS}  '
+    'Greetings to the modern terminal demoscene!  '
+    f'{_BLOCKS}  '
+    'Check out kitty\'s text sizing protocol  '
+    f'{_BLOCKS}  '
+    'unicode: \u6f22\u5b57\u30ab\u30bf\u30ab\u30ca  '
+    f'emoji: \U0001f680\U0001f47e\U0001f3b5\U0001f31f  '
+    f'{_BLOCKS}  '
+)
+
+
+def _sized_char(ch, target, v_align=0, h_align=0, sizing_supported=True):
+    if not sizing_supported:
+        return ch, wcswidth(ch)
+    s, w, n, d = _scale_params(target)
+    if s == 1 and n == 0:
+        return ch, wcswidth(ch)
+    params = TextSizingParams(
+        scale=s, width=w, numerator=n, denominator=d,
+        vertical_align=v_align, horizontal_align=h_align)
+    seq = TextSizing(params, ch, '\x07').make_sequence()
+    width = TextSizing(params, ch, '\x07').display_width()
+    return seq, width
+
+
+def main():
+    term = blessed.Terminal()
+    screen_w = term.width
+    screen_h = term.height
+    vert_amp = screen_h // 3
+
+    sizing_supported = bool(term.does_text_sizing())
+
+    graphemes = list(iter_graphemes(_MESSAGE))
+    graph_len = len(graphemes)
+
+    with term.cbreak(), term.hidden_cursor():
+        t = 0.0
+        scroll_pos = 0.0
+        bounce_phase = 0.0
+        paused = False
+
+        while True:
+            if term.kbhit(timeout=0):
+                key = term.inkey(timeout=0)
+                if key == 'q' or key == '\x03':
+                    break
+                if key == ' ':
+                    paused = not paused
+
+            if paused:
+                time.sleep(0.042)
+                continue
+
+            t += 1.0
+            scroll_pos += 0.003
+            bounce_phase += 0.0006
+
+            graph_offset = int(scroll_pos) % graph_len
+
+            base_freq = 2 * math.pi / screen_w
+            spatial_freq = base_freq * (0.2 + 1.8 * (math.sin(t * 0.0004) + 1.0) / 2.0)
+
+            col_scales = []
+            for col in range(screen_w):
+                norm = (math.sin(col * spatial_freq) + 1.0) / 2.0
+                col_scales.append(0.4 + norm * 3.55)
+
+            grapheme_idx = graph_offset
+            col = 0
+            buf = term.home + term.clear_eos
+
+            while col < screen_w:
+                gr = graphemes[grapheme_idx % graph_len]
+                grapheme_idx += 1
+                if col >= screen_w:
+                    break
+
+                target = col_scales[col]
+                sine_y = vert_amp * math.sin(col * spatial_freq + bounce_phase)
+                y = max(0, min(screen_h - 1, int(screen_h // 2 + sine_y)))
+
+                deriv = math.cos(col * spatial_freq + bounce_phase)
+                if deriv > 0.3:
+                    v = 1
+                elif deriv < -0.3:
+                    v = 0
+                else:
+                    v = 2
+
+                seq, cw = _sized_char(gr, target, v, v, sizing_supported)
+                if col + cw > screen_w:
+                    break
+
+                lerp_t = (y - (screen_h // 2 - vert_amp)) / max(1, vert_amp * 2)
+                lerp_t += 0.15 * math.sin(t * 0.00035)
+                lerp_t = max(0.0, min(1.0, lerp_t))
+                fg = _fire_color(lerp_t)
+
+                buf += term.move_yx(y, col) + fg + seq
+                col += cw
+
+            with term.dec_modes_enabled(term.DecPrivateMode.SYNCHRONIZED_OUTPUT):
+                print(buf, end='', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/set-xterm-title.py
+++ b/bin/set-xterm-title.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Set the xterm window title using blessed."""
+import argparse
+import sys
+
+from blessed import Terminal
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Set the xterm window title.')
+    parser.add_argument('title', nargs='+', help='Title text to set.')
+    parser.add_argument('-m', '--mode', type=int, default=0, choices=[0, 1, 2],
+                        help='OSC mode: 0=both (default), 1=icon only, 2=title only.')
+    args = parser.parse_args()
+
+    term = Terminal()
+    title = ' '.join(args.title)
+    seq = term.set_window_title(title, mode=args.mode)
+    if not seq:
+        print('Terminal does not support styling.', file=sys.stderr)
+        raise SystemExit(1)
+    sys.stdout.write(seq)
+    sys.stdout.flush()
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/text_sizing_protocol.py
+++ b/bin/text_sizing_protocol.py
@@ -132,7 +132,7 @@ def show_alignment(term):
         boxes = [alignment_box(text, rows, cols, v, h) for v, h in params]
         for line_parts in zip(*boxes):
             print(gap.join(line_parts))
-        print(gap.join(f'{l:^{box_w}s}' for l in labels) + f'  ({fixed})')
+        print(gap.join(f'{label:^{box_w}s}' for label in labels) + f'  ({fixed})')
 
         sys.stdout.flush()
         end_y, _ = term.get_location()

--- a/bin/text_sizing_protocol.py
+++ b/bin/text_sizing_protocol.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+"""Demonstrate the Kitty Text Sizing Protocol (OSC 66) with blessed."""
+import sys
+
+from wcwidth import wcswidth
+from blessed import Terminal
+
+
+def make_seq(text, scale=1, width=0, numerator=0, denominator=0,
+             vertical_align=0, horizontal_align=0):
+    parts = []
+    if scale != 1:
+        parts.append(f's={scale}')
+    if width != 0:
+        parts.append(f'w={width}')
+    if numerator != 0:
+        parts.append(f'n={numerator}')
+    if denominator != 0:
+        parts.append(f'd={denominator}')
+    if vertical_align != 0:
+        parts.append(f'v={vertical_align}')
+    if horizontal_align != 0:
+        parts.append(f'h={horizontal_align}')
+    return f'\x1b]66;{":".join(parts)};{text}\x07'
+
+
+def alignment_box(text, rows, cols, v_align, h_align):
+    text_w = len(text)
+    if h_align == 0:
+        content = text + ' ' * (cols - text_w)
+    elif h_align == 1:
+        content = ' ' * (cols - text_w) + text
+    else:
+        left = (cols - text_w) // 2
+        content = ' ' * left + text + ' ' * (cols - text_w - left)
+    empty = ' ' * cols
+    if v_align == 0:
+        text_row = 0
+    elif v_align == 1:
+        text_row = rows - 1
+    else:
+        text_row = rows // 2
+    lines = ['\u250c' + '\u2500' * cols + '\u2510']
+    for r in range(rows):
+        lines.append('\u2502' + (content if r == text_row else empty) + '\u2502')
+    lines.append('\u2514' + '\u2500' * cols + '\u2518')
+    return lines
+
+
+def detect(term):
+    print('term.does_text_sizing() -> ', end='', flush=True)
+    result = term.does_text_sizing(timeout=2)
+    print(f'\r{term.clear_eol}', end='')
+    yn = {True: term.bold_green('YES'), False: term.bold_red('NO')}
+    print(f'Width sizing: {yn[result.width]}   Scale sizing: {yn[result.scale]}')
+    return result
+
+
+def show_scale_factors(term):
+    colors = [term.bright_blue, term.bright_red, term.bright_green]
+    for i, (s, text) in enumerate([(1, 'Ol\u00e1'), (2, 'Gr\u00fc\u00dfe'), (3, 'Bj\u00f6rk')]):
+        heading = term.heading(text, scale=s)
+        # color wraps outside the OSC 66 sequence (SGR can't go inside payload)
+        print(colors[i](heading))
+        print()
+
+
+def show_char_types():
+    types = [
+        ('N',    'A',                            1),
+        ('VS15', '\u231a\ufe0e',                  1),
+        ('CJK',  '\u6f22',                        2),
+        ('VS16', '\u00a9\ufe0f',                  2),
+        ('ZWJ',  '\U0001f468\u200d\U0001f469',    2),
+        ('flag', '\U0001f1ef\U0001f1f5',          2),
+    ]
+    tl, tr, bl, br, hz, vt = '\u250c\u2510\u2514\u2518\u2500\u2502'
+    gap = '    '
+    for _, _, w in types:
+        print(f'{tl}{hz * w}{tr}{gap}', end='')
+    print()
+    for _, char, w in types:
+        print(f'{vt}{make_seq(char, width=w)}{vt}{gap}', end='')
+    print()
+    for _, _, w in types:
+        print(f'{bl}{hz * w}{br}{gap}', end='')
+    print()
+    for label, _, w in types:
+        col_w = w + 2 + len(gap)
+        print(f'{label:<{col_w}}', end='')
+    print()
+
+
+def show_fractional(term):
+    fracs = sorted([(n, d) for d in range(2, 16) for n in range(1, d)
+                    if n / d >= 0.25], key=lambda nd: nd[0] / nd[1])
+    budget = 43
+    step = max(1, (len(fracs) + budget - 2) // (budget - 1))
+    sampled = fracs[::step]
+    sampled.append((0, 0))
+    for n, d in sampled:
+        print(make_seq('X', width=1, numerator=n, denominator=d,
+                        vertical_align=1), end='')
+    print()
+    pcts = {i: (int(n / d * 100) if d else 100) for i, (n, d) in enumerate(sampled)}
+    label_at = {}
+    for target in (25, 50, 75, 100):
+        best = min(pcts, key=lambda i: abs(pcts[i] - target))
+        label_at[best] = f'{pcts[best]}%'
+    lbl = [' '] * (len(sampled) + 5)
+    for i, text in sorted(label_at.items()):
+        for c, ch in enumerate(text):
+            if i + c < len(lbl) and lbl[i + c] == ' ':
+                lbl[i + c] = ch
+    print(''.join(lbl).rstrip())
+
+
+def show_alignment(term):
+    rows, cols, text = 3, 6, 'Hi'
+    text_w = len(text)
+    gap = '  '
+    box_w = cols + 2
+    gap_w = len(gap)
+    common = dict(scale=rows, width=text_w, numerator=1, denominator=2)
+
+    for params, labels, fixed in [
+        ([(0, 0), (2, 0), (1, 0)],
+         ['v=top', 'v=center', 'v=bottom'], 'h=left'),
+        ([(0, 0), (0, 2), (0, 1)],
+         ['h=left', 'h=center', 'h=right'], 'v=top'),
+    ]:
+        boxes = [alignment_box(text, rows, cols, v, h) for v, h in params]
+        for line_parts in zip(*boxes):
+            print(gap.join(line_parts))
+        print(gap.join(f'{l:^{box_w}s}' for l in labels) + f'  ({fixed})')
+
+        sys.stdout.flush()
+        end_y, _ = term.get_location()
+        interior_y = end_y - rows - 3 + 1
+        if end_y > 0 and interior_y >= 0:
+            for i, (v, h) in enumerate(params):
+                raw = term.text_sized(text, **dict(common,
+                                                   vertical_align=v,
+                                                   horizontal_align=h))
+                seq = term.bright_red(raw)
+                interior_x = i * (box_w + gap_w) + 1
+                print(term.move_yx(interior_y, interior_x) + seq, end='')
+            print(term.move_yx(end_y, 0), end='', flush=True)
+        print()
+
+
+def show_ljust_rjust_center(term, supported):
+    box_cols = 35
+    box_rows = 2 if supported else 1
+    tl, tr, bl, br, hz, vt = '\u250c\u2510\u2514\u2518\u2500\u2502'
+    dot = '\u00b7'
+
+    colors = [term.bright_blue, term.bright_red, term.bright_green]
+    for i, (name, method) in enumerate([('ljust', term.ljust), ('rjust', term.rjust),
+                                        ('center', term.center)]):
+        scaled = colors[i](term.scaled(f'BIG {name.upper()}', 2))
+        mixed = 'little and ' + scaled
+        content = method(mixed, box_cols, dot)
+        print(f'{tl}{hz * box_cols}{tr}')
+        for _ in range(box_rows):
+            print(f'{vt}{" " * box_cols}{vt}')
+        print(f'{bl}{hz * box_cols}{br}')
+        sys.stdout.flush()
+        end_y, _ = term.get_location()
+        if end_y > 0:
+            interior_y = end_y - box_rows - 1
+            print(term.move_yx(interior_y, 1) + content, end='')
+            print(term.move_yx(end_y, 0), end='', flush=True)
+
+
+def main():
+    term = Terminal()
+    result = detect(term)
+    show_scale_factors(term)
+    show_char_types()
+    print()
+    show_fractional(term)
+    print()
+    show_alignment(term)
+    show_ljust_rjust_center(term, bool(result))
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/text_sizing_protocol.py
+++ b/bin/text_sizing_protocol.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python
 """Demonstrate the Kitty Text Sizing Protocol (OSC 66) with blessed."""
+
+# std imports
 import math
+
+# 3rd party
 from wcwidth import TextSizing, TextSizingParams
+
+# local
 from blessed import Terminal
 
 FRACTIONS = [(n, d) for d in range(1, 16) for n in range(0, d)]
@@ -86,8 +92,9 @@ def show_scale_factors(term):
     scale_headings = [(1, 'Ol\u00e1'), (2, 'Gr\u00fc\u00dfe'), (3, 'Bj\u00f6rk')]
     for idx, (s, text) in enumerate(scale_headings):
         heading = colors[idx](term.text_sized(text, scale=s))
-        newlines =  ('\n' * s) if term.does_text_sizing().scale else '\n'
+        newlines = ('\n' * s) if term.does_text_sizing().scale else '\n'
         print(heading + newlines + '=' * term.length(heading) + '\n')
+
 
 def show_char_types(term):
     types = [
@@ -180,7 +187,7 @@ def show_ljust_rjust_center(term, supported):
     colors = [term.bright_blue, term.bright_red, term.bright_green]
     for i, (name, method) in enumerate([('ljust', term.ljust), ('rjust', term.rjust),
                                         ('center', term.center)]):
-        scaled = colors[i](term.scaled(f'BIG {name.upper()}', 2))
+        scaled = colors[i](term.text_sized(f'BIG {name.upper()}', 2))
         mixed = 'little and ' + scaled
         content = method(mixed, width=box_cols, fillchar='\u00b7')
         print(f'{tl}{hz * box_cols}{tr}')

--- a/bin/text_sizing_protocol.py
+++ b/bin/text_sizing_protocol.py
@@ -67,12 +67,12 @@ def show_scale_factors(term):
 
 def show_char_types():
     types = [
-        ('N',    'A',                            1),
-        ('VS15', '\u231a\ufe0e',                  1),
-        ('CJK',  '\u6f22',                        2),
-        ('VS16', '\u00a9\ufe0f',                  2),
-        ('ZWJ',  '\U0001f468\u200d\U0001f469',    2),
-        ('flag', '\U0001f1ef\U0001f1f5',          2),
+        ('N', 'A', 1),
+        ('VS15', '\u231a\ufe0e', 1),
+        ('CJK', '\u6f22', 2),
+        ('VS16', '\u00a9\ufe0f', 2),
+        ('ZWJ', '\U0001f468\u200d\U0001f469', 2),
+        ('flag', '\U0001f1ef\U0001f1f5', 2),
     ]
     tl, tr, bl, br, hz, vt = '\u250c\u2510\u2514\u2518\u2500\u2502'
     gap = '    '
@@ -100,7 +100,7 @@ def show_fractional(term):
     sampled.append((0, 0))
     for n, d in sampled:
         print(make_seq('X', width=1, numerator=n, denominator=d,
-                        vertical_align=1), end='')
+                       vertical_align=1), end='')
     print()
     pcts = {i: (int(n / d * 100) if d else 100) for i, (n, d) in enumerate(sampled)}
     label_at = {}

--- a/bin/text_sizing_protocol.py
+++ b/bin/text_sizing_protocol.py
@@ -1,6 +1,52 @@
 #!/usr/bin/env python
 """Demonstrate the Kitty Text Sizing Protocol (OSC 66) with blessed."""
+import math
+from wcwidth import TextSizing, TextSizingParams
 from blessed import Terminal
+
+FRACTIONS = [(n, d) for d in range(1, 16) for n in range(0, d)]
+
+
+def _nearest_fraction(numerator, denominator, fractions):
+    """Return nearest fraction from *fractions* to numerator/denominator."""
+    target = numerator / denominator
+    return min(fractions, key=lambda f: abs(target - f[0] / f[1]))
+
+
+def _params_for_target(target):
+    """Return (scale, numerator, denominator) for a target visual size.
+
+    *scale* is ``ceil(target)`` since *n/d* can only reduce font size.
+    """
+    if target <= 1.0:
+        return 1, 0, 0
+    s = min(7, max(1, math.ceil(target)))
+    if target >= s - 0.03:
+        return s, 0, 0
+    ratio = target / s
+    n, d = _nearest_fraction(round(ratio * 100), 100, FRACTIONS)
+    if n >= d:
+        return s, 0, 0
+    return s, n, d
+
+
+def show_scale_range(term, lo, hi, steps):
+    """Display a row of 'X' characters ranging from *lo* to *hi* in *steps*."""
+    label_top = []
+    label_bot = []
+    chars = []
+    for i in range(steps + 1):
+        target = lo + (hi - lo) * i / steps
+        s, n, d = _params_for_target(target)
+        params = TextSizingParams(scale=s, numerator=n, denominator=d,
+                                  vertical_align=1)
+        chars.append(TextSizing(params, 'X', '\x07').make_sequence())
+        label_top.append(f'{target:.1f}'.center(s * 2))
+        label_bot.append(f's={s}'.center(s * 2))
+    print(''.join(chars))
+    print(''.join(label_top))
+    print(''.join(label_bot))
+    print()
 
 
 def alignment_box(text, rows, cols, v_align, h_align):
@@ -154,6 +200,10 @@ def main():
     show_scale_factors(term)
     show_char_types(term)
     show_fractional(term)
+    print(term.bold('100% -- 200%:'))
+    show_scale_range(term, 1.0, 2.0, 10)
+    print(term.bold('200% -- 300%:'))
+    show_scale_range(term, 2.0, 3.0, 10)
     show_alignment(term)
     show_ljust_rjust_center(term, bool(result))
 

--- a/bin/text_sizing_protocol.py
+++ b/bin/text_sizing_protocol.py
@@ -1,27 +1,6 @@
 #!/usr/bin/env python
 """Demonstrate the Kitty Text Sizing Protocol (OSC 66) with blessed."""
-import sys
-
-from wcwidth import wcswidth
 from blessed import Terminal
-
-
-def make_seq(text, scale=1, width=0, numerator=0, denominator=0,
-             vertical_align=0, horizontal_align=0):
-    parts = []
-    if scale != 1:
-        parts.append(f's={scale}')
-    if width != 0:
-        parts.append(f'w={width}')
-    if numerator != 0:
-        parts.append(f'n={numerator}')
-    if denominator != 0:
-        parts.append(f'd={denominator}')
-    if vertical_align != 0:
-        parts.append(f'v={vertical_align}')
-    if horizontal_align != 0:
-        parts.append(f'h={horizontal_align}')
-    return f'\x1b]66;{":".join(parts)};{text}\x07'
 
 
 def alignment_box(text, rows, cols, v_align, h_align):
@@ -58,14 +37,13 @@ def detect(term):
 
 def show_scale_factors(term):
     colors = [term.bright_blue, term.bright_red, term.bright_green]
-    for i, (s, text) in enumerate([(1, 'Ol\u00e1'), (2, 'Gr\u00fc\u00dfe'), (3, 'Bj\u00f6rk')]):
-        heading = term.heading(text, scale=s)
-        # color wraps outside the OSC 66 sequence (SGR can't go inside payload)
-        print(colors[i](heading))
-        print()
+    scale_headings = [(1, 'Ol\u00e1'), (2, 'Gr\u00fc\u00dfe'), (3, 'Bj\u00f6rk')]
+    for idx, (s, text) in enumerate(scale_headings):
+        heading = colors[idx](term.text_sized(text, scale=s))
+        newlines =  ('\n' * s) if term.does_text_sizing().scale else '\n'
+        print(heading + newlines + '=' * term.length(heading) + '\n')
 
-
-def show_char_types():
+def show_char_types(term):
     types = [
         ('N', 'A', 1),
         ('VS15', '\u231a\ufe0e', 1),
@@ -76,18 +54,18 @@ def show_char_types():
     ]
     tl, tr, bl, br, hz, vt = '\u250c\u2510\u2514\u2518\u2500\u2502'
     gap = '    '
-    for _, _, w in types:
-        print(f'{tl}{hz * w}{tr}{gap}', end='')
+    for _, _, width in types:
+        print(f'{tl}{hz * width}{tr}{gap}', end='')
     print()
-    for _, char, w in types:
-        print(f'{vt}{make_seq(char, width=w)}{vt}{gap}', end='')
+    for _, ucs, width in types:
+        print(f'{vt}{term.text_sized(ucs, width=width)}{vt}{gap}', end='')
     print()
-    for _, _, w in types:
-        print(f'{bl}{hz * w}{br}{gap}', end='')
+    for _, _, width in types:
+        print(f'{bl}{hz * width}{br}{gap}', end='')
     print()
-    for label, _, w in types:
-        col_w = w + 2 + len(gap)
-        print(f'{label:<{col_w}}', end='')
+    for label, _, width in types:
+        col_width = width + 2 + len(gap)
+        print(f'{label:<{col_width}}', end='')
     print()
 
 
@@ -99,8 +77,7 @@ def show_fractional(term):
     sampled = fracs[::step]
     sampled.append((0, 0))
     for n, d in sampled:
-        print(make_seq('X', width=1, numerator=n, denominator=d,
-                       vertical_align=1), end='')
+        print(term.text_sized('X', width=1, numerator=n, denominator=d, vertical_align=1), end='')
     print()
     pcts = {i: (int(n / d * 100) if d else 100) for i, (n, d) in enumerate(sampled)}
     label_at = {}
@@ -113,6 +90,7 @@ def show_fractional(term):
             if i + c < len(lbl) and lbl[i + c] == ' ':
                 lbl[i + c] = ch
     print(''.join(lbl).rstrip())
+    print()
 
 
 def show_alignment(term):
@@ -134,7 +112,6 @@ def show_alignment(term):
             print(gap.join(line_parts))
         print(gap.join(f'{label:^{box_w}s}' for label in labels) + f'  ({fixed})')
 
-        sys.stdout.flush()
         end_y, _ = term.get_location()
         interior_y = end_y - rows - 3 + 1
         if end_y > 0 and interior_y >= 0:
@@ -153,34 +130,30 @@ def show_ljust_rjust_center(term, supported):
     box_cols = 35
     box_rows = 2 if supported else 1
     tl, tr, bl, br, hz, vt = '\u250c\u2510\u2514\u2518\u2500\u2502'
-    dot = '\u00b7'
 
     colors = [term.bright_blue, term.bright_red, term.bright_green]
     for i, (name, method) in enumerate([('ljust', term.ljust), ('rjust', term.rjust),
                                         ('center', term.center)]):
         scaled = colors[i](term.scaled(f'BIG {name.upper()}', 2))
         mixed = 'little and ' + scaled
-        content = method(mixed, box_cols, dot)
+        content = method(mixed, width=box_cols, fillchar='\u00b7')
         print(f'{tl}{hz * box_cols}{tr}')
         for _ in range(box_rows):
             print(f'{vt}{" " * box_cols}{vt}')
         print(f'{bl}{hz * box_cols}{br}')
-        sys.stdout.flush()
+
         end_y, _ = term.get_location()
-        if end_y > 0:
-            interior_y = end_y - box_rows - 1
-            print(term.move_yx(interior_y, 1) + content, end='')
-            print(term.move_yx(end_y, 0), end='', flush=True)
+        interior_y = max(0, end_y - box_rows - 1)
+        print(term.move_yx(interior_y, 1) + content, end='')
+        print(term.move_yx(end_y, 0), end='', flush=True)
 
 
 def main():
     term = Terminal()
     result = detect(term)
     show_scale_factors(term)
-    show_char_types()
-    print()
+    show_char_types(term)
     show_fractional(term)
-    print()
     show_alignment(term)
     show_ljust_rjust_center(term, bool(result))
 

--- a/bin/text_sizing_protocol.py
+++ b/bin/text_sizing_protocol.py
@@ -20,7 +20,8 @@ def _nearest_fraction(numerator, denominator, fractions):
 
 
 def _params_for_target(target):
-    """Return (scale, numerator, denominator) for a target visual size.
+    """
+    Return (scale, numerator, denominator) for a target visual size.
 
     *scale* is ``ceil(target)`` since *n/d* can only reduce font size.
     """

--- a/blessed/colorspace.py
+++ b/blessed/colorspace.py
@@ -65,7 +65,7 @@ def hex_to_rgb(hex_color: str) -> Tuple[int, int, int]:
         b = int(hex_color[4:6], 16)
     else:
         # 12-digit: #RRRRGGGGBBBB (16-bit) -> convert to 8-bit
-        # eg ('ffff' -> 65536 # -> 256)
+        # eg. ('ffff' -> 65536 -> 256)
         r = int(hex_color[0:4], 16) >> 8
         g = int(hex_color[4:8], 16) >> 8
         b = int(hex_color[8:12], 16) >> 8

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -1506,7 +1506,7 @@ def _read_until(term: 'Terminal',
         may be :class:`re.MatchObject` if pattern is discovered
         in input stream before timeout has elapsed, otherwise
         None. ``str`` is any remaining text received exclusive
-        of the matching pattern).
+        of the matching pattern.
 
     The reason a tuple containing non-matching data is returned, is that the
     consumer should push such data back into the input buffer by

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -1807,7 +1807,6 @@ KEY_KP_7 = 527
 KEY_KP_8 = 528
 KEY_KP_9 = 529
 KEY_MENU = 530
-KEY_CPR_RESPONSE = 531
 
 # Kitty protocol control character to keycode mapping
 # Maps common control character unicode values to their curses keycodes

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -1047,12 +1047,12 @@ class Keystroke(str):
         Some Examples,
 
         - Plain text: 'a', 'A', '1', ';', ' ', 'Ω', emoji with ZWJ sequences
-        - Alt+printable: Alt+a → 'a', Alt+A → 'A'
-        - Ctrl+letter: Ctrl+A → 'a', Ctrl+Z → 'z'
-        - Ctrl+symbol: Ctrl+@ → '@', Ctrl+? → '?', Ctrl+[ → '['
+        - Alt+printable: Alt+a -> 'a', Alt+A -> 'A'
+        - Ctrl+letter: Ctrl+A -> 'a', Ctrl+Z -> 'z'
+        - Ctrl+symbol: Ctrl+@ -> '@', Ctrl+? -> '?', Ctrl+[ → '['
         - Control chars: '\t', '\n', '\x08', '\x1b' (for Enter/Tab/Backspace/Escape keycodes)
         - Application keys: KEY_UP, KEY_F1, etc. → ''
-        - Release events: always → ''
+        - Release events: always -> ''
         """
         # Release events never have text
         if self.released:

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -78,6 +78,10 @@ RE_PATTERN_FOCUS = re.compile(r'\x1b\[(?P<io>[IO])')
 # Resize notification (mode 2048): ESC [ 48 ; height ; width ; height_px ; width_px t
 RE_PATTERN_RESIZE = re.compile(r'\x1b\[48;(?P<height_chars>\d+);(?P<width_chars>\d+)'
                                r';(?P<height_pixels>\d+);(?P<width_pixels>\d+)t')
+# CPR (Cursor Position Report): ESC [ row ; column R
+# Row 1 excluded -- ambiguously matches RE_PATTERN_LEGACY_CSI_MODIFIERS 
+RE_PATTERN_CPR = re.compile(
+    r'\x1b\[(?P<row>[2-9]\d*|[1-9]\d+);(?P<column>\d+)R')
 
 # DEC event pattern container
 DECEventPattern = namedtuple("DECEventPattern", ["mode", "pattern"])
@@ -542,6 +546,10 @@ class Keystroke(str):
         - Focus events: 'FOCUS_IN' or 'FOCUS_OUT'
         - Bracketed paste: 'BRACKETED_PASTE'
         - Resize events: 'RESIZE_EVENT'
+
+        For terminal query responses:
+        - Cursor position report: 'KEY_CPR_RESPONSE' (row >= 2 only;
+          row 1 is ambiguous with F3+modifier)
 
         When non-None, all phrases begin with either 'KEY', 'MOUSE', 'FOCUS_IN', 'FOCUS_OUT',
         'BRACKETED_PASTE', or 'RESIZE_EVENT', with one exception: 'CSI' is returned for '\\x1b['
@@ -1393,6 +1401,7 @@ def resolve_sequence(text: str,
             functools.partial(_match_dec_event, dec_mode_cache=dec_mode_cache),
             _match_kitty_key,
             _match_modify_other_keys,
+            _match_cpr_response,
             _match_legacy_csi_letter_form,
             _match_legacy_csi_tilde_form,
             _match_legacy_ss3_fkey_form):
@@ -1536,6 +1545,26 @@ def _match_dec_event(text: str,
         match = pattern.match(text)
         if match:
             return Keystroke(ucs=match.group(0), mode=mode, match=match)
+    return None
+
+
+def _match_cpr_response(text: str) -> Optional[Keystroke]:
+    """
+    Match CPR (Cursor Position Report): ESC [ row ; column R.
+
+    :arg str text: Input text to match against CPR pattern.
+    :rtype: Keystroke or None
+    :returns: :class:`Keystroke` if matched, ``None`` otherwise.
+
+    Matches terminal CPR responses where row >= 2. Row 1 is not
+    matched on input, preferring to match F3 + Modifier in the
+    legacy CSI letter form.
+    """
+    match = RE_PATTERN_CPR.match(text)
+    if match:
+        return Keystroke(ucs=match.group(0),
+                         code=KEY_CPR_RESPONSE,
+                         name='KEY_CPR_RESPONSE')
     return None
 
 
@@ -1742,6 +1771,7 @@ KEY_KP_7 = 527
 KEY_KP_8 = 528
 KEY_KP_9 = 529
 KEY_MENU = 530
+KEY_CPR_RESPONSE = 531
 
 # Kitty protocol control character to keycode mapping
 # Maps common control character unicode values to their curses keycodes

--- a/blessed/sequences.py
+++ b/blessed/sequences.py
@@ -104,7 +104,7 @@ class Termcap():
         :arg str name: Variable name given for this pattern.
         :arg str capability: A unicode string representing a terminal
             capability to build for. When ``nparams`` is non-zero, it
-            must be a callable unicode string (such as the result from
+            must be a callable unicode string, such as the result from
             ``getattr(term, 'bold')``.
         :arg str attribute: The terminfo(5) capability name by which this
             pattern is known.

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -876,7 +876,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         The following sequence should cause the cursor to not move at all::
 
             >>> term = Terminal()
-            >>> term.move_yx(*term.get_location()))
+            >>> term.move_yx(*term.get_location())
 
         And the following should assert True with a terminal:
 

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -3329,9 +3329,12 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             denominator=denominator, vertical_align=vertical_align,
             horizontal_align=horizontal_align,
         )
+        # Specification is pretty exact -- text must be utf-8 and no more than 4096 bytes.  Although
+        # we do not enforce utf-8, we do enforce 4096 of encoded bytes and assume utf-8, because any
+        # terminal where does_test_size() is True is presumed utf-8, anyway.
         utf8_len = len(text.encode())
         if utf8_len > 4096:
-            raise ValueError("'text' must be no longer than 4096 bytes")
+            raise ValueError(f"'text' must be no longer than 4096 bytes, got {utf8_len}")
         return f'\x1b]66;{params};{text}\x07'
 
     def scaled(self, text: str, scale: int) -> str:
@@ -3740,7 +3743,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             indefinitely.
         :arg float esc_delay: Time in seconds to block after Escape key
            is received to await another key sequence beginning with
-           escape such as *KEY_LEFT*, sequence ``'\x1b[D'``], before returning a
+           escape such as *KEY_LEFT*, sequence ``'\x1b[D'``, before returning a
            :class:`~.Keystroke` instance for ``KEY_ESCAPE``.
 
            Users may override the default value of ``esc_delay`` in seconds,

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -3265,6 +3265,135 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             width = self.width
         return wcwidth_center(text, width.__index__(), fillchar, control_codes='ignore')
 
+    @staticmethod
+    def _text_sizing_params_str(
+        scale: int = 1,
+        width: int = 0,
+        numerator: int = 0,
+        denominator: int = 0,
+        vertical_align: int = 0,
+        horizontal_align: int = 0,
+    ) -> str:
+        """Build colon-separated metadata for an OSC 66 sequence."""
+        # arguments are in the order described in specification
+        parts = []
+        if scale != 1:
+            parts.append(f's={scale}')
+        if width != 0:
+            parts.append(f'w={width}')
+        if numerator != 0:
+            parts.append(f'n={numerator}')
+        if denominator != 0:
+            parts.append(f'd={denominator}')
+        if vertical_align != 0:
+            parts.append(f'v={vertical_align}')
+        if horizontal_align != 0:
+            parts.append(f'h={horizontal_align}')
+        return ':'.join(parts)
+
+    def text_sized(
+        self,
+        text: str,
+        *,
+        scale: int = 1,
+        width: int = 0,
+        numerator: int = 0,
+        denominator: int = 0,
+        vertical_align: int = 0,
+        horizontal_align: int = 0,
+    ) -> str:
+        """
+        Wrap ``text`` in a text sizing escape sequence (OSC 66).
+
+        Returns ``text`` unchanged when the terminal does not support text sizing, providing
+        graceful degradation.
+
+        :arg str text: Text payload.
+        :arg int scale: Scale factor (1--7).
+        :arg int width: Width in cells (0--7). 0 means auto-calculate
+            from the inner text.
+        :arg int numerator: Fractional scaling numerator (0--15).
+        :arg int denominator: Fractional scaling denominator (0--15).
+        :arg int vertical_align: Vertical alignment (0=top, 1=bottom, 2=center).
+        :arg int horizontal_align: Horizontal alignment (0=left, 1=right, 2=center).
+        :rtype: str
+        :returns: Text wrapped in an OSC 66 escape sequence, or plain
+            ``text`` on unsupported terminals.
+
+        .. seealso:: `Kitty Text Sizing Protocol
+            <https://sw.kovidgoyal.net/kitty/text-sizing-protocol/>`_
+        """
+        if not self.does_text_sizing():
+            return text
+        params = self._text_sizing_params_str(
+            scale=scale, width=width, numerator=numerator,
+            denominator=denominator, vertical_align=vertical_align,
+            horizontal_align=horizontal_align,
+        )
+        return f'\x1b]66;{params};{text}\x07'
+
+    def scaled(self, text: str, scale: int) -> str:
+        """
+        Scale ``text`` using the text sizing protocol with auto-calculatwidth.
+
+        This is the most common use case: render ``text`` at ``scale``
+        times its natural size. Returns ``text`` unchanged when the
+        terminal does not support text sizing.
+
+        :arg str text: Text payload.
+        :arg int scale: Scale factor (1 to 7).
+        :rtype: str
+        :returns: Text wrapped in an OSC 66 escape sequence with
+            auto-calculated width, or plain ``text`` on unsupported
+            terminals.
+
+        .. seealso:: `Kitty Text Sizing Protocol
+            <https://sw.kovidgoyal.net/kitty/text-sizing-protocol/>`_
+        """
+        if not self.does_text_sizing():
+            return text
+        params = self._text_sizing_params_str(scale=scale)
+        return f'\x1b]66;{params};{text}\x07'
+
+    # XXX TODO: I think we should cut this ..
+    def heading(
+        self,
+        text: str,
+        scale: int = 2,
+        underline_char: str = '=',
+    ) -> str:
+        r"""
+        Return ``text`` scaled as a heading with a correctly-sized underline.
+
+        When text sizing is supported, the heading is rendered at ``scale`` times its natural size
+        (2x by default), followed by a newline and an underline of the correct measured width.
+
+        When unsupported, returns text plain and underlined.
+
+        :arg str text: Heading text.
+        :arg int scale: Scale factor (1--7). Default is 2.
+        :arg str underline_char: Character for the underline. Default
+            is ``'='``.
+        :rtype: str
+        :returns: Multi-line string: scaled heading + blank lines for
+            multi-row rendering + underline.
+
+        Example::
+
+            >>> term.heading('Chapter One')
+            '\x1b]66;s=2:Chapter One\x07\n\n======================'
+
+        .. seealso:: `Kitty Text Sizing Protocol
+            <https://sw.kovidgoyal.net/kitty/text-sizing-protocol/>`_
+        """
+        sized = self.scaled(text, scale)
+        w = wcwidth_width(sized)
+        lines = sized + '\n'
+        if self.does_text_sizing() and scale > 1:
+            lines += '\n' * (scale - 1)
+        lines += underline_char * w
+        return lines
+
     def truncate(self, text: str, width: Optional[SupportsIndex] = None) -> str:
         r"""
         Truncate ``text`` to ``width`` printable characters, retaining terminal sequences.

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -23,6 +23,7 @@ from wcwidth import ljust as wcwidth_ljust
 from wcwidth import rjust as wcwidth_rjust
 from wcwidth import width as wcwidth_width
 from wcwidth import center as wcwidth_center
+from wcwidth import TextSizing, TextSizingParams
 
 # local
 from .color import COLOR_DISTANCE_ALGORITHMS, xterm256gray_from_rgb, xterm256color_from_rgb
@@ -3263,33 +3264,6 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             width = self.width
         return wcwidth_center(text, width.__index__(), fillchar)
 
-    @staticmethod
-    def _text_sizing_params_str(
-        scale: int = 1,
-        width: int = 0,
-        numerator: int = 0,
-        denominator: int = 0,
-        vertical_align: int = 0,
-        horizontal_align: int = 0,
-    ) -> str:
-        # pylint: disable=too-many-positional-arguments
-        """Build colon-separated metadata for an OSC 66 sequence."""
-        # arguments are in the order described in specification
-        parts = []
-        if scale != 1:
-            parts.append(f's={scale}')
-        if width != 0:
-            parts.append(f'w={width}')
-        if numerator != 0:
-            parts.append(f'n={numerator}')
-        if denominator != 0:
-            parts.append(f'd={denominator}')
-        if vertical_align != 0:
-            parts.append(f'v={vertical_align}')
-        if horizontal_align != 0:
-            parts.append(f'h={horizontal_align}')
-        return ':'.join(parts)
-
     def text_sized(
         self,
         text: str,
@@ -3324,18 +3298,16 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         """
         if not self.does_text_sizing():
             return text
-        params = self._text_sizing_params_str(
-            scale=scale, width=width, numerator=numerator,
-            denominator=denominator, vertical_align=vertical_align,
-            horizontal_align=horizontal_align,
-        )
         # Specification is pretty exact -- text must be utf-8 and no more than 4096 bytes.  Although
         # we do not enforce utf-8, we do enforce 4096 of encoded bytes and assume utf-8, because any
         # terminal where does_test_size() is True is presumed utf-8, anyway.
         utf8_len = len(text.encode())
         if utf8_len > 4096:
             raise ValueError(f"'text' must be no longer than 4096 bytes, got {utf8_len}")
-        return f'\x1b]66;{params};{text}\x07'
+        params = TextSizingParams(scale=scale, width=width, numerator=numerator,
+                                  denominator=denominator, vertical_align=vertical_align,
+                                  horizontal_align=horizontal_align)
+        return TextSizing(params, text, '\x07').make_sequence()
 
     def scaled(self, text: str, scale: int) -> str:
         """
@@ -3357,8 +3329,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         """
         if not self.does_text_sizing():
             return text
-        params = self._text_sizing_params_str(scale=scale)
-        return f'\x1b]66;{params};{text}\x07'
+        params = TextSizingParams(scale=scale)
+        return TextSizing(params, text, '\x07').make_sequence()
 
     def truncate(self, text: str, width: Optional[SupportsIndex] = None) -> str:
         r"""

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -3274,6 +3274,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         vertical_align: int = 0,
         horizontal_align: int = 0,
     ) -> str:
+        # pylint: disable=too-many-positional-arguments
         """Build colon-separated metadata for an OSC 66 sequence."""
         # arguments are in the order described in specification
         parts = []

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -18,12 +18,12 @@ import collections
 from typing import IO, Dict, List, Match, Tuple, Union, Optional, Generator, SupportsIndex
 
 # 3rd party
+from wcwidth import TextSizing, TextSizingParams
 from wcwidth import wrap as wcwidth_wrap
 from wcwidth import ljust as wcwidth_ljust
 from wcwidth import rjust as wcwidth_rjust
 from wcwidth import width as wcwidth_width
 from wcwidth import center as wcwidth_center
-from wcwidth import TextSizing, TextSizingParams
 
 # local
 from .color import COLOR_DISTANCE_ALGORITHMS, xterm256gray_from_rgb, xterm256color_from_rgb
@@ -3267,8 +3267,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
     def text_sized(
         self,
         text: str,
-        *,
         scale: int = 1,
+        *,
         width: int = 0,
         numerator: int = 0,
         denominator: int = 0,
@@ -3292,6 +3292,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         :rtype: str
         :returns: Text wrapped in an OSC 66 escape sequence, or plain
             ``text`` on unsupported terminals.
+        :raises ValueError: when the encoded ``text`` exceeds 4096 bytes.
 
         .. seealso:: `Kitty Text Sizing Protocol
             <https://sw.kovidgoyal.net/kitty/text-sizing-protocol/>`_
@@ -3307,29 +3308,6 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         params = TextSizingParams(scale=scale, width=width, numerator=numerator,
                                   denominator=denominator, vertical_align=vertical_align,
                                   horizontal_align=horizontal_align)
-        return TextSizing(params, text, '\x07').make_sequence()
-
-    def scaled(self, text: str, scale: int) -> str:
-        """
-        Scale ``text`` using the text sizing protocol with auto-calculatwidth.
-
-        This is the most common use case: render ``text`` at ``scale``
-        times its natural size. Returns ``text`` unchanged when the
-        terminal does not support text sizing.
-
-        :arg str text: Text payload.
-        :arg int scale: Scale factor (1 to 7).
-        :rtype: str
-        :returns: Text wrapped in an OSC 66 escape sequence with
-            auto-calculated width, or plain ``text`` on unsupported
-            terminals.
-
-        .. seealso:: `Kitty Text Sizing Protocol
-            <https://sw.kovidgoyal.net/kitty/text-sizing-protocol/>`_
-        """
-        if not self.does_text_sizing():
-            return text
-        params = TextSizingParams(scale=scale)
         return TextSizing(params, text, '\x07').make_sequence()
 
     def truncate(self, text: str, width: Optional[SupportsIndex] = None) -> str:

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -3321,7 +3321,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
                              f"got ESC (\\x1b) at index {pos_esc}")
 
         if isinstance(vertical_align, int):
-            if -1 < vertical_align > 2:
+            if not (0 <= vertical_align <= 2):
                 raise ValueError(f"'vertical_align' out of range (0-2), got {vertical_align}")
         else:
             mapping_vert = {'top': 0, 'bottom': 1, 'center': 2, 'default': 0}
@@ -3332,7 +3332,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             vertical_align = mapping_vert[vertical_align]
 
         if isinstance(horizontal_align, int):
-            if -1 < horizontal_align > 2:
+            if not (0 <= horizontal_align <= 2):
                 raise ValueError(f"'horizontal_align' out of range (0-2), got {horizontal_align}")
         else:
             mapping_horz = {'left': 0, 'right': 1, 'center': 2, 'default': 0}

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -3229,11 +3229,9 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         :rtype: str
         :returns: String of ``text``, left-aligned by ``width``.
         """
-        # Left justification is different from left alignment, but we continue
-        # the vocabulary error of the str method for polymorphism.
         if width is None:
             width = self.width
-        return wcwidth_ljust(text, width.__index__(), fillchar, control_codes='ignore')
+        return wcwidth_ljust(text, width.__index__(), fillchar)
 
     def rjust(self, text: str, width: Optional[SupportsIndex] = None, fillchar: str = ' ') -> str:
         """
@@ -3248,7 +3246,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         """
         if width is None:
             width = self.width
-        return wcwidth_rjust(text, width.__index__(), fillchar, control_codes='ignore')
+        return wcwidth_rjust(text, width.__index__(), fillchar)
 
     def center(self, text: str, width: Optional[SupportsIndex] = None, fillchar: str = ' ') -> str:
         """
@@ -3263,7 +3261,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         """
         if width is None:
             width = self.width
-        return wcwidth_center(text, width.__index__(), fillchar, control_codes='ignore')
+        return wcwidth_center(text, width.__index__(), fillchar)
 
     @staticmethod
     def _text_sizing_params_str(
@@ -3331,6 +3329,9 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             denominator=denominator, vertical_align=vertical_align,
             horizontal_align=horizontal_align,
         )
+        utf8_len = len(text.encode())
+        if utf8_len > 4096:
+            raise ValueError("'text' must be no longer than 4096 bytes")
         return f'\x1b]66;{params};{text}\x07'
 
     def scaled(self, text: str, scale: int) -> str:
@@ -3355,45 +3356,6 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             return text
         params = self._text_sizing_params_str(scale=scale)
         return f'\x1b]66;{params};{text}\x07'
-
-    # XXX TODO: I think we should cut this ..
-    def heading(
-        self,
-        text: str,
-        scale: int = 2,
-        underline_char: str = '=',
-    ) -> str:
-        r"""
-        Return ``text`` scaled as a heading with a correctly-sized underline.
-
-        When text sizing is supported, the heading is rendered at ``scale`` times its natural size
-        (2x by default), followed by a newline and an underline of the correct measured width.
-
-        When unsupported, returns text plain and underlined.
-
-        :arg str text: Heading text.
-        :arg int scale: Scale factor (1--7). Default is 2.
-        :arg str underline_char: Character for the underline. Default
-            is ``'='``.
-        :rtype: str
-        :returns: Multi-line string: scaled heading + blank lines for
-            multi-row rendering + underline.
-
-        Example::
-
-            >>> term.heading('Chapter One')
-            '\x1b]66;s=2:Chapter One\x07\n\n======================'
-
-        .. seealso:: `Kitty Text Sizing Protocol
-            <https://sw.kovidgoyal.net/kitty/text-sizing-protocol/>`_
-        """
-        sized = self.scaled(text, scale)
-        w = wcwidth_width(sized)
-        lines = sized + '\n'
-        if self.does_text_sizing() and scale > 1:
-            lines += '\n' * (scale - 1)
-        lines += underline_char * w
-        return lines
 
     def truncate(self, text: str, width: Optional[SupportsIndex] = None) -> str:
         r"""

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -864,14 +864,14 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         :arg float timeout: Return after time elapsed in seconds with value ``(-1, -1)`` indicating
             that the remote end did not respond.
         :rtype: tuple
-        :returns: cursor position as tuple in form of ``(y, x)``.  When a timeout is specified,
-            always ensure the return value is checked for ``(-1, -1)``.
+        :returns: cursor position as tuple in form of ``(y, x)``.  Always ensure the return value is
+            checked for ``(-1, -1)``.
 
-        The location of the cursor is determined by emitting the ``u7`` terminal capability, or
+        The location of the cursor is determined by emitting the ``u7`` terminal capability for the
         VT100 `Query Cursor Position
-        <https://www2.ccs.neu.edu/research/gpc/VonaUtils/vona/terminal/vtansi.htm#status>`_
-        when such capability is undefined, which elicits a response from a reply string described by
-        capability ``u6``, or again VT100's definition of ``\x1b[%i%d;%dR`` when undefined.
+        <https://www2.ccs.neu.edu/research/gpc/VonaUtils/vona/terminal/vtansi.htm#status>`_.
+        This elicits a response from a reply string described by capability ``u6`` for the VT100
+        response.
 
         The ``(y, x)`` return value matches the parameter order of the :meth:`move_yx` capability.
         The following sequence should cause the cursor to not move at all::
@@ -889,24 +889,21 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             >>> assert given_x == result_x, (given_x, result_x)
             >>> assert given_y == result_y, (given_y, result_y)
         """
-        # Local lines attached by termios and remote login protocols such as
-        # ssh and telnet both provide a means to determine the window
-        # dimensions of a connected client, but **no means to determine the
-        # location of the cursor**.
+        # Local lines attached by termios and remote login protocols such as ssh and telnet both
+        # provide a means to determine the window dimensions of a connected client, but **no means
+        # to determine the location of the cursor**.
         #
         # from https://invisible-island.net/ncurses/terminfo.src.html,
         #
-        # > The System V Release 4 and XPG4 terminfo format defines ten string
-        # > capabilities for use by applications, <u0>...<u9>.   In this file,
-        # > we use certain of these capabilities to describe functions which
-        # > are not covered by terminfo.  The mapping is as follows:
+        # > The System V Release 4 and XPG4 terminfo format defines ten string capabilities for
+        # > use by applications, <u0>...<u9>.   In this file, we use certain of these capabilities
+        # > to describe functions which are not covered by terminfo.  The mapping is as follows:
         # >
         # >  u9   terminal enquire string (equiv. to ANSI/ECMA-48 DA)
         # >  u8   terminal answerback description
         # >  u7   cursor position request (equiv. to VT100/ANSI/ECMA-48 DSR 6)
         # >  u6   cursor position report (equiv. to ANSI/ECMA-48 CPR)
 
-        response_str = getattr(self, self.caps['cursor_report'].attribute) or '\x1b[%i%d;%dR'
         match = self._query_response(
             self.u7 or '\x1b[6n', self.caps['cursor_report'].re_compiled, timeout)
 
@@ -914,21 +911,19 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             # return matching sequence response, the cursor location.
             row, col = (int(val) for val in match.groups())
 
-            # Per https://invisible-island.net/ncurses/terminfo.src.html
-            # The cursor position report (<u6>) string must contain two
-            # scanf(3)-style %d format elements.  The first of these must
-            # correspond to the Y coordinate and the second to the %d.
-            # If the string contains the sequence %i, it is taken as an
-            # instruction to decrement each value after reading it (this is
-            # the inverse sense from the cup string).
+            # Per https://invisible-island.net/ncurses/terminfo.src.html The cursor position report
+            # (<u6>) string must contain two scanf(3)-style %d format elements.  The first of these
+            # must correspond to the Y coordinate and the second to the %d.  If the string contains
+            # the sequence %i, it is taken as an instruction to decrement each value after reading
+            # it (this is the inverse sense from the cup string).
+            response_str = getattr(self, self.caps['cursor_report'].attribute) or '\x1b[%i%d;%dR'
             if '%i' in response_str:
                 row -= 1
                 col -= 1
             return row, col
 
-        # We chose to return an illegal value rather than an exception,
-        # favoring that users author function filters, such as max(0, y),
-        # rather than crowbarring such logic into an exception handler.
+        # Return an illegal value (-1) rather than a custom exception, developers should
+        # check or filters, such as if (x, y) != (-1, -1) or max(0, y).
         return -1, -1
 
     def get_fgcolor(self, timeout: float = 1, bits: int = 16) -> Tuple[int, int, int]:
@@ -2123,7 +2118,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
         Responses are cached unless *force* is True.
 
-        :arg float timeout: Timeout in seconds for each CPR query.
+        :arg float timeout: Timeout in seconds for each cursor position query.
         :arg bool force: Bypass cached result.
         :rtype: TextSizingResult
         :returns: Result with ``.width`` and ``.scale`` boolean attributes.
@@ -2143,6 +2138,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         _, col1 = self.get_location(timeout)
         if col1 == -1:
             return TextSizingResult()
+        does_width = col1 - col0 == 2
 
         # scale test
         self.stream.write('\x1b]66;s=2; \x07')
@@ -2150,10 +2146,15 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         _, col2 = self.get_location(timeout)
         if col2 == -1:
             return TextSizingResult()
+        does_scale = col2 - col1 == 2
 
-        width = col1 - col0 == 2
-        scale = col2 - col1 == 2
-        result = TextSizingResult(width=width, scale=scale)
+        # erase over any intermediary output, even though we used ' ', we need to draw a ' ' over
+        # the scale=2 ' ', otherwise kitty will favor the scaled ' ' over any text of the next row,
+        # causing surprising effect of 'drawing under'.
+        _movement = max(0, col2 - col0)
+        self.stream.write('\b' * _movement + ' ' * _movement + '\b' * _movement)
+        self.stream.flush()
+        result = TextSizingResult(width=does_width, scale=does_scale)
         self._text_sizing_cache = result
         return result
 
@@ -2299,7 +2300,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
         :arg int | DecPrivateMode modes: One or more DEC Private Modes to enable
 
-        Emits the DECSET sequence to the attached stream as a side-effect, to
+        Emits the DECSET sequence to the attached stream as a side effect, to
         enable the specified modes, and cache their known state as 'SET'
         (enabled) for subsequent :meth:`get_dec_mode` queries.
 
@@ -2339,7 +2340,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
         :arg int | DecPrivateMode modes: One or more DEC Private Modes to disable
 
-        Emits the DECRST sequence to the attached stream as a side-effect, to
+        Emits the DECRST sequence to the attached stream as a side effect, to
         enable the specified modes, and cache their known state as 'RESET'
         (disabled) for subsequent :meth:`get_dec_mode` queries.
 
@@ -3272,8 +3273,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         width: int = 0,
         numerator: int = 0,
         denominator: int = 0,
-        vertical_align: int = 0,
-        horizontal_align: int = 0,
+        vertical_align: Union[int, str] = 0,
+        horizontal_align: Union[int, str] = 0,
     ) -> str:
         """
         Wrap ``text`` in a text sizing escape sequence (OSC 66).
@@ -3282,32 +3283,72 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         graceful degradation.
 
         :arg str text: Text payload.
-        :arg int scale: Scale factor (1--7).
-        :arg int width: Width in cells (0--7). 0 means auto-calculate
+        :arg int scale: Scale factor (1 to 7).
+        :arg int width: Width in cells (0 to 7). 0 means auto-calculate
             from the inner text.
-        :arg int numerator: Fractional scaling numerator (0--15).
-        :arg int denominator: Fractional scaling denominator (0--15).
-        :arg int vertical_align: Vertical alignment (0=top, 1=bottom, 2=center).
-        :arg int horizontal_align: Horizontal alignment (0=left, 1=right, 2=center).
+        :arg int numerator: Fractional scaling numerator (0 to 15).
+        :arg int denominator: Fractional scaling denominator (0 to 15).
+        :arg vertical_align: Vertical alignment: ('top', 'bottom', 'center'), or protocol code
+            (0=top, 1=bottom, 2=center).
+        :arg horizontal_align: Horizontal alignment. ('left', 'right', 'center') or protocol code
+            (0=left, 1=right, 2=center).
         :rtype: str
         :returns: Text wrapped in an OSC 66 escape sequence, or plain
             ``text`` on unsupported terminals.
         :raises ValueError: when the encoded ``text`` exceeds 4096 bytes.
+        :raises ValueError: when ``vertical_align`` or ``horizontal_align`` is an
+            unrecognized string value.
 
         .. seealso:: `Kitty Text Sizing Protocol
             <https://sw.kovidgoyal.net/kitty/text-sizing-protocol/>`_
+
+        .. note:: Because the first call to :meth:`Terminal.text_sized` will cause the side effect
+            of writing destructive spaces to the columns and row following the current cursor
+            position as required for detection of `kitty text sizing protocol`_, it is suggested
+            to first call :meth:`Terminal.does_text_sizing` during program initialization.
+
+            The result is permanently cached and all further calls to these methods return
+            immediately without this side effect.
         """
-        if not self.does_text_sizing():
-            return text
-        # Specification is pretty exact -- text must be utf-8 and no more than 4096 bytes.  Although
-        # we do not enforce utf-8, we do enforce 4096 of encoded bytes and assume utf-8, because any
-        # terminal where does_test_size() is True is presumed utf-8, anyway.
-        utf8_len = len(text.encode())
+        # validation,
+        utf8_len = len(text.encode('utf-8'))
         if utf8_len > 4096:
             raise ValueError(f"'text' must be no longer than 4096 bytes, got {utf8_len}")
+
+        pos_esc = text.find('\x1b')
+        if pos_esc >= 0:
+            raise ValueError("'text' must not contain control codes or terminal sequences, "
+                             f"got ESC (\\x1b) at index {pos_esc}")
+
+        if isinstance(vertical_align, int):
+            if -1 < vertical_align > 2:
+                raise ValueError(f"'vertical_align' out of range (0-2), got {vertical_align}")
+        else:
+            mapping_vert = {'top': 0, 'bottom': 1, 'center': 2, 'default': 0}
+            if vertical_align not in mapping_vert:
+                expected_vert = ', '.join(mapping_vert)
+                raise ValueError(f"'vertical_align' invalid, expected: {expected_vert}, "
+                                 f"got {vertical_align}")
+            vertical_align = mapping_vert[vertical_align]
+
+        if isinstance(horizontal_align, int):
+            if -1 < horizontal_align > 2:
+                raise ValueError(f"'horizontal_align' out of range (0-2), got {horizontal_align}")
+        else:
+            mapping_horz = {'left': 0, 'right': 1, 'center': 2, 'default': 0}
+            if horizontal_align not in mapping_horz:
+                expected_horz = ', '.join(mapping_horz)
+                raise ValueError(f"'horizontal_align' invalid, expected: {expected_horz}, "
+                                 f"got {horizontal_align}")
+            horizontal_align = mapping_horz[horizontal_align]
+
         params = TextSizingParams(scale=scale, width=width, numerator=numerator,
                                   denominator=denominator, vertical_align=vertical_align,
                                   horizontal_align=horizontal_align)
+
+        if not self.does_text_sizing():
+            # return text as-is when unsupported
+            return text
         return TextSizing(params, text, '\x07').make_sequence()
 
     def truncate(self, text: str, width: Optional[SupportsIndex] = None) -> str:

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -3321,7 +3321,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
                              f"got ESC (\\x1b) at index {pos_esc}")
 
         if isinstance(vertical_align, int):
-            if not (0 <= vertical_align <= 2):
+            if not 0 <= vertical_align <= 2:
                 raise ValueError(f"'vertical_align' out of range (0-2), got {vertical_align}")
         else:
             mapping_vert = {'top': 0, 'bottom': 1, 'center': 2, 'default': 0}
@@ -3332,7 +3332,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             vertical_align = mapping_vert[vertical_align]
 
         if isinstance(horizontal_align, int):
-            if not (0 <= horizontal_align <= 2):
+            if not 0 <= horizontal_align <= 2:
                 raise ValueError(f"'horizontal_align' out of range (0-2), got {horizontal_align}")
         else:
             mapping_horz = {'left': 0, 'right': 1, 'center': 2, 'default': 0}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,7 +127,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
-# unit titles (such as .. function::).
+# unit titles (such as '.. function::').
 add_module_names = False
 
 # If true, sectionauthor and moduleauthor directives will be shown in the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,7 +82,7 @@ extensions = ['sphinx.ext.autodoc',
 templates_path = ['_templates']
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = {'.rst': 'restructuredtext'}
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -219,16 +219,23 @@ https://github.com/jquast/blessed/blob/master/bin/scroll_region.py
 This program demonstrates the :meth:`~.Terminal.scroll_region` context manager to create a
 scrollable area with a fixed header and status bar.
 
+.. _text_sizing_protocol.py:
+
 text_sizing_protocol.py
 -----------------------
+
+https://github.com/jquast/blessed/blob/master/bin/text_sizing_protocol.py
 
 This program demonstrates the various uses of :meth:`~.Terminal.text_sized`, the ``OSC 66``
 `kitty text sizing protocol <https://sw.kovidgoyal.net/kitty/text-sizing-protocol/>`_.
 
 .. figure:: https://dxtz6bzwq9sxx.cloudfront.net/blessed_text_sizing_demo.png
 
+.. _scroller.py:
+
 scroller.py
------------------------
+-----------
+https://github.com/jquast/blessed/blob/master/bin/scroller.py
 
 .. figure:: https://dxtz6bzwq9sxx.cloudfront.net/blessed_text_sizing.gif
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -218,3 +218,19 @@ https://github.com/jquast/blessed/blob/master/bin/scroll_region.py
 
 This program demonstrates the :meth:`~.Terminal.scroll_region` context manager to create a
 scrollable area with a fixed header and status bar.
+
+text_sizing_protocol.py
+-----------------------
+
+This program demonstrates the various uses of :meth:`~.Terminal.text_sized`, the ``OSC 66``
+`kitty text sizing protocol <https://sw.kovidgoyal.net/kitty/text-sizing-protocol/>`_.
+
+.. figure:: https://dxtz6bzwq9sxx.cloudfront.net/blessed_text_sizing_demo.png
+
+scroller.py
+-----------------------
+
+.. figure:: https://dxtz6bzwq9sxx.cloudfront.net/blessed_text_sizing.gif
+
+A classic sine-wave "demoscene" text scroller effect that uses :meth:`~.Terminal.text_sized`, the
+``OSC 66`` `kitty text sizing protocol <https://sw.kovidgoyal.net/kitty/text-sizing-protocol/>`_.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -15,6 +15,9 @@ Version History
     return the decoded cursor coordinates.  :ghpull:`369`.
   * improved: :meth:`~.Terminal.inkey` raises :exc:`EOFError` when keyboard fd is at EOF, rather
     than returning an empty :class:`~.Keystroke`.  :ghpull:`371`.
+  * improved: :meth:`~.Terminal.ljust`, :meth:`~.Terminal.rjust`, and :meth:`~.Terminal.center`
+    now measure text containing hyperlinks, Kitty text sizing protocol sequences, and overtyping
+    (backspace/cursor-left with painter's algorithm) introduced in wcwidth 0.7.0.
 
 1.38
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,19 @@
 Version History
 ===============
 
+1.39
+
+  * introduced: :meth:`~.Terminal.text_sized` -- wrap text in Kitty text sizing protocol (OSC 66)
+    escape sequences, with graceful fallback to plain text when the terminal does not support
+    the protocol.
+  * introduced: :class:`~.Keystroke` of name ``CPR_RESPONSE`` for asynchronous capture of Cursor
+    Position Report responses via :meth:`~.Terminal.inkey`.  New argument
+    ``capture_cpr=True`` resolves the legacy F3 key ambiguity and matches against
+    ``CPR_RESPONSE``.  New properties :attr:`~.Keystroke.cpr_yx` and :attr:`~.Keystroke.cpr_xy`
+    return the decoded cursor coordinates.  :ghpull:`369`.
+  * improved: :meth:`~.Terminal.inkey` raises :exc:`EOFError` when keyboard fd is at EOF, rather
+    than returning an empty :class:`~.Keystroke`.  :ghpull:`371`.
+
 1.38
 
   * introduced: :meth:`~.Terminal.does_osc52_clipboard`, :meth:`~.Terminal.clipboard_copy`, and

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -113,6 +113,8 @@ the same above with the same API, as well as following **enhancements**:
   respectively.
 * Allows sequences to be removed from strings that contain them, using `Terminal.strip_seqs()`_ or
   sequences and whitespace using `Terminal.strip()`_.
+* Per-character text sizing using the `kitty text sizing protocol`_, via `Terminal.text_sized()`_
+  and `Terminal.does_text_sizing()`_.
 
 Before And After
 ----------------
@@ -190,6 +192,8 @@ The same program with *Blessed* is simply:
 .. _`Terminal.cbreak()`: https://blessed.readthedocs.io/en/stable/api/terminal.html#blessed.terminal.Terminal.cbreak
 .. _`Terminal.raw()`: https://blessed.readthedocs.io/en/stable/api/terminal.html#blessed.terminal.Terminal.raw
 .. _`Terminal.inkey()`: https://blessed.readthedocs.io/en/stable/api/terminal.html#blessed.terminal.Terminal.inkey
+.. _`Terminal.text_sized()`: https://blessed.readthedocs.io/en/stable/api/terminal.html#blessed.terminal.Terminal.text_sized
+.. _`Terminal.does_text_sizing()`: https://blessed.readthedocs.io/en/stable/api/terminal.html#blessed.terminal.Terminal.does_text_sizing
 .. _Colors: https://blessed.readthedocs.io/en/stable/colors.html
 .. _Styles: https://blessed.readthedocs.io/en/stable/terminal.html#styles
 .. _Location: https://blessed.readthedocs.io/en/stable/location.html
@@ -207,6 +211,7 @@ The same program with *Blessed* is simply:
 .. _Enlighten: https://github.com/Rockhopper-Technologies/enlighten
 .. _macht: https://github.com/rolfmorel/macht
 .. _f-strings: https://docs.python.org/3/reference/lexical_analysis.html#f-strings
+.. _kitty text sizing protocol: https://sw.kovidgoyal.net/kitty/text-sizing-protocol/
 .. |pypi_downloads| image:: https://img.shields.io/pypi/dm/blessed.svg?logo=pypi
     :alt: Downloads
     :target: https://pypi.org/project/blessed/

--- a/docs/line_editor.rst
+++ b/docs/line_editor.rst
@@ -25,7 +25,7 @@ Feed keystrokes (from :meth:`~.Terminal.inkey` or :meth:`~.Terminal.async_inkey`
 :class:`~blessed.line_editor.LineEditResult` with these fields:
 
 - ``line`` the accepted string when Enter is pressed, otherwise ``None``.
-- ``interrupt`` / ``eof`` — ``True`` on Ctrl+C / Ctrl+D respectively.
+- ``interrupt``, ``eof``: ``True`` on Ctrl+C / Ctrl+D respectively.
 - ``changed`` ``True`` when the display needs redrawing.
 - ``bell`` a bell string to emit (empty when silent).
 

--- a/docs/line_editor.rst
+++ b/docs/line_editor.rst
@@ -84,7 +84,7 @@ Rendering Helpers
 build complete escape-sequence strings from the current display state:
 
 :meth:`~blessed.line_editor.LineEditor.render`
-   Full redraw — always produces correct output.
+   Full redraw, always produces correct output.
 
 :meth:`~blessed.line_editor.LineEditor.render_insert`
    Fast-path after a character insert at end of buffer.  Returns ``None``

--- a/docs/line_editor.rst
+++ b/docs/line_editor.rst
@@ -9,7 +9,7 @@ movement, auto-suggest from history, password masking, and horizontal scrolling.
 
 .. note::
 
-   The editor never writes to the terminal directly — your application
+   The editor never writes to the terminal directly, your application
    controls when and where output appears.
 
    Use the built-in :ref:`render methods <line_editor_render>` to produce
@@ -24,10 +24,10 @@ Feed keystrokes (from :meth:`~.Terminal.inkey` or :meth:`~.Terminal.async_inkey`
 :meth:`~blessed.line_editor.LineEditor.feed_key`.  It returns a
 :class:`~blessed.line_editor.LineEditResult` with these fields:
 
-- ``line`` — the accepted string when Enter is pressed, otherwise ``None``
-- ``interrupt`` / ``eof`` — ``True`` on Ctrl+C / Ctrl+D respectively
-- ``changed`` — ``True`` when the display needs redrawing
-- ``bell`` — a bell string to emit (empty when silent)
+- ``line`` the accepted string when Enter is pressed, otherwise ``None``.
+- ``interrupt`` / ``eof`` — ``True`` on Ctrl+C / Ctrl+D respectively.
+- ``changed`` ``True`` when the display needs redrawing.
+- ``bell`` a bell string to emit (empty when silent).
 
 For bracketed paste, feed the pasted text through
 :meth:`~blessed.line_editor.LineEditor.insert_text` instead of

--- a/docs/measuring.rst
+++ b/docs/measuring.rst
@@ -63,7 +63,7 @@ visual width:
 The length measurements of blessed very accurately matches most popular terminals, but not all. The
 python `wcwidth`_ library provides support of complex emojis, CJK, flags, and complex languages, and
 support for unicode may vary by terminal, as discovered by `the results
-<https://ucs-detect.readthedocs.io/results.html>`_ of the `ucs-detect`_ CLI. 
+<https://ucs-detect.readthedocs.io/results.html>`_ of the `ucs-detect`_ CLI.
 
 :meth:`~.Terminal.length` makes a best effort without returning error, even when the cursor position
 is ambiguous, such as text containing ``term.move_x(0)``, or containing vertical movement like

--- a/docs/measuring.rst
+++ b/docs/measuring.rst
@@ -1,18 +1,24 @@
 Sizing & Alignment
 ==================
 
-Any string containing sequences can be measured by blessed using the :meth:`~.Terminal.length`
-method. This means that blessed can measure, right-align, center, truncate, or word-wrap its
-own output!
-
 The :attr:`~.Terminal.height` and :attr:`~.Terminal.width` properties always provide a current
 readout of the size of the window in character cells:
+
+.. code-block:: python
+
+    from blessed import Terminal
+    term = Terminal()
 
     >>> term.height, term.width
     (34, 102)
 
 The :attr:`~.Terminal.pixel_height` and :attr:`~.Terminal.pixel_width` properties provide the
 window size in pixels when available:
+
+.. code-block:: python
+
+    from blessed import Terminal
+    term = Terminal()
 
     >>> term.pixel_height, term.pixel_width
     (1080, 1920)
@@ -22,6 +28,61 @@ window size in pixels when available:
    For sixel graphics, use :meth:`~.Terminal.get_sixel_height_and_width` instead,
    which returns the actual drawable area by accounting for margins. See
    :doc:`sixel` for details.
+
+Length
+------
+
+Any string **containing sequences** can be measured using :meth:`~.Terminal.length`.
+
+This means that blessed can measure, right-align, center, truncate, or word-wrap its own output!
+Text containing colors and styling, hyperlinks, or text sizing protocol are measured for their
+visual width:
+
+.. code-block:: python
+
+    from blessed import Terminal
+    term = Terminal()
+
+    >>> print(term.length(term.bold_blue('123')))
+    3
+    >>> print(term.length('abc\b\b\bxyz'))
+    3
+    >>> print(term.length(term.text_sized('BIG', scale=3)))
+    9
+    >>> print(term.length(term.link('http://example.com', 'link')))
+    4
+    >> phrase = (
+        "\u26F9"        # PERSON WITH BALL
+        "\U0001F3FB"    # EMOJI MODIFIER FITZPATRICK TYPE-1-2
+        "\u200D"        # ZERO WIDTH JOINER
+        "\u2640"        # FEMALE SIGN
+        "\uFE0F")       # VARIATION SELECTOR-16
+    >> print(term.length(phrase))
+    2
+
+The length measurements of blessed very accurately matches most popular terminals, but not all. The
+python `wcwidth`_ library provides support of complex emojis, CJK, flags, and complex languages, and
+support for unicode may vary by terminal, as discovered by `the results
+<https://ucs-detect.readthedocs.io/results.html>`_ of the `ucs-detect`_ CLI. 
+
+:meth:`~.Terminal.length` makes a best effort without returning error, even when the cursor position
+is ambiguous, such as text containing ``term.move_x(0)``, or containing vertical movement like
+``'\n'`` or ``term.move_up(99)``, the text is assumed for display on the first column and vertical
+sequences are ignored. Carriage return, ``'\r'`` is treated like ``term.move_x(0)``:
+
+.. code-block:: python
+
+    from blessed import Terminal
+    term = Terminal()
+
+    >>> print(term.length('abc' + term.move_x(0) + 'xyz'))
+    3
+    >>> print(term.length('abc' + term.move_up(99) + 'xyz'))
+    6
+    >>> print(term.length('abc' + '\r' + 'xyz'))
+    3
+    >>> print(term.length('abc' + '\n' + 'xyz'))
+    6
 
 Alignment
 ---------
@@ -33,6 +94,9 @@ contain sequences.
 
 .. code-block:: python
 
+    from blessed import Terminal
+    term = Terminal()
+
     with term.location(y=term.height // 2):
         print(term.center(term.bold('press return to begin!')))
         term.inkey()
@@ -42,7 +106,6 @@ In the following example, :meth:`~Terminal.wrap` word-wraps a short poem contain
 .. code-block:: python
 
     from blessed import Terminal
-
     term = Terminal()
 
     poem = (term.bold_cyan('Plan difficult tasks'),
@@ -52,6 +115,47 @@ In the following example, :meth:`~Terminal.wrap` word-wraps a short poem contain
 
     for line in poem:
         print('\n'.join(term.wrap(line, width=25, subsequent_indent=' ' * 4)))
+
+Text Sizing
+-----------
+
+The :meth:`~.Terminal.text_sized` method wraps text in an ``OSC 66`` escape sequence for
+terminals that support the `kitty text sizing protocol`_. This enables per-character control
+over cell footprint, fractional font scaling, and alignment:
+
+.. code-block:: python
+
+    from blessed import Terminal
+    term = Terminal()
+
+    # 'scale' is great for printing large headings
+    _scale = 3
+    heading = term.text_sized('Big text', scale=_scale)
+    print(heading + ('\n' * (_scale)) + '=' * term.length(heading))
+
+    # fractional scaling is great for superscript and subscript
+    print('2' + term.text_sized('128', width=1, numerator=1, denominator=3))
+
+    # text sizing sequences can bookended or wrapped by any other sequence,
+    footnote_txt = term.text_sized('[2]', width=2, numerator=2, denominator=3, vertical_align='top')
+    footnote_hlink = term.link('https://sw.kovidgoyal.net/kitty/text-sizing-protocol/', footnote_txt)
+    print('Text sizing protocol' + footnote_hlink)
+
+    # and it may also be aligned
+    print(term.center(term.reverse_yellow(term.text_sized('Big Yellow', scale=2, vertical_align='bottom'))))
+
+.. figure:: https://dxtz6bzwq9sxx.cloudfront.net/blessed_text_sizing_repl_output.png
+
+.. note:: Because the first call to :meth:`Terminal.text_sized` will cause the side effect
+    of writing destructive spaces to the columns and row following the current cursor
+    position as required for detection of `kitty text sizing protocol`_, it is suggested
+    to first call :meth:`Terminal.does_text_sizing` during program initialization.
+
+.. seealso::
+
+   :ref:`text_sizing_protocol.py` and :ref:`scroller.py` demonstration programs.
+
+.. _kitty text sizing protocol: https://sw.kovidgoyal.net/kitty/text-sizing-protocol/
 
 Detecting Resize
 ----------------

--- a/docs/measuring.rst
+++ b/docs/measuring.rst
@@ -61,9 +61,10 @@ visual width:
     2
 
 The length measurements of blessed very accurately matches most popular terminals, but not all. The
-python `wcwidth`_ library provides support of complex emojis, CJK, flags, and complex languages, and
-support for unicode may vary by terminal, as discovered by `the results
-<https://ucs-detect.readthedocs.io/results.html>`_ of the `ucs-detect`_ CLI.
+python `wcwidth <https://wcwidth.readthedocs.io/en/latest/intro.html#discrepancies>`_ library
+provides support of complex emojis, CJK, flags, and complex languages, and support for unicode may
+vary by terminal, as discovered by the `results published by ucs-detect
+<https://ucs-detect.readthedocs.io/results.html>`_.
 
 :meth:`~.Terminal.length` makes a best effort without returning error, even when the cursor position
 is ambiguous, such as text containing ``term.move_x(0)``, or containing vertical movement like
@@ -83,6 +84,7 @@ sequences are ignored. Carriage return, ``'\r'`` is treated like ``term.move_x(0
     3
     >>> print(term.length('abc' + '\n' + 'xyz'))
     6
+
 
 Alignment
 ---------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ classifiers = [
     'Typing :: Typed',
 ]
 dependencies = [
-    'wcwidth>=0.6',
+    'wcwidth>=0.7',
     'jinxed>=1.4.0; platform_system == "Windows"',
 ]
 dynamic = ['version']

--- a/tests/test_async_inkey.py
+++ b/tests/test_async_inkey.py
@@ -281,7 +281,7 @@ def test_async_inkey_incomplete_csi_timeout():
             finally:
                 loop.close()
             # partial CSI \x1b[ arrives, loop iterates reading bytes,
-            # then times out on next read — returns empty Keystroke
+            # then times out on next read and returns empty Keystroke
             assert str(ks) == '' or ks.name is not None
             return b'OK'
 

--- a/tests/test_autoresponses.py
+++ b/tests/test_autoresponses.py
@@ -532,6 +532,7 @@ def test_text_sized(supported, kwargs, expected, measured):
 def test_text_sized_ValueError():
     @as_subprocess
     def child():
+        term = _sizing_term(True)
         with pytest.raises(ValueError):
             term.text_sized('X'*4097, scale=2)
 

--- a/tests/test_autoresponses.py
+++ b/tests/test_autoresponses.py
@@ -5,6 +5,11 @@ import io
 # 3rd party
 import pytest
 
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 # local
 from blessed._capabilities import ITerm2Capabilities, TextSizingResult
 from .conftest import IS_WINDOWS
@@ -492,6 +497,44 @@ def test_does_text_sizing_scale_location_timeout():
     output = pty_test(child, parent_func=None,
                       test_name='test_does_text_sizing_scale_location_timeout')
     assert 'OK' in output
+
+
+def test_does_text_sizing_cleanup_side_effect():
+    """does_text_sizing writes cleanup (backspace+space+backspace) to erase probes."""
+    @as_subprocess
+    def child():
+        stream = io.StringIO()
+        term = TestTerminal(stream=stream, force_styling=True)
+        term._is_a_tty = True
+        with mock.patch.object(term, 'get_location', side_effect=[
+            (5, 10),  # initial: col0=10
+            (5, 12),  # after width probe: col1=12
+            (5, 14),  # after scale probe: col2=14
+        ]):
+            result = term.does_text_sizing(timeout=0.1)
+        assert result == TextSizingResult(width=True, scale=True)
+        output = stream.getvalue()
+        # cleanup: _movement=4 backspaces, 4 spaces, 4 backspaces
+        assert '\b' * 4 + ' ' * 4 + '\b' * 4 in output
+
+    child()
+
+
+def test_does_text_sizing_no_cleanup_when_cached():
+    """does_text_sizing does not write probes/cleanup when cached result exists."""
+    @as_subprocess
+    def child():
+        stream = io.StringIO()
+        term = TestTerminal(stream=stream, force_styling=True)
+        term._is_a_tty = True
+        term._text_sizing_cache = TextSizingResult(width=True, scale=True)
+        stream.truncate(0)
+        stream.seek(0)
+        result = term.does_text_sizing()
+        assert result == TextSizingResult(width=True, scale=True)
+        assert stream.getvalue() == ''
+
+    child()
 
 
 def _sizing_term(supported):

--- a/tests/test_autoresponses.py
+++ b/tests/test_autoresponses.py
@@ -492,3 +492,91 @@ def test_does_text_sizing_scale_location_timeout():
     output = pty_test(child, parent_func=None,
                       test_name='test_does_text_sizing_scale_location_timeout')
     assert 'OK' in output
+
+
+@pytest.mark.parametrize('kwargs,expected', [
+    ({}, ''),
+    ({'scale': 2}, 's=2'),
+    ({'width': 3}, 'w=3'),
+    ({'numerator': 1}, 'n=1'),
+    ({'denominator': 2}, 'd=2'),
+    ({'vertical_align': 1}, 'v=1'),
+    ({'horizontal_align': 2}, 'h=2'),
+    ({'scale': 2, 'width': 3, 'numerator': 1, 'denominator': 2,
+      'vertical_align': 1, 'horizontal_align': 2},
+     's=2:w=3:n=1:d=2:v=1:h=2'),
+])
+def test_text_sizing_params_str(kwargs, expected):
+    """_text_sizing_params_str builds colon-separated metadata."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        assert term._text_sizing_params_str(**kwargs) == expected
+    child()
+
+
+def _sizing_term(supported):
+    term = TestTerminal(stream=io.StringIO(), force_styling=True)
+    term._is_a_tty = True
+    term._text_sizing_cache = (
+        TextSizingResult(width=True, scale=True) if supported
+        else TextSizingResult())
+    return term
+
+
+@pytest.mark.parametrize('supported,kwargs,expected,measured', [
+    (False, {'scale': 2}, 'hello', None),
+    (True, {}, '\x1b]66;;hello\x07', 5),
+    (True, {'scale': 2, 'width': 3, 'numerator': 1, 'denominator': 2,
+            'vertical_align': 1, 'horizontal_align': 2},
+     '\x1b]66;s=2:w=3:n=1:d=2:v=1:h=2;hello\x07', 6),
+])
+def test_text_sized(supported, kwargs, expected, measured):
+    """text_sized wraps OSC 66 when supported, returns text as-is otherwise."""
+    @as_subprocess
+    def child():
+        from wcwidth import width as wcwidth_width
+        term = _sizing_term(supported)
+        result = term.text_sized('hello', **kwargs)
+        assert result == expected
+        if measured is not None:
+            assert wcwidth_width(result) == measured
+    child()
+
+
+@pytest.mark.parametrize('supported,expected,measured', [
+    (False, 'hi', None),
+    (True, '\x1b]66;s=3;hi\x07', 6),
+])
+def test_scaled(supported, expected, measured):
+    """scaled wraps OSC 66 when supported, returns text as-is otherwise."""
+    @as_subprocess
+    def child():
+        from wcwidth import width as wcwidth_width
+        term = _sizing_term(supported)
+        result = term.scaled('hi', 3)
+        assert result == expected
+        if measured is not None:
+            assert wcwidth_width(result) == measured
+    child()
+
+
+@pytest.mark.parametrize('supported,kwargs,expected', [
+    (False, {}, 'abc\n==='),
+    (True, {}, '\x1b]66;s=2;abc\x07\n\n======'),
+    (True, {'scale': 1}, '\x1b]66;;abc\x07\n==='),
+    (True, {'scale': 3}, '\x1b]66;s=3;abc\x07\n\n\n========='),
+    (True, {'scale': 2, 'underline_char': '-'}, '\x1b]66;s=2;abc\x07\n\n------'),
+])
+def test_heading(supported, kwargs, expected):
+    """heading scales text and renders a wcwidth-sized underline."""
+    @as_subprocess
+    def child():
+        from wcwidth import width as wcwidth_width
+        term = _sizing_term(supported)
+        result = term.heading('abc', **kwargs)
+        assert result == expected
+        sized = result.split('\n', 1)[0]
+        underline = result.rsplit('\n', 1)[-1]
+        assert len(underline) == wcwidth_width(sized)
+    child()

--- a/tests/test_autoresponses.py
+++ b/tests/test_autoresponses.py
@@ -530,10 +530,11 @@ def test_text_sized(supported, kwargs, expected, measured):
 
 
 def test_text_sized_ValueError():
+    """text_sized raises ValueError for text exceeding 4096 length limit."""
     @as_subprocess
     def child():
         term = _sizing_term(True)
         with pytest.raises(ValueError):
-            term.text_sized('X'*4097, scale=2)
+            term.text_sized('X' * 4097, scale=2)
 
     child()

--- a/tests/test_autoresponses.py
+++ b/tests/test_autoresponses.py
@@ -494,27 +494,6 @@ def test_does_text_sizing_scale_location_timeout():
     assert 'OK' in output
 
 
-@pytest.mark.parametrize('kwargs,expected', [
-    ({}, ''),
-    ({'scale': 2}, 's=2'),
-    ({'width': 3}, 'w=3'),
-    ({'numerator': 1}, 'n=1'),
-    ({'denominator': 2}, 'd=2'),
-    ({'vertical_align': 1}, 'v=1'),
-    ({'horizontal_align': 2}, 'h=2'),
-    ({'scale': 2, 'width': 3, 'numerator': 1, 'denominator': 2,
-      'vertical_align': 1, 'horizontal_align': 2},
-     's=2:w=3:n=1:d=2:v=1:h=2'),
-])
-def test_text_sizing_params_str(kwargs, expected):
-    """_text_sizing_params_str builds colon-separated metadata."""
-    @as_subprocess
-    def child():
-        term = TestTerminal(stream=io.StringIO(), force_styling=True)
-        assert term._text_sizing_params_str(**kwargs) == expected
-    child()
-
-
 def _sizing_term(supported):
     term = TestTerminal(stream=io.StringIO(), force_styling=True)
     term._is_a_tty = True
@@ -525,58 +504,26 @@ def _sizing_term(supported):
 
 
 @pytest.mark.parametrize('supported,kwargs,expected,measured', [
-    (False, {'scale': 2}, 'hello', None),
-    (True, {}, '\x1b]66;;hello\x07', 5),
-    (True, {'scale': 2, 'width': 3, 'numerator': 1, 'denominator': 2,
-            'vertical_align': 1, 'horizontal_align': 2},
-     '\x1b]66;s=2:w=3:n=1:d=2:v=1:h=2;hello\x07', 6),
+    (False, {}, 'abc', len('abc')),
+    (False, {'scale': 2}, 'abc', len('abc')),
+    (True, {'scale': 2}, '\x1b]66;s=2;abc\x07', len('abc') * 2),
+    (True, {}, '\x1b]66;;abc\x07', len('abc')),
+    (True, {
+        'scale': 2, 'width': 3, 'numerator': 1, 'denominator': 2,
+        'vertical_align': 1, 'horizontal_align': 2},
+     '\x1b]66;s=2:w=3:n=1:d=2:v=1:h=2;abc\x07', 6),
+    (True, {'scale': 3}, '\x1b]66;s=3;abc\x07', len('abc') * 3),
+    (True, {'scale': 4}, '\x1b]66;s=4;abc\x07', len('abc') * 4),
+    (True, {'scale': 5}, '\x1b]66;s=5;abc\x07', len('abc') * 5),
+
 ])
 def test_text_sized(supported, kwargs, expected, measured):
-    """text_sized wraps OSC 66 when supported, returns text as-is otherwise."""
+    """text_sized returns OSC 66-wrapped text when supported, as-is otherwise."""
     @as_subprocess
     def child():
         from wcwidth import width as wcwidth_width
         term = _sizing_term(supported)
-        result = term.text_sized('hello', **kwargs)
+        result = term.text_sized('abc', **kwargs)
         assert result == expected
-        if measured is not None:
-            assert wcwidth_width(result) == measured
-    child()
-
-
-@pytest.mark.parametrize('supported,expected,measured', [
-    (False, 'hi', None),
-    (True, '\x1b]66;s=3;hi\x07', 6),
-])
-def test_scaled(supported, expected, measured):
-    """scaled wraps OSC 66 when supported, returns text as-is otherwise."""
-    @as_subprocess
-    def child():
-        from wcwidth import width as wcwidth_width
-        term = _sizing_term(supported)
-        result = term.scaled('hi', 3)
-        assert result == expected
-        if measured is not None:
-            assert wcwidth_width(result) == measured
-    child()
-
-
-@pytest.mark.parametrize('supported,kwargs,expected', [
-    (False, {}, 'abc\n==='),
-    (True, {}, '\x1b]66;s=2;abc\x07\n\n======'),
-    (True, {'scale': 1}, '\x1b]66;;abc\x07\n==='),
-    (True, {'scale': 3}, '\x1b]66;s=3;abc\x07\n\n\n========='),
-    (True, {'scale': 2, 'underline_char': '-'}, '\x1b]66;s=2;abc\x07\n\n------'),
-])
-def test_heading(supported, kwargs, expected):
-    """heading scales text and renders a wcwidth-sized underline."""
-    @as_subprocess
-    def child():
-        from wcwidth import width as wcwidth_width
-        term = _sizing_term(supported)
-        result = term.heading('abc', **kwargs)
-        assert result == expected
-        sized = result.split('\n', 1)[0]
-        underline = result.rsplit('\n', 1)[-1]
-        assert len(underline) == wcwidth_width(sized)
+        assert wcwidth_width(result) == measured
     child()

--- a/tests/test_autoresponses.py
+++ b/tests/test_autoresponses.py
@@ -527,3 +527,12 @@ def test_text_sized(supported, kwargs, expected, measured):
         assert result == expected
         assert wcwidth_width(result) == measured
     child()
+
+
+def test_text_sized_ValueError():
+    @as_subprocess
+    def child():
+        with pytest.raises(ValueError):
+            term.text_sized('X'*4097, scale=2)
+
+    child()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -309,13 +309,6 @@ def test_setupterm_invalid_has_no_styling():
     child()
 
 
-def test_without_dunder():
-    """Ensure dunder does not remain in module (py2x InterruptedError test."""
-    # local
-    import blessed.terminal
-    assert '_' not in dir(blessed.terminal)
-
-
 def test_IOUnsupportedOperation():
     """Ensure stream that throws IOUnsupportedOperation results in non-tty."""
     @as_subprocess

--- a/tests/test_full_keyboard.py
+++ b/tests/test_full_keyboard.py
@@ -331,7 +331,7 @@ def test_keystroke_20ms_cbreak_with_input():
 
 @pytest.mark.skipif(TEST_QUICK, reason="TEST_QUICK specified")
 def test_esc_delay_cbreak_15ms():
-    """esc_delay=0.15 will cause a single ESC (\\x1b) to delay for 15ms"""
+    r"""esc_delay=0.15 will cause a single ESC ('\x1b') to delay for 15ms"""
     def child(term):
         os.write(sys.__stdout__.fileno(), SEMAPHORE)
         with term.cbreak():

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -285,7 +285,8 @@ def test_get_keyboard_codes():
                          # Modifier keys
                          'LEFT_SHIFT', 'LEFT_CONTROL', 'LEFT_ALT', 'LEFT_SUPER',
                          'LEFT_HYPER', 'LEFT_META', 'RIGHT_SHIFT', 'RIGHT_CONTROL',
-                         'RIGHT_ALT', 'RIGHT_SUPER', 'RIGHT_HYPER', 'RIGHT_META')
+                         'RIGHT_ALT', 'RIGHT_SUPER', 'RIGHT_HYPER', 'RIGHT_META',
+                         'CPR_RESPONSE')
     for value, keycode in blessed.keyboard.get_keyboard_codes().items():
         if keycode in exemptions:
             assert value == exemptions[keycode]
@@ -457,6 +458,44 @@ def test_resolve_sequence_order():
     assert ks.is_sequence
     assert ks.mode is None
     assert repr(ks) == "KEY_L"
+
+
+@pytest.mark.parametrize("sequence", [
+    '\x1b[3;4R',
+    '\x1b[2;1R',
+    '\x1b[100;200R',
+    '\x1b[24;80R',
+    '\x1b[10;1R',
+])
+def test_cpr_response(sequence):
+    """CPR response matched as single KEY_CPR_RESPONSE keystroke."""
+    from blessed.keyboard import (resolve_sequence,
+                                  KEY_CPR_RESPONSE, OrderedDict)
+    ks = resolve_sequence(sequence, OrderedDict(), {})
+    assert ks == sequence
+    assert ks.name == 'KEY_CPR_RESPONSE'
+    assert ks.code == KEY_CPR_RESPONSE
+    assert ks.is_sequence
+    assert not ks.uses_keyboard_protocol
+
+
+@pytest.mark.parametrize("sequence,expected_name", [
+    ('\x1b[1;2R', 'KEY_SHIFT_F3'),
+    ('\x1b[0;5R', 'CSI'),
+])
+def test_cpr_response_not_matched(sequence, expected_name):
+    """Row 0 and row 1 are not matched as CPR."""
+    from blessed.keyboard import resolve_sequence, OrderedDict
+    ks = resolve_sequence(sequence, OrderedDict(), {})
+    assert ks.name == expected_name
+
+
+def test_cpr_response_with_trailing_text():
+    """CPR matcher consumes only the CPR sequence."""
+    from blessed.keyboard import resolve_sequence, OrderedDict
+    ks = resolve_sequence('\x1b[5;10Rextra', OrderedDict(), {})
+    assert ks == '\x1b[5;10R'
+    assert ks.name == 'KEY_CPR_RESPONSE'
 
 
 def test_keyboard_prefixes():

--- a/tests/test_length_sequence.py
+++ b/tests/test_length_sequence.py
@@ -280,7 +280,7 @@ def test_sequence_length(all_terms):
         # moving backwards and forwards horizontally must be
         # accounted for as a "length", as <x><move right 10><y>
         # will result in a printed column length of 12 (even
-        # though columns 2-11 are non-destructive space
+        # though columns 2-11 are non-destructive space)
 
         # NOTE: As of wcwidth 0.3.0, length() returns "maximum extent" rather
         # than "effective length after destructive cursor movements". So 'x\b'

--- a/tests/test_software_version.py
+++ b/tests/test_software_version.py
@@ -7,7 +7,7 @@ The XTVERSION query (CSI > q or ESC [ > q) requests the terminal software
 name and version. Supported by modern terminal emulators including xterm,
 mintty, iTerm2, tmux, kitty, WezTerm, foot, and VTE-based terminals.
 
-Terminal response: DCS > | text ST  (ESC P > | text ESC \)
+Terminal response: DCS > | text ST  (ESC P > | text ESC \\)
 
 Text format varies by terminal:
   - XTerm(367)

--- a/tests/test_text_sizing.py
+++ b/tests/test_text_sizing.py
@@ -1,0 +1,191 @@
+"""Tests for Terminal.text_sized()."""
+# std imports
+import io
+
+# 3rd party
+import pytest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+# local
+from .accessories import TestTerminal, as_subprocess
+
+
+def test_string_vertical_align_top():
+    """vertical_align='top' produces no v= key (default 0)."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        with mock.patch.object(term, 'does_text_sizing', return_value=True):
+            result = term.text_sized('Hi', vertical_align='top')
+            assert result.startswith('\x1b]66;')
+            assert result.endswith('\x07')
+            assert 'v=' not in result
+    child()
+
+
+def test_string_vertical_align_bottom():
+    """vertical_align='bottom' produces v=1."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        with mock.patch.object(term, 'does_text_sizing', return_value=True):
+            result = term.text_sized('Hi', vertical_align='bottom')
+            assert 'v=1' in result
+    child()
+
+
+def test_string_vertical_align_center():
+    """vertical_align='center' produces v=2."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        with mock.patch.object(term, 'does_text_sizing', return_value=True):
+            result = term.text_sized('Hi', vertical_align='center')
+            assert 'v=2' in result
+    child()
+
+
+def test_string_horizontal_align_left():
+    """horizontal_align='left' produces no h= key (default 0)."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        with mock.patch.object(term, 'does_text_sizing', return_value=True):
+            result = term.text_sized('Hi', horizontal_align='left')
+            assert 'h=' not in result
+    child()
+
+
+def test_string_horizontal_align_right():
+    """horizontal_align='right' produces h=1."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        with mock.patch.object(term, 'does_text_sizing', return_value=True):
+            result = term.text_sized('Hi', horizontal_align='right')
+            assert 'h=1' in result
+    child()
+
+
+def test_string_horizontal_align_center():
+    """horizontal_align='center' produces h=2."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        with mock.patch.object(term, 'does_text_sizing', return_value=True):
+            result = term.text_sized('Hi', horizontal_align='center')
+            assert 'h=2' in result
+    child()
+
+
+def test_int_align_still_works():
+    """Integer alignment values still work as before."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        with mock.patch.object(term, 'does_text_sizing', return_value=True):
+            result = term.text_sized('Hi', vertical_align=2, horizontal_align=1)
+            assert 'v=2' in result
+            assert 'h=1' in result
+    child()
+
+
+def test_string_vertical_align_default():
+    """vertical_align='default' produces no v= key."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        with mock.patch.object(term, 'does_text_sizing', return_value=True):
+            result = term.text_sized('Hi', vertical_align='default')
+            assert 'v=' not in result
+    child()
+
+
+def test_string_horizontal_align_default():
+    """horizontal_align='default' produces no h= key."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        with mock.patch.object(term, 'does_text_sizing', return_value=True):
+            result = term.text_sized('Hi', horizontal_align='default')
+            assert 'h=' not in result
+    child()
+
+
+@pytest.mark.parametrize('name,value', [
+    ('vertical_align', 'invalid'),
+    ('horizontal_align', 'invalid'),
+    ('vertical_align', 'left'),
+    ('vertical_align', 'right'),
+    ('horizontal_align', 'top'),
+    ('horizontal_align', 'bottom'),
+])
+def test_invalid_string_align_raises_valueerror(name, value):
+    """Invalid string alignment values raise ValueError."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        with mock.patch.object(term, 'does_text_sizing', return_value=True):
+            with pytest.raises(ValueError):
+                term.text_sized('Hi', **{name: value})
+    child()
+
+
+def test_graceful_degradation_without_support():
+    """text_sized returns plain text when does_text_sizing is False."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        with mock.patch.object(term, 'does_text_sizing', return_value=False):
+            assert term.text_sized('Hello') == 'Hello'
+    child()
+
+
+@pytest.mark.parametrize('value', [3, -1, 999])
+def test_vertical_align_int_out_of_range(value):
+    """vertical_align int outside 0--2 raises ValueError."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        with mock.patch.object(term, 'does_text_sizing', return_value=True):
+            with pytest.raises(ValueError):
+                term.text_sized('Hi', vertical_align=value)
+    child()
+
+
+@pytest.mark.parametrize('value', [3, -1, 999])
+def test_horizontal_align_int_out_of_range(value):
+    """horizontal_align int outside 0--2 raises ValueError."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        with mock.patch.object(term, 'does_text_sizing', return_value=True):
+            with pytest.raises(ValueError):
+                term.text_sized('Hi', horizontal_align=value)
+    child()
+
+
+def test_text_with_esc_raises_valueerror():
+    """Text containing ESC raises ValueError."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        with mock.patch.object(term, 'does_text_sizing', return_value=True):
+            with pytest.raises(ValueError):
+                term.text_sized('Hello\x1bWorld')
+    child()
+
+
+def test_text_exactly_4096_bytes():
+    """Text at exactly 4096 UTF-8 bytes does not raise ValueError."""
+    @as_subprocess
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        with mock.patch.object(term, 'does_text_sizing', return_value=True):
+            result = term.text_sized('x' * 4096)
+            assert '\x1b]66;' in result
+    child()

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ commands =
 # docformatter not yet compatible with py314, https://github.com/PyCQA/docformatter/issues/327
 basepython = python3.13
 deps =
-    docformatter>=1.7.7
+    docformatter==1.7.7
     untokenize
 commands =
     docformatter \

--- a/tox.ini
+++ b/tox.ini
@@ -52,10 +52,11 @@ commands =
     autopep8 --in-place  --recursive --aggressive --aggressive blessed/ bin/ tests/
 
 [testenv:docformatter]
-# docformatter not yet compatible with py314, https://github.com/PyCQA/docformatter/issues/327
+# docformatter>=1.7.8 has tokenize.untokenize ValueError regression.
+# Pin to 1.7.7 until fixed upstream.
 basepython = python3.13
 deps =
-    docformatter>=1.7.7
+    docformatter==1.7.7
     untokenize
 commands =
     docformatter \
@@ -69,7 +70,7 @@ commands =
         {toxinidir}/docs/conf.py
 
 [testenv:docformatter_check]
-# docformatter not yet compatible with py314, https://github.com/PyCQA/docformatter/issues/327
+# docformatter>=1.7.8 has tokenize.untokenize ValueError regression.
 basepython = python3.13
 deps =
     docformatter==1.7.7
@@ -185,13 +186,12 @@ commands =
 deps =
     codespell
 commands =
-    codespell --skip="MANIFEST.in,*.pyc,htmlcov,_build,build,*.egg-info" \
+    codespell --skip="MANIFEST.in,*.pyc,htmlcov,_build,build,*.egg-info,typescript" \
               --ignore-words .spelling-ignore-words.txt \
               --uri-ignore-words-list '*' \
               --summary --count
 
 [testenv:format]
-# docformatter not yet compatible with py314
 basepython = python3.13
 deps =
     {[testenv:isort]deps}
@@ -203,7 +203,6 @@ commands =
     {[testenv:autopep8]commands}
 
 [testenv:lint]
-# docformatter not yet compatible with py314
 basepython = python3.14
 deps =
     {[testenv:flake8]deps}


### PR DESCRIPTION
From bin/text_sizing_protocol.py:

<img width="543" height="1158" alt="Screenshot_20260410_185914" src="https://github.com/user-attachments/assets/bef957ea-2823-41a8-a046-6bf78565bbe8" />

From bin/scroller.py:

https://github.com/user-attachments/assets/8d5180a4-820e-4d14-aaff-20f0b80dafcb

