### PR TITLE
CPR_RESPONSE and coordinate capture with inkey(capture_cpr=True)

### DIFF
--- a/bin/cpr-async.py
+++ b/bin/cpr-async.py
@@ -21,7 +21,7 @@ with term.cbreak(), term.fullscreen():
             cpr_last_sent = time.time()
         inp = term.inkey(timeout=0.1, capture_cpr=True)
         print(inp)
-        if inp.name == 'KEY_CPR_RESPONSE':
+        if inp.name == 'CPR_RESPONSE':
             elapsed_ms = (time.time() - cpr_last_sent) * 1000
             msg(term, f'CPR {elapsed_ms:3.2f}ms rtt; yx={inp.cpr_yx}')
         elif inp:

--- a/bin/cpr-async.py
+++ b/bin/cpr-async.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+"""Example of Terminal.inkey(capture_cpr=True)."""
+import blessed, time
+
+term = blessed.Terminal()
+
+def msg(term, txt):
+    ypos = term.height // 2
+    print(term.move_yx(term.height // 2, 0) + term.center(txt))
+
+
+with term.cbreak(), term.fullscreen():
+    print(term.home + term.clear)
+    interval = 0.5
+    cpr_last_sent = time.time() - interval
+    while True:
+        stime = time.time()
+        if stime - cpr_last_sent > interval:
+            print(term.u7 or '\x1b[6n', flush=True, end='')
+            cpr_last_sent = time.time()
+        inp = term.inkey(timeout=0.1, capture_cpr=True)
+        print(inp)
+        if inp.name == 'KEY_CPR_RESPONSE':
+            elapsed_ms = (time.time() - cpr_last_sent) * 1000
+            msg(term, f'CPR {elapsed_ms:3.2f}ms rtt; yx={inp.cpr_yx}')
+        elif inp:
+            msg(term, f"Keystroke: {inp!r} !")

--- a/bin/cpr-async.py
+++ b/bin/cpr-async.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 """Example of Terminal.inkey(capture_cpr=True)."""
-import blessed, time
+import blessed
+import time
 
 term = blessed.Terminal()
 
+
 def msg(term, txt):
-    ypos = term.height // 2
     print(term.move_yx(term.height // 2, 0) + term.center(txt))
 
 

--- a/bin/cpr-every-pos.py
+++ b/bin/cpr-every-pos.py
@@ -78,7 +78,7 @@ def main():
                 cap.capture(term.inkey(timeout=1, capture_cpr=True))
         cap.display()
 
-        # verify number transmitted to coordinates received 
+        # verify number transmitted to coordinates received
         assert len(cap.coords) == term.height * term.width
         # verify all coordinate numbers received are unique
         assert len(cap.coords.keys()) == len(set(cap.coords.keys()))

--- a/bin/cpr-every-pos.py
+++ b/bin/cpr-every-pos.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# Shis script demonstrates that many possible Cursor Position Report
+# sequences are in conflict with vt220 function key F3, eg:
+#
+# KEY_F3 : ['\x1b[1;1R', '\x1b[1;65R']
+# KEY_SHIFT_F3 : ['\x1b[1;2R', '\x1b[1;66R']
+# KEY_ALT_F3 : ['\x1b[1;3R', '\x1b[1;67R']
+#
+# From infocmp:
+#
+#        kf15= '\E[1;2R'.
+#        kf27= '\E[1;5R'.
+#        kf39= '\E[1;6R'.
+#        kf51= '\E[1;3R'.
+#        kf63= '\E[1;4R'.
+#
+# This F3 with modifier input is a bit unique, rarely but sometimes still used by terminal
+# emulators that are "vt220" derived, which they all try to be at heart, we call this
+# "Legacy CSI modifier sequence", CSI_FINAL_CHAR_TO_KEYCODE in blessed/keyboard.py.
+#
+# http://xahlee.info/kbd/vt220_terminal.html
+#
+# These have a special encoding partly because they were special and local to the vt220,
+# "Hold Screen" (F1), Print Screen (F2), Setup(F3), and Break (F5).
+#
+# As written about DEFAULT_SEQUENCE_MIXIN in blessed/keybaord.py, blessed takes an approach of
+# capturing most any kind of keyboard input sequence no matter current TERM type, because many
+# terminals emit sequences not described in their terminfo entries, we take a "catch all" approach.
+# 
+# And so, we must chose between being able to capture coordinates in the KEY_CPR_RESPONSE,
+# or, leave it undescribed and allow 
+# 
+# it's quite a mess!
+# Very few terminals are emit them, mainly because the
+# PF1-PF4 keys on the vt220 perfor, I think F3 is "Setup" key
+# KEY_CPR_RESPONSE is ambigious and in conflict with false key
+# detection of F3 key on the first row
+import blessed
+import blessed.keyboard
+
+term = blessed.Terminal()
+
+
+class CaptureResponses:
+    def __init__(self):
+        self.key_names = dict()
+        self.key_seqs = dict()
+
+    def capture(self, inp):
+        # track unique count of KEY_BY_NAME matches
+        self.key_names[inp.name] = self.key_names.get(inp.name, 0) + 1
+        # track itemized list of sequences matching it
+        self.key_seqs[inp.name] = self.key_seqs.get(inp.name, []) + [str(inp)]
+
+    def display(self):
+        for key in sorted(self.key_names.keys(), key=lambda k: self.key_names[k], reverse=True):
+            count = self.key_names[key]
+            seqs = self.key_seqs[key]
+            txt_seqs = f'{seqs[:10]}..' if len(seqs) > 10 else seqs
+            print(count, key, ':', txt_seqs)
+        ys, xs = [], []
+        for key in self.key_seqs:
+            for seq in self.key_seqs[key]:
+                print(repr(blessed.keyboard._match_cpr_response(seq)))
+
+with term.cbreak():
+    cap = CaptureResponses()
+    cpr = term.u7 or '\x1b[6n'
+    for y in range(0, term.height):
+        for x in range(0, term.width):
+            print(term.move_yx(y, x) + cpr, end='', flush=True)
+            cap.capture(term.inkey(timeout=1))
+    cap.display()

--- a/bin/cpr-every-pos.py
+++ b/bin/cpr-every-pos.py
@@ -52,6 +52,7 @@ class CaptureResponses:
             if count != 1:
                 print(count, ':', coord)
 
+
 def heading(msg):
     print()
     print(msg)
@@ -77,6 +78,7 @@ def main():
                 cap.capture(term.inkey(timeout=1, capture_cpr=True))
         cap.display()
         assert len(cap.coords) == term.height * term.width
+
 
 if __name__ == '__main__':
     main()

--- a/bin/cpr-every-pos.py
+++ b/bin/cpr-every-pos.py
@@ -1,40 +1,25 @@
 #!/usr/bin/env python
-# Shis script demonstrates that many possible Cursor Position Report
-# sequences are in conflict with vt220 function key F3, eg:
+#
+# This script interactively demonstrates the many possible Cursor Position Report sequences that are
+# in conflict with vt220 function key F3, eg:
 #
 # KEY_F3 : ['\x1b[1;1R', '\x1b[1;65R']
 # KEY_SHIFT_F3 : ['\x1b[1;2R', '\x1b[1;66R']
 # KEY_ALT_F3 : ['\x1b[1;3R', '\x1b[1;67R']
 #
-# From infocmp:
-#
-#        kf15= '\E[1;2R'.
-#        kf27= '\E[1;5R'.
-#        kf39= '\E[1;6R'.
-#        kf51= '\E[1;3R'.
-#        kf63= '\E[1;4R'.
-#
-# This F3 with modifier input is a bit unique, rarely but sometimes still used by terminal
-# emulators that are "vt220" derived, which they all try to be at heart, we call this
-# "Legacy CSI modifier sequence", CSI_FINAL_CHAR_TO_KEYCODE in blessed/keyboard.py.
+# The "F3 with modifier" is a bit rare but still common for anything "vt220"-derived, we call this
+# sequence "Legacy CSI modifier", CSI_FINAL_CHAR_TO_KEYCODE in blessed/keyboard.py,
 #
 # http://xahlee.info/kbd/vt220_terminal.html
 #
-# These have a special encoding partly because they were special and local to the vt220,
-# "Hold Screen" (F1), Print Screen (F2), Setup(F3), and Break (F5).
+# These specific keys on a vt220 are encoding partly because they were special and local to the
+# vt220, "Hold Screen" (F1), Print Screen (F2), Setup(F3), and Break (F5) are special keys along
+# with UP, DOWN, HOME, END, and CENTER/BEGIN. Older programs and emulators may still sometimes use
+# this form.
 #
-# As written about DEFAULT_SEQUENCE_MIXIN in blessed/keybaord.py, blessed takes an approach of
-# capturing most any kind of keyboard input sequence no matter current TERM type, because many
-# terminals emit sequences not described in their terminfo entries, we take a "catch all" approach.
-# 
-# And so, we must chose between being able to capture coordinates in the KEY_CPR_RESPONSE,
-# or, leave it undescribed and allow 
-# 
-# it's quite a mess!
-# Very few terminals are emit them, mainly because the
-# PF1-PF4 keys on the vt220 perfor, I think F3 is "Setup" key
-# KEY_CPR_RESPONSE is ambigious and in conflict with false key
-# detection of F3 key on the first row
+# This program runs in two passes, first, using default argument to inkey(capture_cpr=False),
+# then in second pass with capture_cpr=True. In the first case, many "false matches" of
+# KEY_modifier_F3 is matched, and in the second case, only coordinates.
 import blessed
 import blessed.keyboard
 
@@ -44,30 +29,54 @@ term = blessed.Terminal()
 class CaptureResponses:
     def __init__(self):
         self.key_names = dict()
+        self.coords = dict()
         self.key_seqs = dict()
 
     def capture(self, inp):
-        # track unique count of KEY_BY_NAME matches
+        # track count of KEY_BY_NAME
         self.key_names[inp.name] = self.key_names.get(inp.name, 0) + 1
-        # track itemized list of sequences matching it
+        # track count of sequences
         self.key_seqs[inp.name] = self.key_seqs.get(inp.name, []) + [str(inp)]
+        # track count of coordinates
+        self.coords[inp.cpr_yx] = self.coords.get(inp.cpr_yx, 0) + 1
 
     def display(self):
+        # display unique list of key_names
         for key in sorted(self.key_names.keys(), key=lambda k: self.key_names[k], reverse=True):
             count = self.key_names[key]
             seqs = self.key_seqs[key]
             txt_seqs = f'{seqs[:10]}..' if len(seqs) > 10 else seqs
             print(count, key, ':', txt_seqs)
-        ys, xs = [], []
-        for key in self.key_seqs:
-            for seq in self.key_seqs[key]:
-                print(repr(blessed.keyboard._match_cpr_response(seq)))
+        # and, a unique list of coordinates
+        for coord, count in sorted(self.coords.items(), key=lambda kv: kv[1]):
+            if count != 1:
+                print(count, ':', coord)
 
-with term.cbreak():
-    cap = CaptureResponses()
-    cpr = term.u7 or '\x1b[6n'
-    for y in range(0, term.height):
-        for x in range(0, term.width):
-            print(term.move_yx(y, x) + cpr, end='', flush=True)
-            cap.capture(term.inkey(timeout=1))
-    cap.display()
+def heading(msg):
+    print()
+    print(msg)
+    print('=' * len(msg))
+
+
+def main():
+    with term.cbreak():
+        heading("Testing KEY_CPR_RESPONSE vs. Ambiguous vt220")
+        cap = CaptureResponses()
+        cpr = term.u7 or '\x1b[6n'
+        for y in range(0, term.height):
+            for x in range(0, term.width):
+                print(term.move_yx(y, x) + cpr, end='', flush=True)
+                cap.capture(term.inkey(timeout=1))
+        cap.display()
+
+        heading("Testing KEY_CPR_RESPONSE with capture_cpr=True")
+        cap = CaptureResponses()
+        for y in range(0, term.height):
+            for x in range(0, term.width):
+                print(term.move_yx(y, x) + cpr, end='', flush=True)
+                cap.capture(term.inkey(timeout=1, capture_cpr=True))
+        cap.display()
+        assert len(cap.coords) == term.height * term.width
+
+if __name__ == '__main__':
+    main()

--- a/bin/cpr-every-pos.py
+++ b/bin/cpr-every-pos.py
@@ -62,7 +62,7 @@ def heading(msg):
 def main():
     cpr = term.u7 or '\x1b[6n'
     with term.cbreak():
-        heading("Testing KEY_CPR_RESPONSE vs. Ambiguous vt220")
+        heading("Testing CPR_RESPONSE vs. Ambiguous vt220")
         cap = CaptureResponses()
         for y in range(0, term.height):
             for x in range(0, term.width):
@@ -70,7 +70,7 @@ def main():
                 cap.capture(term.inkey(timeout=1))
         cap.display()
 
-        heading("Testing KEY_CPR_RESPONSE with capture_cpr=True")
+        heading("Testing CPR_RESPONSE with capture_cpr=True")
         cap = CaptureResponses()
         for y in range(0, term.height):
             for x in range(0, term.width):

--- a/bin/cpr-every-pos.py
+++ b/bin/cpr-every-pos.py
@@ -1,25 +1,25 @@
 #!/usr/bin/env python
-#
-# This script interactively demonstrates the many possible Cursor Position Report sequences that are
-# in conflict with vt220 function key F3, eg:
-#
-# KEY_F3 : ['\x1b[1;1R', '\x1b[1;65R']
-# KEY_SHIFT_F3 : ['\x1b[1;2R', '\x1b[1;66R']
-# KEY_ALT_F3 : ['\x1b[1;3R', '\x1b[1;67R']
-#
-# The "F3 with modifier" is a bit rare but still common for anything "vt220"-derived, we call this
-# sequence "Legacy CSI modifier", CSI_FINAL_CHAR_TO_KEYCODE in blessed/keyboard.py,
-#
-# http://xahlee.info/kbd/vt220_terminal.html
-#
-# These specific keys on a vt220 are encoding partly because they were special and local to the
-# vt220, "Hold Screen" (F1), Print Screen (F2), Setup(F3), and Break (F5) are special keys along
-# with UP, DOWN, HOME, END, and CENTER/BEGIN. Older programs and emulators may still sometimes use
-# this form.
-#
-# This program runs in two passes, first, using default argument to inkey(capture_cpr=False),
-# then in second pass with capture_cpr=True. In the first case, many "false matches" of
-# KEY_modifier_F3 is matched, and in the second case, only coordinates.
+"""
+This script interactively demonstrates the many possible Cursor Position Report sequences that are
+in conflict with vt220 function key F3, eg:
+
+    KEY_F3 : ['\x1b[1;1R', '\x1b[1;65R']
+    KEY_SHIFT_F3 : ['\x1b[1;2R', '\x1b[1;66R']
+    KEY_ALT_F3 : ['\x1b[1;3R', '\x1b[1;67R']
+
+The "F3 with modifier" is a bit rare but possible for anything "vt220"-derived, blessed
+labels it under "Legacy CSI modifier", CSI_FINAL_CHAR_TO_KEYCODE in blessed/keyboard.py,
+
+See vt220 keyboard, http://xahlee.info/kbd/vt220_terminal.html
+
+"Hold Screen" (F1), Print Screen (F2), Setup(F3), and Break (F5) are special keys along with UP,
+DOWN, HOME, END, and CENTER/BEGIN. Older programs and emulators may still sometimes use this form,
+it's partly why the first few function keys are encoded in so many different forms.
+
+This program runs in two passes, first, using default argument of ``capture_cpr=False`` for
+call to inkey(), then in second pass with ``capture_cpr=True``. In the first case, many "false
+matches" of KEY_modifier_F3 is matched, and in the second case, only coordinates.
+"""
 import blessed
 import blessed.keyboard
 

--- a/bin/cpr-every-pos.py
+++ b/bin/cpr-every-pos.py
@@ -45,8 +45,8 @@ class CaptureResponses:
         for key in sorted(self.key_names.keys(), key=lambda k: self.key_names[k], reverse=True):
             count = self.key_names[key]
             seqs = self.key_seqs[key]
-            txt_seqs = f'{seqs[:10]}..' if len(seqs) > 10 else seqs
-            print(count, key, ':', txt_seqs)
+            txt_seqs = f'{seqs[:6]}…' if len(seqs) > 6 else seqs
+            print(f'{count}x {key}: {txt_seqs}')
         # and, a unique list of coordinates
         for coord, count in sorted(self.coords.items(), key=lambda kv: kv[1]):
             if count != 1:
@@ -60,10 +60,10 @@ def heading(msg):
 
 
 def main():
+    cpr = term.u7 or '\x1b[6n'
     with term.cbreak():
         heading("Testing KEY_CPR_RESPONSE vs. Ambiguous vt220")
         cap = CaptureResponses()
-        cpr = term.u7 or '\x1b[6n'
         for y in range(0, term.height):
             for x in range(0, term.width):
                 print(term.move_yx(y, x) + cpr, end='', flush=True)
@@ -77,7 +77,11 @@ def main():
                 print(term.move_yx(y, x) + cpr, end='', flush=True)
                 cap.capture(term.inkey(timeout=1, capture_cpr=True))
         cap.display()
+
+        # verify number transmitted to coordinates received 
         assert len(cap.coords) == term.height * term.width
+        # verify all coordinate numbers received are unique
+        assert len(cap.coords.keys()) == len(set(cap.coords.keys()))
 
 
 if __name__ == '__main__':

--- a/bin/display-terminalinfo.py
+++ b/bin/display-terminalinfo.py
@@ -206,8 +206,12 @@ def main():
                         value=lflag)
         display_ctl_chars(index=CTLCHAR_INDEX,
                           ctlc=ctlc)
-        print(f'os.ttyname({fd}) => {os.ttyname(fd)}')
-        print(f'os.ctermid() => {os.ttyname(fd)}')
+        try:
+            tty_name = os.ttyname(fd)
+        except OSError as exc:
+            tty_name = f'OSError: {exc}'
+        print(f'os.ttyname({fd}) => {tty_name}')
+        print(f'os.ctermid() => {os.ctermid()}')
 
 
 if __name__ == '__main__':

--- a/bin/keyboard_simple.py
+++ b/bin/keyboard_simple.py
@@ -3,11 +3,5 @@ from blessed import Terminal
 
 term = Terminal()
 with term.cbreak():
-    #print('\033=')
     key = term.inkey()
-    extra = term.flushinp()
-    print(f"You pressed: {key!r} ({str(key)!r}) extra={str(extra)!r}")
-    #print('\033>')
-    key = term.inkey()
-    extra = term.flushinp()
-    print(f"You pressed: {key!r} ({str(key)!r}) extra={str(extra)!r}")
+    print(f"You pressed: {key!r}")

--- a/bin/keyboard_simple.py
+++ b/bin/keyboard_simple.py
@@ -3,5 +3,11 @@ from blessed import Terminal
 
 term = Terminal()
 with term.cbreak():
+    #print('\033=')
     key = term.inkey()
-    print(f"You pressed: {key!r}")
+    extra = term.flushinp()
+    print(f"You pressed: {key!r} ({str(key)!r}) extra={str(extra)!r}")
+    #print('\033>')
+    key = term.inkey()
+    extra = term.flushinp()
+    print(f"You pressed: {key!r} ({str(key)!r}) extra={str(extra)!r}")

--- a/bin/screen-scrape.py
+++ b/bin/screen-scrape.py
@@ -2,16 +2,17 @@
 #
 # Demonstrates silent screen-reading via DECRQCRA (DEC Request Checksum of Rectangular Area).
 #
-# Only mlterm and WezTerm are known to be afflicted by default. This sequence is very useful for
-# automatic testing like with `vttest`, likely used while developing an emulator, but most make the
-# correct choice of using a disabled-by-default compile-time option. iTerm2 makes a runtime prompt
-# that clearly warns, "this allows screen scraping", while ghostty displays 'DECRQCRA' with
-# allow/deny.
+# Only mlterm, WezTerm (fixed in HEAD), and SyncTERM (fixed in HEAD) are known to be afflicted by
+# default. This sequence is very useful for automatic testing like with `vttest`, likely used while
+# developing an emulator, but most make the correct choice of using a disabled-by-default
+# compile-time option. iTerm2 makes a runtime prompt that clearly warns, "this allows screen
+# scraping", while ghostty displays only "DECRQCRA" with an allow/deny.
 #
 # https://vt100.net/docs/vt510-rm/DECRQCRA.html allows to silently read the contents of the visible
 # screen as a "checksum", but we can pre-compute expected checksums for printable ASCII, building a
 # reverse lookup table that recovers the original characters.
 #
+from blessed import Terminal
 import argparse
 import json
 import os
@@ -19,7 +20,8 @@ import re
 import select
 import sys
 
-from blessed import Terminal
+UNKNOWN_CKSUM_RE = re.compile(r"\?0x[0-9A-Fa-f]{4}")
+
 
 DECRQCRA = "\x1b[{pid};1;{r};{c};{r};{c}*y"
 DECCKSR_RE = re.compile(r"\x1bP(\d+)!~([0-9A-Fa-f]{4})\x1b\\")
@@ -172,19 +174,34 @@ def main():
         alt = blast_scrape(term, rows, cols, lookup)
         emit(ALT_SCREEN_OFF)
 
+    normal_clean = UNKNOWN_CKSUM_RE.sub(" ", normal)
+    alt_clean = UNKNOWN_CKSUM_RE.sub(" ", alt)
+
+    # If both screens are identical, the terminal doesn't support
+    # alternate buffer — store only screen 0.
+    if normal_clean == alt_clean:
+        alt_clean = None
+        alt = None
+
     if args.save_json:
         result = {
-            "screen_0": normal,
-            "screen_1": alt,
+            "screen_0": normal_clean,
+            "screen_0_with_unknown_checksums": normal,
             "rows": rows,
             "cols": cols,
         }
+        if alt_clean is not None:
+            result["screen_1"] = alt_clean
+            result["screen_1_with_unknown_checksums"] = alt
         with open(args.save_json, "w", encoding="utf-8") as f:
             json.dump(result, f, indent=2)
     else:
         emit(term.move_yx(start_row, 0) + term.clear_eol)
-        print(f"screen 0: {repr(normal)}")
-        print(f"screen 1: {repr(alt)}")
+        print(f"screen 0: {repr(normal_clean)}")
+        if alt_clean is not None:
+            print(f"screen 1: {repr(alt_clean)}")
+        else:
+            print("screen 1: (same as screen 0, no alternate buffer)")
 
     return 0
 

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -82,7 +82,7 @@ RE_PATTERN_RESIZE = re.compile(r'\x1b\[48;(?P<height_chars>\d+);(?P<width_chars>
 # Row 1 ambiguously matches RE_PATTERN_LEGACY_CSI_MODIFIERS, see 'capture_cpr=True'
 # to prefer matches of KEY_CPR_RESPONSE over KEY_SHIFT_F3 and others.
 RE_PATTERN_CPR = re.compile(
-    r'\x1b\[(?P<row>[1-9]\d*|[1-9]\d+);(?P<column>\d+)R')
+    r'\x1b\[(?P<row>[1-9]\d*|[1-9]\d+);(?P<column>[1-9]\d*|[1-9]\d+)R')
 
 # DEC event pattern container
 DECEventPattern = namedtuple("DECEventPattern", ["mode", "pattern"])

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -79,9 +79,10 @@ RE_PATTERN_FOCUS = re.compile(r'\x1b\[(?P<io>[IO])')
 RE_PATTERN_RESIZE = re.compile(r'\x1b\[48;(?P<height_chars>\d+);(?P<width_chars>\d+)'
                                r';(?P<height_pixels>\d+);(?P<width_pixels>\d+)t')
 # CPR (Cursor Position Report): ESC [ row ; column R
-# Row 1 excluded -- ambiguously matches RE_PATTERN_LEGACY_CSI_MODIFIERS 
+# Row 1 ambiguously matches RE_PATTERN_LEGACY_CSI_MODIFIERS, see 'capture_cpr=True'
+# to prefer matches of cursor position report over KEY_SHIFT_F3 and others
 RE_PATTERN_CPR = re.compile(
-    r'\x1b\[(?P<row>[2-9]\d*|[1-9]\d+);(?P<column>\d+)R')
+    r'\x1b\[(?P<row>[1-9]\d*|[1-9]\d+);(?P<column>\d+)R')
 
 # DEC event pattern container
 DECEventPattern = namedtuple("DECEventPattern", ["mode", "pattern"])
@@ -1131,6 +1132,20 @@ class Keystroke(str):
         return (-1, -1)
 
     @property
+    def cpr_yx(self) -> Tuple[int, int]:
+        """
+        Cursor position as (y, x) tuple for Cursor Position Report
+
+        :rtype: tuple of (int, int)
+        :returns: (y, x) coordinate tuple (0-indexed) for cursor position report,
+            or ``(-1, -1)`` if not a KEY_CPR_RESPONSE
+        """
+        match = RE_PATTERN_CPR.match(self)
+        if match:
+            return match.group(0)
+        return None
+
+    @property
     def text(self) -> Optional[str]:
         """
         Pasted text for bracketed paste events.
@@ -1363,7 +1378,8 @@ def resolve_sequence(text: str,
                      codes: typing.Mapping[int, str],
                      prefixes: Optional[Set[str]] = None,
                      final: bool = False,
-                     dec_mode_cache: Optional[Dict[int, int]] = None) -> Keystroke:
+                     dec_mode_cache: Optional[Dict[int, int]] = None,
+                     capture_cpr: bool = False) -> Keystroke:
     r"""
     Return a single :class:`Keystroke` instance for given sequence ``text``.
 
@@ -1397,14 +1413,18 @@ def resolve_sequence(text: str,
 
     # First try advanced keyboard protocol matchers and DEC events
     ks = None
-    for match_fn in (
-            functools.partial(_match_dec_event, dec_mode_cache=dec_mode_cache),
-            _match_kitty_key,
-            _match_modify_other_keys,
-            _match_cpr_response,
-            _match_legacy_csi_letter_form,
-            _match_legacy_csi_tilde_form,
-            _match_legacy_ss3_fkey_form):
+    match_funcs = [
+        functools.partial(_match_dec_event, dec_mode_cache=dec_mode_cache),
+        _match_kitty_key,
+        _match_modify_other_keys,
+        _match_legacy_csi_letter_form,
+        _match_legacy_csi_tilde_form,
+        _match_legacy_ss3_fkey_form,
+        _match_cpr_response]
+    if capture_cpr:
+        # prioritize capturing KEY_CPR_RESPONSE over legacy CSI Modifiers
+        match_funcs.insert(3, match_funcs.pop())
+    for match_fn in match_func:
         ks = match_fn(text)
         if ks:
             break

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -1134,7 +1134,7 @@ class Keystroke(str):
     @property
     def cpr_yx(self) -> Tuple[int, int]:
         """
-        Cursor position as (y, x) tuple for Cursor Position Report
+        Cursor position as (y, x) tuple for Cursor Position Report.
 
         :rtype: tuple of (int, int)
         :returns: (y, x) coordinate tuple (0-indexed) for cursor position report,
@@ -1148,7 +1148,7 @@ class Keystroke(str):
     @property
     def cpr_xy(self) -> Tuple[int, int]:
         """
-        Cursor position as (x, y) tuple for Cursor Position Report
+        Cursor position as (x, y) tuple for Cursor Position Report.
 
         :rtype: tuple of (int, int)
         :returns: (x, y) coordinate tuple (0-indexed) for cursor position report,
@@ -1405,6 +1405,8 @@ def resolve_sequence(text: str,
     :arg set prefixes: Set of all valid sequence prefixes for quick matching
     :arg bool final: Whether this is the final resolution attempt (no more input expected)
     :arg dict dec_mode_cache: Dictionary of DEC private mode states (mode number -> state value)
+    :arg bool capture_cpr: Prefer matches of ``KEY_CPR_RESPONSE`` over conflicting vt220 Legacy
+        function keys (eg. ``KEY_F3``, ``KEY_SHIFT_F3``).
     :rtype: Keystroke
     :returns: Keystroke instance for the given sequence
 

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -80,7 +80,7 @@ RE_PATTERN_RESIZE = re.compile(r'\x1b\[48;(?P<height_chars>\d+);(?P<width_chars>
                                r';(?P<height_pixels>\d+);(?P<width_pixels>\d+)t')
 # CPR (Cursor Position Report): ESC [ row ; column R
 # Row 1 ambiguously matches RE_PATTERN_LEGACY_CSI_MODIFIERS, see 'capture_cpr=True'
-# to prefer matches of cursor position report over KEY_SHIFT_F3 and others
+# to prefer matches of KEY_CPR_RESPONSE over KEY_SHIFT_F3 and others.
 RE_PATTERN_CPR = re.compile(
     r'\x1b\[(?P<row>[1-9]\d*|[1-9]\d+);(?P<column>\d+)R')
 
@@ -1142,8 +1142,22 @@ class Keystroke(str):
         """
         match = RE_PATTERN_CPR.match(self)
         if match:
-            return match.group(0)
-        return None
+            return (int(match.group(1)) - 1, int(match.group(2)) - 1)
+        return (-1, -1)
+
+    @property
+    def cpr_xy(self) -> Tuple[int, int]:
+        """
+        Cursor position as (x, y) tuple for Cursor Position Report
+
+        :rtype: tuple of (int, int)
+        :returns: (x, y) coordinate tuple (0-indexed) for cursor position report,
+            or ``(-1, -1)`` if not a KEY_CPR_RESPONSE
+        """
+        match = RE_PATTERN_CPR.match(self)
+        if match:
+            return (int(match.group(2)) - 1, int(match.group(1)) - 1)
+        return (-1, -1)
 
     @property
     def text(self) -> Optional[str]:
@@ -1424,7 +1438,7 @@ def resolve_sequence(text: str,
     if capture_cpr:
         # prioritize capturing KEY_CPR_RESPONSE over legacy CSI Modifiers
         match_funcs.insert(3, match_funcs.pop())
-    for match_fn in match_func:
+    for match_fn in match_funcs:
         ks = match_fn(text)
         if ks:
             break

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -80,7 +80,7 @@ RE_PATTERN_RESIZE = re.compile(r'\x1b\[48;(?P<height_chars>\d+);(?P<width_chars>
                                r';(?P<height_pixels>\d+);(?P<width_pixels>\d+)t')
 # CPR (Cursor Position Report): ESC [ row ; column R
 # Row 1 ambiguously matches RE_PATTERN_LEGACY_CSI_MODIFIERS, see 'capture_cpr=True'
-# to prefer matches of KEY_CPR_RESPONSE over KEY_SHIFT_F3 and others.
+# to prefer matches of CPR_RESPONSE over KEY_SHIFT_F3 and others.
 RE_PATTERN_CPR = re.compile(
     r'\x1b\[(?P<row>[1-9]\d*|[1-9]\d+);(?P<column>[1-9]\d*|[1-9]\d+)R')
 
@@ -551,7 +551,7 @@ class Keystroke(str):
 
         For terminal query responses:
 
-        - Cursor position report: 'KEY_CPR_RESPONSE' (row >= 2 only;
+        - Cursor position report: 'CPR_RESPONSE' (row >= 2 only;
           row 1 is ambiguous with F3+modifier)
 
         When non-None, all phrases begin with either 'KEY', 'MOUSE', 'FOCUS_IN', 'FOCUS_OUT',
@@ -1140,7 +1140,7 @@ class Keystroke(str):
 
         :rtype: tuple of (int, int)
         :returns: (y, x) coordinate tuple (0-indexed) for cursor position report,
-            or ``(-1, -1)`` if not a KEY_CPR_RESPONSE
+            or ``(-1, -1)`` if not a CPR_RESPONSE
         """
         match = RE_PATTERN_CPR.match(self)
         if match:
@@ -1154,7 +1154,7 @@ class Keystroke(str):
 
         :rtype: tuple of (int, int)
         :returns: (x, y) coordinate tuple (0-indexed) for cursor position report,
-            or ``(-1, -1)`` if not a KEY_CPR_RESPONSE
+            or ``(-1, -1)`` if not a CPR_RESPONSE
         """
         match = RE_PATTERN_CPR.match(self)
         if match:
@@ -1407,7 +1407,7 @@ def resolve_sequence(text: str,
     :arg set prefixes: Set of all valid sequence prefixes for quick matching
     :arg bool final: Whether this is the final resolution attempt (no more input expected)
     :arg dict dec_mode_cache: Dictionary of DEC private mode states (mode number -> state value)
-    :arg bool capture_cpr: Prefer matches of ``KEY_CPR_RESPONSE`` over conflicting vt220 Legacy
+    :arg bool capture_cpr: Prefer matches of ``CPR_RESPONSE`` over conflicting vt220 Legacy
         function keys (eg. ``KEY_F3``, ``KEY_SHIFT_F3``).
     :rtype: Keystroke
     :returns: Keystroke instance for the given sequence
@@ -1440,7 +1440,7 @@ def resolve_sequence(text: str,
         _match_legacy_ss3_fkey_form,
         _match_cpr_response]
     if capture_cpr:
-        # prioritize capturing KEY_CPR_RESPONSE over legacy CSI Modifiers
+        # prioritize capturing CPR_RESPONSE over legacy CSI Modifiers
         match_funcs.insert(3, match_funcs.pop())
     for match_fn in match_funcs:
         ks = match_fn(text)
@@ -1600,9 +1600,7 @@ def _match_cpr_response(text: str) -> Optional[Keystroke]:
     """
     match = RE_PATTERN_CPR.match(text)
     if match:
-        return Keystroke(ucs=match.group(0),
-                         code=KEY_CPR_RESPONSE,
-                         name='KEY_CPR_RESPONSE')
+        return Keystroke(ucs=match.group(0), name='CPR_RESPONSE')
     return None
 
 
@@ -1786,10 +1784,10 @@ def _match_legacy_ss3_fkey_form(text: str) -> Optional[Keystroke]:
     return Keystroke(ucs=matched_text, code=keycode, mode=-3, match=legacy_event)
 
 
-# We invent a few to fixup for missing keys in curses, these aren't especially
-# required or useful except to survive as API compatibility for the earliest
-# versions of this software. They must be these values in this order, used as
-# constants for equality checks to Keystroke.code.
+# We invent a few to fixup for missing keys in curses, these aren't especially required or useful
+# except to survive as API compatibility for the earliest versions of this software, before
+# "synthesized names" were created. They must be these values in this order, used as constants for
+# equality checks to Keystroke.code.
 KEY_TAB = 512
 KEY_KP_MULTIPLY = 513
 KEY_KP_ADD = 514
@@ -1809,7 +1807,6 @@ KEY_KP_7 = 527
 KEY_KP_8 = 528
 KEY_KP_9 = 529
 KEY_MENU = 530
-KEY_CPR_RESPONSE = 531
 
 # Kitty protocol control character to keycode mapping
 # Maps common control character unicode values to their curses keycodes

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -544,11 +544,13 @@ class Keystroke(str):
         ``'MOUSE_RIGHT_MOTION'``, ``'MOUSE_LEFT_RELEASED'``.
 
         For other DEC events:
+
         - Focus events: 'FOCUS_IN' or 'FOCUS_OUT'
         - Bracketed paste: 'BRACKETED_PASTE'
         - Resize events: 'RESIZE_EVENT'
 
         For terminal query responses:
+
         - Cursor position report: 'KEY_CPR_RESPONSE' (row >= 2 only;
           row 1 is ambiguous with F3+modifier)
 

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -78,6 +78,10 @@ RE_PATTERN_FOCUS = re.compile(r'\x1b\[(?P<io>[IO])')
 # Resize notification (mode 2048): ESC [ 48 ; height ; width ; height_px ; width_px t
 RE_PATTERN_RESIZE = re.compile(r'\x1b\[48;(?P<height_chars>\d+);(?P<width_chars>\d+)'
                                r';(?P<height_pixels>\d+);(?P<width_pixels>\d+)t')
+# CPR (Cursor Position Report): ESC [ row ; column R
+# Row 1 excluded -- ambiguously matches RE_PATTERN_LEGACY_CSI_MODIFIERS 
+RE_PATTERN_CPR = re.compile(
+    r'\x1b\[(?P<row>[2-9]\d*|[1-9]\d+);(?P<column>\d+)R')
 
 # DEC event pattern container
 DECEventPattern = namedtuple("DECEventPattern", ["mode", "pattern"])
@@ -542,6 +546,10 @@ class Keystroke(str):
         - Focus events: 'FOCUS_IN' or 'FOCUS_OUT'
         - Bracketed paste: 'BRACKETED_PASTE'
         - Resize events: 'RESIZE_EVENT'
+
+        For terminal query responses:
+        - Cursor position report: 'KEY_CPR_RESPONSE' (row >= 2 only;
+          row 1 is ambiguous with F3+modifier)
 
         When non-None, all phrases begin with either 'KEY', 'MOUSE', 'FOCUS_IN', 'FOCUS_OUT',
         'BRACKETED_PASTE', or 'RESIZE_EVENT', with one exception: 'CSI' is returned for '\\x1b['
@@ -1393,6 +1401,7 @@ def resolve_sequence(text: str,
             functools.partial(_match_dec_event, dec_mode_cache=dec_mode_cache),
             _match_kitty_key,
             _match_modify_other_keys,
+            _match_cpr_response,
             _match_legacy_csi_letter_form,
             _match_legacy_csi_tilde_form,
             _match_legacy_ss3_fkey_form):
@@ -1536,6 +1545,26 @@ def _match_dec_event(text: str,
         match = pattern.match(text)
         if match:
             return Keystroke(ucs=match.group(0), mode=mode, match=match)
+    return None
+
+
+def _match_cpr_response(text: str) -> Optional[Keystroke]:
+    """
+    Match CPR (Cursor Position Report): ESC [ row ; column R.
+
+    :arg str text: Input text to match against CPR pattern.
+    :rtype: Keystroke or None
+    :returns: :class:`Keystroke` if matched, ``None`` otherwise.
+
+    Matches terminal CPR responses where row >= 2. Row 1 is not
+    matched on input, preferring to match F3 + Modifier in the
+    legacy CSI letter form.
+    """
+    match = RE_PATTERN_CPR.match(text)
+    if match:
+        return Keystroke(ucs=match.group(0),
+                         code=KEY_CPR_RESPONSE,
+                         name='KEY_CPR_RESPONSE')
     return None
 
 
@@ -1742,6 +1771,7 @@ KEY_KP_7 = 527
 KEY_KP_8 = 528
 KEY_KP_9 = 529
 KEY_MENU = 530
+KEY_CPR_RESPONSE = 531
 
 # Kitty protocol control character to keycode mapping
 # Maps common control character unicode values to their curses keycodes

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -3656,6 +3656,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
            `ncurses(3)`_ section labeled *ESCDELAY* for details.  Setting
            the value as an argument to this function will override any
            such preference.
+        :arg bool capture_cpr: Prefer matches of ``KEY_CPR_RESPONSE`` over conflicting vt220 Legacy
+            function keys (eg. ``KEY_F3``, ``KEY_SHIFT_F3``).
         :rtype: :class:`~.Keystroke`.
         :returns: :class:`~.Keystroke`, which may be empty (``''``) if
            ``timeout`` is specified and keystroke is not received.

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -3656,7 +3656,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
            `ncurses(3)`_ section labeled *ESCDELAY* for details.  Setting
            the value as an argument to this function will override any
            such preference.
-        :arg bool capture_cpr: Prefer matches of ``KEY_CPR_RESPONSE`` over conflicting vt220 Legacy
+        :arg bool capture_cpr: Prefer matches of ``CPR_RESPONSE`` over conflicting vt220 Legacy
             function keys (eg. ``KEY_F3``, ``KEY_SHIFT_F3``).
         :rtype: :class:`~.Keystroke`.
         :returns: :class:`~.Keystroke`, which may be empty (``''``) if

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -3636,7 +3636,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
                 any(p.startswith(text) for p in self._keymap_prefixes))
 
     def inkey(self, timeout: Optional[float] = None,
-              esc_delay: float = DEFAULT_ESCDELAY) -> Keystroke:
+              esc_delay: float = DEFAULT_ESCDELAY,
+              capture_cpr: bool = False) -> Keystroke:
         r"""
         Read and return the next keyboard event within given timeout.
 
@@ -3677,7 +3678,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
         # decode buffered keystroke, if any
         ks = resolve_sequence(ucs, self._keymap, self._keycodes, self._keymap_prefixes,
-                              final=False, dec_mode_cache=self._dec_mode_cache)
+                              final=False, dec_mode_cache=self._dec_mode_cache,
+                              capture_cpr=capture_cpr)
 
         # so long as the most immediately received or buffered keystroke is
         # incomplete, (which may be a multibyte encoding), block until until
@@ -3692,7 +3694,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
             # and then resolve for sequence
             ks = resolve_sequence(ucs, self._keymap, self._keycodes, self._keymap_prefixes,
-                                  final=False, dec_mode_cache=self._dec_mode_cache)
+                                  final=False, dec_mode_cache=self._dec_mode_cache,
+                                  capture_cpr=capture_cpr)
 
         # handle escape key (KEY_ESCAPE) vs. escape sequence (like those
         # that begin with \x1b[ or \x1bO) up to esc_delay when
@@ -3716,13 +3719,15 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
                 # re-check 'final' after reading more bytes
                 final = bool(ucs) and not self._is_incomplete_keystroke(ucs)
                 ks = resolve_sequence(ucs, self._keymap, self._keycodes, self._keymap_prefixes,
-                                      final=final, dec_mode_cache=self._dec_mode_cache)
+                                      final=final, dec_mode_cache=self._dec_mode_cache,
+                                      capture_cpr=capture_cpr)
 
             # If we still have KEY_ESCAPE and ucs is a prefix, resolve with final=True
             # to handle unmatched sequences like '\x1b[' (CSI)
             if ks.code == self.KEY_ESCAPE and self._is_incomplete_keystroke(ucs):
                 ks = resolve_sequence(ucs, self._keymap, self._keycodes, self._keymap_prefixes,
-                                      final=True, dec_mode_cache=self._dec_mode_cache)
+                                      final=True, dec_mode_cache=self._dec_mode_cache,
+                                      capture_cpr=capture_cpr)
 
         # buffer any remaining text received
         self.ungetch(ucs[len(ks):])
@@ -3742,6 +3747,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
     async def async_inkey(
         self, timeout: Optional[float] = None,
         esc_delay: float = DEFAULT_ESCDELAY,
+        capture_cpr: bool = False,
     ) -> Keystroke:
         r"""
         Asynchronous version of :meth:`inkey` for use with :mod:`asyncio`.
@@ -3762,6 +3768,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             indefinitely.
         :arg float esc_delay: Time in seconds to wait after Escape key
             is received to disambiguate bare Escape from escape sequences.
+        :arg bool capture_cpr: TODO
         :rtype: :class:`~.Keystroke`
         :returns: :class:`~.Keystroke`, which may be empty (``''``) if
             ``timeout`` is specified and keystroke is not received.
@@ -3775,7 +3782,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         # resolve any buffered keystroke
         ks = resolve_sequence(ucs, self._keymap, self._keycodes,
                               self._keymap_prefixes, final=False,
-                              dec_mode_cache=self._dec_mode_cache)
+                              dec_mode_cache=self._dec_mode_cache,
+                              capture_cpr=capture_cpr)
 
         # read bytes until a complete keystroke is resolved
         while not ks:
@@ -3795,7 +3803,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
             ks = resolve_sequence(ucs, self._keymap, self._keycodes,
                                   self._keymap_prefixes, final=False,
-                                  dec_mode_cache=self._dec_mode_cache)
+                                  dec_mode_cache=self._dec_mode_cache,
+                                  capture_cpr=capture_cpr)
 
         # escape key disambiguation: wait esc_delay for more bytes
         if ks.code == self.KEY_ESCAPE and len(ks) == 1:
@@ -3817,13 +3826,15 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
                 ks = resolve_sequence(
                     ucs, self._keymap, self._keycodes,
                     self._keymap_prefixes, final=final,
-                    dec_mode_cache=self._dec_mode_cache)
+                    dec_mode_cache=self._dec_mode_cache,
+                    capture_cpr=capture_cpr)
 
             if ks.code == self.KEY_ESCAPE and self._is_incomplete_keystroke(ucs):
                 ks = resolve_sequence(
                     ucs, self._keymap, self._keycodes,
                     self._keymap_prefixes, final=True,
-                    dec_mode_cache=self._dec_mode_cache)
+                    dec_mode_cache=self._dec_mode_cache,
+                    capture_cpr=capture_cpr)
 
         # buffer any remaining text
         self.ungetch(ucs[len(ks):])

--- a/docs/location.rst
+++ b/docs/location.rst
@@ -111,6 +111,31 @@ Although this wouldn't be suggested in most applications because of its latency,
 simplifies many applications, and, can also be timed, to make a determination of the round-trip
 time, perhaps even the bandwidth constraints, of a remote terminal!
 
+KEY_CPR_RESPONSE
+----------------
+
+The :meth:`~.Terminal.get_location` method is blocking, sending a cursor position report sequence
+and awaiting the response. It may sometimes be necessary send and capture Cursor Position Report
+responses asynchronously as keyboard input events.
+
+- Print Cursor Position Report sequence, ``term.u7 or '\x1b[6n'``
+- Call :meth:`~Terminal.inkey` with ``capture_cpr=True``
+- When return :attr:`~Keystroke.name` is ``KEY_CPR_RESPONSE``, use the :meth:`~Keystroke.cpr_yx`
+  or :meth:`~Keystroke.cpr_xy` methods to receive the coordinates.
+
+Although :meth:`~Terminal.inkey` is capable of receiving *most* Cursor Position Report (CPR)
+sequences as Keystroke of name ``KEY_CPR_RESPONSE``, Some coordinate responses are in conflict with
+the "F3" key of the DEC vt220, but few very terminals transmit them in this conflicting form. If not
+bound or legacy vt220 key compatibility is not required, but asynchronous receipt of CPR Responses
+with correct coordinates are, use :meth:`~Terminal.inkey` argument ``capture_cpr=True``.
+
+In the following example, keyboard input is rapidly polled for and displayed,
+CPR Sequences are sent at a fixed interval, and the response or round-trip time is displayed.
+
+.. literalinclude:: ../bin/cpr-async.py
+   :language: python
+   :lines: 2-
+
 Scroll Region
 -------------
 

--- a/docs/location.rst
+++ b/docs/location.rst
@@ -111,8 +111,8 @@ Although this wouldn't be suggested in most applications because of its latency,
 simplifies many applications, and, can also be timed, to make a determination of the round-trip
 time, perhaps even the bandwidth constraints, of a remote terminal!
 
-KEY_CPR_RESPONSE
-----------------
+CPR_RESPONSE
+------------
 
 The :meth:`~.Terminal.get_location` method is blocking, sending a cursor position report sequence
 and awaiting the response. It may sometimes be necessary send and capture Cursor Position Report
@@ -120,11 +120,11 @@ responses asynchronously as keyboard input events.
 
 - Print Cursor Position Report sequence, ``term.u7 or '\x1b[6n'``
 - Call :meth:`~Terminal.inkey` with ``capture_cpr=True``
-- When return :attr:`~Keystroke.name` is ``KEY_CPR_RESPONSE``, use the :meth:`~Keystroke.cpr_yx`
+- When return :attr:`~Keystroke.name` is ``CPR_RESPONSE``, use the :meth:`~Keystroke.cpr_yx`
   or :meth:`~Keystroke.cpr_xy` methods to receive the coordinates.
 
 Although :meth:`~Terminal.inkey` is capable of receiving *most* Cursor Position Report (CPR)
-sequences as Keystroke of name ``KEY_CPR_RESPONSE``, Some coordinate responses are in conflict with
+sequences as Keystroke of name ``CPR_RESPONSE``, Some coordinate responses are in conflict with
 the "F3" key of the DEC vt220, but few very terminals transmit them in this conflicting form. If not
 bound or legacy vt220 key compatibility is not required, but asynchronous receipt of CPR Responses
 with correct coordinates are, use :meth:`~Terminal.inkey` argument ``capture_cpr=True``.

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -285,7 +285,8 @@ def test_get_keyboard_codes():
                          # Modifier keys
                          'LEFT_SHIFT', 'LEFT_CONTROL', 'LEFT_ALT', 'LEFT_SUPER',
                          'LEFT_HYPER', 'LEFT_META', 'RIGHT_SHIFT', 'RIGHT_CONTROL',
-                         'RIGHT_ALT', 'RIGHT_SUPER', 'RIGHT_HYPER', 'RIGHT_META')
+                         'RIGHT_ALT', 'RIGHT_SUPER', 'RIGHT_HYPER', 'RIGHT_META',
+                         'CPR_RESPONSE')
     for value, keycode in blessed.keyboard.get_keyboard_codes().items():
         if keycode in exemptions:
             assert value == exemptions[keycode]
@@ -457,6 +458,44 @@ def test_resolve_sequence_order():
     assert ks.is_sequence
     assert ks.mode is None
     assert repr(ks) == "KEY_L"
+
+
+@pytest.mark.parametrize("sequence", [
+    '\x1b[3;4R',
+    '\x1b[2;1R',
+    '\x1b[100;200R',
+    '\x1b[24;80R',
+    '\x1b[10;1R',
+])
+def test_cpr_response(sequence):
+    """CPR response matched as single KEY_CPR_RESPONSE keystroke."""
+    from blessed.keyboard import (resolve_sequence,
+                                  KEY_CPR_RESPONSE, OrderedDict)
+    ks = resolve_sequence(sequence, OrderedDict(), {})
+    assert ks == sequence
+    assert ks.name == 'KEY_CPR_RESPONSE'
+    assert ks.code == KEY_CPR_RESPONSE
+    assert ks.is_sequence
+    assert not ks.uses_keyboard_protocol
+
+
+@pytest.mark.parametrize("sequence,expected_name", [
+    ('\x1b[1;2R', 'KEY_SHIFT_F3'),
+    ('\x1b[0;5R', 'CSI'),
+])
+def test_cpr_response_not_matched(sequence, expected_name):
+    """Row 0 and row 1 are not matched as CPR."""
+    from blessed.keyboard import resolve_sequence, OrderedDict
+    ks = resolve_sequence(sequence, OrderedDict(), {})
+    assert ks.name == expected_name
+
+
+def test_cpr_response_with_trailing_text():
+    """CPR matcher consumes only the CPR sequence."""
+    from blessed.keyboard import resolve_sequence, OrderedDict
+    ks = resolve_sequence('\x1b[5;10Rextra', OrderedDict(), {})
+    assert ks == '\x1b[5;10R'
+    assert ks.name == 'KEY_CPR_RESPONSE'
 
 
 def test_keyboard_prefixes():

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -464,12 +464,12 @@ def test_resolve_sequence_order():
 
 @pytest.mark.parametrize("seq,capture_cpr,expected_name,expected_yx", [
     # any legal row2+ CPR response,
-    ('\x1b[3;4R', True, 'KEY_CPR_RESPONSE', (2, 3)),
-    ('\x1b[2;1R', True, 'KEY_CPR_RESPONSE', (1, 0)),
-    ('\x1b[100;200R', True, 'KEY_CPR_RESPONSE', (99, 199)),
-    ('\x1b[3;4R', False, 'KEY_CPR_RESPONSE', (2, 3)),
-    ('\x1b[2;1R', False, 'KEY_CPR_RESPONSE', (1, 0)),
-    ('\x1b[100;200R', False, 'KEY_CPR_RESPONSE', (99, 199)),
+    ('\x1b[3;4R', True, 'CPR_RESPONSE', (2, 3)),
+    ('\x1b[2;1R', True, 'CPR_RESPONSE', (1, 0)),
+    ('\x1b[100;200R', True, 'CPR_RESPONSE', (99, 199)),
+    ('\x1b[3;4R', False, 'CPR_RESPONSE', (2, 3)),
+    ('\x1b[2;1R', False, 'CPR_RESPONSE', (1, 0)),
+    ('\x1b[100;200R', False, 'CPR_RESPONSE', (99, 199)),
     # CPR response with 0-index is invalid ('CSI')
     ('\x1b[0;100R', True, 'CSI', (-1, -1)),
     ('\x1b[0;100R', False, 'CSI', (-1, -1)),
@@ -477,18 +477,16 @@ def test_resolve_sequence_order():
     ('\x1b[100;0R', False, 'CSI', (-1, -1)),
     # row 1 may be ambigious with 'KEY*F3' depending on capture_cpr argument
     ('\x1b[1;1R', False, 'KEY_F3', (0, 0)),
-    ('\x1b[1;1R', True, 'KEY_CPR_RESPONSE', (0, 0)),
+    ('\x1b[1;1R', True, 'CPR_RESPONSE', (0, 0)),
     ('\x1b[1;2R', False, 'KEY_SHIFT_F3', (0, 1)),
-    ('\x1b[1;2R', True, 'KEY_CPR_RESPONSE', (0, 1)),
+    ('\x1b[1;2R', True, 'CPR_RESPONSE', (0, 1)),
     ('\x1b[1;3R', False, 'KEY_ALT_F3', (0, 2)),
-    ('\x1b[1;3R', True, 'KEY_CPR_RESPONSE', (0, 2)),
+    ('\x1b[1;3R', True, 'CPR_RESPONSE', (0, 2)),
 ])
 def test_cpr_response(seq, capture_cpr, expected_name, expected_yx):
-    """CPR response matched as single KEY_CPR_RESPONSE keystroke."""
+    """CPR response matched as single CPR_RESPONSE keystroke."""
     from blessed.keyboard import resolve_sequence
-    expected_kb_proto = (
-            not expected_name.startswith('KEY_CPR') and
-            not expected_name == 'CSI')
+    expected_kb_proto = not expected_name in ('CPR_RESPONSE', 'CSI')
     mapper = collections.OrderedDict()
     ks = resolve_sequence(seq, mapper, {}, capture_cpr=capture_cpr)
     if expected_name == 'CSI':
@@ -519,7 +517,7 @@ def test_cpr_response_with_trailing_text():
     mapper = collections.OrderedDict()
     ks = resolve_sequence('\x1b[5;10Rextra', mapper, {})
     assert ks == '\x1b[5;10R'
-    assert ks.name == 'KEY_CPR_RESPONSE'
+    assert ks.name == 'CPR_RESPONSE'
 
 
 def test_keyboard_prefixes():

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -5,6 +5,7 @@ import os
 import platform
 import sys
 import tempfile
+import collections
 from unittest import mock
 
 # 3rd party
@@ -396,15 +397,16 @@ def test_get_keyboard_sequence(monkeypatch):
 
 def test_resolve_sequence_order():
     """Test resolve_sequence for order-dependent mapping."""
-    from blessed.keyboard import resolve_sequence, OrderedDict
-    mapper = OrderedDict((('SEQ1', 1),
-                          ('SEQ2', 2),
-                          # takes precedence over LONGSEQ, first-match
-                          ('LONGSEQ', 4),
-                          # won't match, LONGSEQ is first-match in this order
-                          ('LONGSEQ_longer', 5),
-                          # falls through for L{anything_else}
-                          ('L', 6)))
+    from blessed.keyboard import resolve_sequence
+    mapper = collections.OrderedDict(
+            (('SEQ1', 1),
+             ('SEQ2', 2),
+             # takes precedence over LONGSEQ, first-match
+             ('LONGSEQ', 4),
+             # won't match, LONGSEQ is first-match in this order
+             ('LONGSEQ_longer', 5),
+             # falls through for L{anything_else}
+             ('L', 6)))
     codes = {1: 'KEY_SEQ1',
              2: 'KEY_SEQ2',
              3: 'KEY_LONGSEQ_longest',
@@ -460,23 +462,43 @@ def test_resolve_sequence_order():
     assert repr(ks) == "KEY_L"
 
 
-@pytest.mark.parametrize("sequence", [
-    '\x1b[3;4R',
-    '\x1b[2;1R',
-    '\x1b[100;200R',
-    '\x1b[24;80R',
-    '\x1b[10;1R',
+@pytest.mark.parametrize("seq,capture_cpr,expected_name,expected_yx", [
+    # any legal row2+ CPR response,
+    ('\x1b[3;4R', True, 'KEY_CPR_RESPONSE', (2, 3)),
+    ('\x1b[2;1R', True, 'KEY_CPR_RESPONSE', (1, 0)),
+    ('\x1b[100;200R', True, 'KEY_CPR_RESPONSE', (99, 199)),
+    ('\x1b[3;4R', False, 'KEY_CPR_RESPONSE', (2, 3)),
+    ('\x1b[2;1R', False, 'KEY_CPR_RESPONSE', (1, 0)),
+    ('\x1b[100;200R', False, 'KEY_CPR_RESPONSE', (99, 199)),
+    # CPR response with 0-index is invalid ('CSI')
+    ('\x1b[0;100R', True, 'CSI', (-1, -1)),
+    ('\x1b[0;100R', False, 'CSI', (-1, -1)),
+    ('\x1b[100;0R', True, 'CSI', (-1, -1)),
+    ('\x1b[100;0R', False, 'CSI', (-1, -1)),
+    # row 1 may be ambigious with 'KEY*F3' depending on capture_cpr argument
+    ('\x1b[1;1R', False, 'KEY_F3', (0, 0)),
+    ('\x1b[1;1R', True, 'KEY_CPR_RESPONSE', (0, 0)),
+    ('\x1b[1;2R', False, 'KEY_SHIFT_F3', (0, 1)),
+    ('\x1b[1;2R', True, 'KEY_CPR_RESPONSE', (0, 1)),
+    ('\x1b[1;3R', False, 'KEY_ALT_F3', (0, 2)),
+    ('\x1b[1;3R', True, 'KEY_CPR_RESPONSE', (0, 2)),
 ])
-def test_cpr_response(sequence):
+def test_cpr_response(seq, capture_cpr, expected_name, expected_yx):
     """CPR response matched as single KEY_CPR_RESPONSE keystroke."""
-    from blessed.keyboard import (resolve_sequence,
-                                  KEY_CPR_RESPONSE, OrderedDict)
-    ks = resolve_sequence(sequence, OrderedDict(), {})
-    assert ks == sequence
-    assert ks.name == 'KEY_CPR_RESPONSE'
-    assert ks.code == KEY_CPR_RESPONSE
+    from blessed.keyboard import resolve_sequence
+    expected_kb_proto = (
+            not expected_name.startswith('KEY_CPR') and
+            not expected_name == 'CSI')
+    mapper = collections.OrderedDict()
+    ks = resolve_sequence(seq, mapper, {}, capture_cpr=capture_cpr)
+    if expected_name == 'CSI':
+        assert str(ks).startswith('\x1b[')
+    else:
+        assert str(ks) == seq
+    assert ks.name == expected_name
+    assert ks.cpr_yx == expected_yx
     assert ks.is_sequence
-    assert not ks.uses_keyboard_protocol
+    assert ks.uses_keyboard_protocol == expected_kb_proto
 
 
 @pytest.mark.parametrize("sequence,expected_name", [
@@ -484,16 +506,18 @@ def test_cpr_response(sequence):
     ('\x1b[0;5R', 'CSI'),
 ])
 def test_cpr_response_not_matched(sequence, expected_name):
-    """Row 0 and row 1 are not matched as CPR."""
-    from blessed.keyboard import resolve_sequence, OrderedDict
-    ks = resolve_sequence(sequence, OrderedDict(), {})
+    """Row 0 or 1 not matched as CPR."""
+    from blessed.keyboard import resolve_sequence
+    mapper = collections.OrderedDict()
+    ks = resolve_sequence(sequence, mapper, {})
     assert ks.name == expected_name
 
 
 def test_cpr_response_with_trailing_text():
     """CPR matcher consumes only the CPR sequence."""
-    from blessed.keyboard import resolve_sequence, OrderedDict
-    ks = resolve_sequence('\x1b[5;10Rextra', OrderedDict(), {})
+    from blessed.keyboard import resolve_sequence
+    mapper = collections.OrderedDict()
+    ks = resolve_sequence('\x1b[5;10Rextra', mapper, {})
     assert ks == '\x1b[5;10R'
     assert ks.name == 'KEY_CPR_RESPONSE'
 

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -495,6 +495,7 @@ def test_cpr_response(seq, capture_cpr, expected_name, expected_yx):
         assert str(ks) == seq
     assert ks.name == expected_name
     assert ks.cpr_yx == expected_yx
+    assert ks.cpr_xy == (expected_yx[1], expected_yx[0])
     assert ks.is_sequence
     assert ks.uses_keyboard_protocol == expected_kb_proto
 

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -399,14 +399,14 @@ def test_resolve_sequence_order():
     """Test resolve_sequence for order-dependent mapping."""
     from blessed.keyboard import resolve_sequence
     mapper = collections.OrderedDict(
-            (('SEQ1', 1),
-             ('SEQ2', 2),
-             # takes precedence over LONGSEQ, first-match
-             ('LONGSEQ', 4),
-             # won't match, LONGSEQ is first-match in this order
-             ('LONGSEQ_longer', 5),
-             # falls through for L{anything_else}
-             ('L', 6)))
+        (('SEQ1', 1),
+         ('SEQ2', 2),
+         # takes precedence over LONGSEQ, first-match
+         ('LONGSEQ', 4),
+         # won't match, LONGSEQ is first-match in this order
+         ('LONGSEQ_longer', 5),
+         # falls through for L{anything_else}
+         ('L', 6)))
     codes = {1: 'KEY_SEQ1',
              2: 'KEY_SEQ2',
              3: 'KEY_LONGSEQ_longest',
@@ -475,7 +475,7 @@ def test_resolve_sequence_order():
     ('\x1b[0;100R', False, 'CSI', (-1, -1)),
     ('\x1b[100;0R', True, 'CSI', (-1, -1)),
     ('\x1b[100;0R', False, 'CSI', (-1, -1)),
-    # row 1 may be ambigious with 'KEY*F3' depending on capture_cpr argument
+    # row 1 may be ambiguous with 'KEY*F3' depending on capture_cpr argument
     ('\x1b[1;1R', False, 'KEY_F3', (0, 0)),
     ('\x1b[1;1R', True, 'CPR_RESPONSE', (0, 0)),
     ('\x1b[1;2R', False, 'KEY_SHIFT_F3', (0, 1)),
@@ -486,7 +486,7 @@ def test_resolve_sequence_order():
 def test_cpr_response(seq, capture_cpr, expected_name, expected_yx):
     """CPR response matched as single CPR_RESPONSE keystroke."""
     from blessed.keyboard import resolve_sequence
-    expected_kb_proto = not expected_name in ('CPR_RESPONSE', 'CSI')
+    expected_kb_proto = expected_name not in ('CPR_RESPONSE', 'CSI')
     mapper = collections.OrderedDict()
     ks = resolve_sequence(seq, mapper, {}, capture_cpr=capture_cpr)
     if expected_name == 'CSI':


### PR DESCRIPTION
Closes #367

Parse for new Keystroke of name ``CPR_RESPONSE`` and attributes ``cpr_yx`` and ``cpr_xy``. This allows ``inkey()`` to capture the response for Cursor Position Report asynchronously.

New argument to ``inkey(capture_cpr=False)`` continues to match "legacy CSI Modifiers" for the F3 key as ``KEY_SHIFT_F3`` et al, but, when set True, always matches as ``KEY_CPR_RESPONSE``.

New example programs,
- ``bin/cpr-every-pos.py`` an exhaustive integration test
- ``bin/cpr-async.py`` provides an asynchronous example