### PR TITLE
curses-free jinxed 2.0 integration

### DIFF
--- a/bin/display-xtgettcap.py
+++ b/bin/display-xtgettcap.py
@@ -28,7 +28,7 @@ def main():
     print(f'{term.bold("XTGETTCAP")}: {reported}/{total} capabilities reported')
     print()
     print(f'   Terminal: {result.terminal_name}')
-    print(f'   Colors: {result.num_colors}')
+    print(f'   Colors: {term.number_of_colors}')
     print()
 
     # column widths

--- a/bin/scroller.py
+++ b/bin/scroller.py
@@ -67,15 +67,18 @@ _MESSAGE = (
 
 
 def _sized_char(ch, target, term, v_align=0, h_align=0):
+    """Return text-sizing sequence and display width for *ch* at *target* scale."""
     if not term.does_text_sizing().scale:
         return ch, wcswidth(ch)
     s, w, n, d = _scale_params(target)
     if s == 1 and n == 0:
         return ch, wcswidth(ch)
-    params = TextSizingParams(
-        scale=s, width=w, numerator=n, denominator=d,
-        vertical_align=v_align, horizontal_align=h_align)
-    seq = TextSizing(params, ch, '\x07').make_sequence()
+    seq = term.text_sized(ch, scale=s, width=w,
+                          numerator=n, denominator=d,
+                          vertical_align=v_align,
+                          horizontal_align=h_align)
+    params = TextSizingParams(scale=s, width=w, numerator=n, denominator=d,
+                              vertical_align=v_align, horizontal_align=h_align)
     width = TextSizing(params, ch, '\x07').display_width()
     return seq, width
 

--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -15,4 +15,4 @@ else:
 from blessed.line_editor import LineEditor, LineHistory
 
 __all__ = ('Terminal', 'LineEditor', 'LineHistory')
-__version__ = "1.39.0"
+__version__ = "1.40.0"

--- a/blessed/_capabilities.py
+++ b/blessed/_capabilities.py
@@ -46,7 +46,7 @@ CAPABILITY_DATABASE: \
         ('enter_fullscreen', ('smcup', {})),
         ('enter_standout_mode', ('standout', {})),
         ('enter_superscript_mode', ('superscript', {})),
-        ('enter_susimpleript_mode', ('susimpleript', {})),
+        ('enter_susimpleript_mode', ('ssubm', {})),
         ('enter_underline_mode', ('underline', {})),
         ('erase_chars', ('ech', {'nparams': 1})),
         ('exit_alt_charset_mode', ('rmacs', {})),
@@ -177,23 +177,128 @@ CAPABILITIES_CAUSE_MOVEMENT: typing.Tuple[str, ...] = tuple(CAPABILITIES_HORIZON
     'scroll_forward',
 )
 
+XTGETTCAP_INIT_CAPABILITIES = (
+    # Terminal capabilities requested at Initialization time:
+    # - TN: determines preferred TERM
+    # - colors, RGB: determines Terminal.number_of_colors
+    # - blink, sitm, ritm, cvvis: nice to have as overlays, often omitted
+    #
+    # These were chosen from a May 2026 survey of all popular terminal emulators: what capabilities
+    # and their values are reported by XTGETTCAP that are otherwise not discovered by the latest
+    # ncurses termcap matching their defined TERM?
+    'TN', 'RGB', 'colors', 'blink', 'sitm', 'ritm', 'cvvis', 'Smulx', 'Setulc', 'Ms')
+
+
 XTGETTCAP_CAPABILITIES = (
-    # xterm extensions
+    # Terminal identification and 24-bit color fields, note that the order of the first three
+    # matters for xterm compatibility, described at https://codeberg.org/dnkl/foot#xtgettcap
     ("TN", "Terminal name"),
-    ("Co", "Number of colors"),
-    # Numeric capabilities
-    ("colors", "Max colors"),
+    ("RGB", "Bits per color channel (8 = 24-bit truecolor)"),
+    ("colors", "Number of colors"),
+    # as well as the order of the next section, where xterm supports **only** keyboard capabilities
+    # via XTGETTCAP, and we have to be sensitive to request only supported capabilities, as xterm
+    # stops replying after the first unsupported (non-keyboard) capability after these,
+    # String capabilities -- keypad key sequences
+    ("kcuu1", "Up arrow key"),
+    ("kcud1", "Down arrow key"),
+    ("kcub1", "Left arrow key"),
+    ("kcuf1", "Right arrow key"),
+    ("khome", "Home key"),
+    ("kend", "End key"),
+    ("knp", "Next page key"),
+    ("kpp", "Previous page key"),
+    ("kich1", "Insert character key"),
+    ("kdch1", "Delete character key"),
+    ("kbs", "Backspace key"),
+    ("kcbt", "Back-tab key"),
+    # String capabilities -- keypad application mode keys
+    ("ka1", "Keypad upper left"),
+    ("ka3", "Keypad upper right"),
+    ("kb2", "Keypad center"),
+    ("kc1", "Keypad lower left"),
+    ("kc3", "Keypad lower right"),
+    # String capabilities -- function keys
+    ("kf1", "Function key F1"),
+    ("kf2", "Function key F2"),
+    ("kf3", "Function key F3"),
+    ("kf4", "Function key F4"),
+    ("kf5", "Function key F5"),
+    ("kf6", "Function key F6"),
+    ("kf7", "Function key F7"),
+    ("kf8", "Function key F8"),
+    ("kf9", "Function key F9"),
+    ("kf10", "Function key F10"),
+    ("kf11", "Function key F11"),
+    # Function keys kf1-kf12 only: higher-numbered F-keys (kf13-kf63) do not
+    # meaningfully differ between terminals; they describe F-key-with-modifier support,
+    # and differences across terminal descriptions are limited to kf1-kf5 at most.
+    ("kf12", "Function key F12"),
+    # String capabilities -- modified navigation key sequences
+    ("kDC", "Shifted delete-char key"),
+    ("kEND", "Shifted end key"),
+    ("kHOM", "Shifted home key"),
+    ("kIC", "Shifted insert-char key"),
+    ("kLFT", "Shifted left-arrow key"),
+    ("kRIT", "Shifted right-arrow key"),
+    ("kDN", "Shifted down-arrow key"),
+    ("kUP", "Shifted up-arrow key"),
+    ("kNXT", "Shifted next-page key"),
+    ("kPRV", "Shifted previous-page key"),
+    ("kent", "Enter/send key"),
+    ("kind", "Scroll-down key"),
+    ("kri", "Scroll-up key"),
+    ("kmous", "Mouse key"),
+    # And here is where xterm-supported XTGETTCAP capbilities end.
+    #
+    # We otherwise expect foot and kitty behavior -- if we wanted to, we could go without jinxed's
+    # virtual capability database entirely, after careful audit I find only the following attributes
+    # that may be missing or different from xterm-256color, and can be commonly patched by XTGETTCAP
+    ("blink", "Enter blink mode"),
+    ("sitm", "Enter italics mode"),
+    ("ritm", "Exit italics mode"),
+    ("cvvis", "Very visible cursor"),
+    # And here is where blessed's integration ends. All remaining capabilities, for blessed's
+    # purposes, are informational only. Used by the downstream 'ucs-detect' tool for auditing and
+    # fingerprinting purposes, like "kitty-query-clipboard_control".
+    #
+    # Remaining numeric capabilities
+    ("colors", "Max colors on screen"),
+    ("cols", "Columns"),
+    ("lines", "Lines"),
+    ("it", "Init tabs"),
+    ("pairs", "Max color pairs"),
+    # Boolean capabilities
+    ("am", "Auto right margin"),
+    ("bce", "Background color erase"),
+    ("bw", "Auto left margin"),
+    ("ccc", "Can redefine colors"),
+    ("da", "Memory above"),
+    ("db", "Memory below"),
+    ("eslok", "Status line escape OK"),
+    ("hs", "Has status line"),
+    ("km", "Has meta key"),
+    ("mir", "Move in insert mode"),
+    ("msgr", "Move in standout mode"),
+    ("npc", "No pad character"),
+    ("ul", "Transparent underline"),
+    ("xenl", "Newline glitch"),
+    ("xt", "Destructive tabs"),
+    ("mc5i", "Will not echo input"),
+    ("AX", "Supports default colors"),
+    ("Tc", "Truecolor (24-bit RGB)"),
+    ("Su", "Colored underlines"),
+    ("XT", "Xterm extensions"),
+    ("fullkbd", "Full Kitty keyboard protocol"),
+    ("xvpa", "Extended vertical positioning"),
+    ("XF", "Extended functionality"),
     # String capabilities -- attributes
     ("bold", "Enter bold mode"),
     ("dim", "Enter dim mode"),
-    ("blink", "Enter blink mode"),
     ("rev", "Enter reverse mode"),
     ("smso", "Enter standout mode"),
     ("rmso", "Exit standout mode"),
     ("smul", "Enter underline mode"),
     ("rmul", "Exit underline mode"),
-    ("sitm", "Enter italics mode"),
-    ("ritm", "Exit italics mode"),
     ("sgr0", "Reset attributes"),
     # String capabilities -- colors
     ("setaf", "Set foreground color"),
@@ -204,7 +309,6 @@ XTGETTCAP_CAPABILITIES = (
     ("rc", "Restore cursor"),
     ("civis", "Hide cursor"),
     ("cnorm", "Normal cursor"),
-    ("cvvis", "Very visible cursor"),
     ("cup", "Cursor address"),
     ("home", "Cursor home"),
     ("hpa", "Horizontal position"),
@@ -250,10 +354,137 @@ XTGETTCAP_CAPABILITIES = (
     ("u7", "CPR request"),
     ("u8", "DA response format"),
     ("u9", "DA request"),
-    # Extended capabilities -- modern terminal features
-    ("Ms", "Clipboard via OSC 52"),
-    ("Smulx", "Set extended underline style"),
+    # Terminal-specific queries (kitty and foot extensions)
+    ("query-os-name", "OS name query"),
+    ("kitty-query-name", "terminal name"),
+    ("kitty-query-version", "version"),
+    ("kitty-query-allow_hyperlinks", "hyperlink support"),
+    ("kitty-query-font_family", "font family"),
+    ("kitty-query-bold_font", "bold font"),
+    ("kitty-query-italic_font", "italic font"),
+    ("kitty-query-bold_italic_font", "bold-italic font"),
+    ("kitty-query-font_size", "font size"),
+    ("kitty-query-dpi_x", "DPI X"),
+    ("kitty-query-dpi_y", "DPI Y"),
+    ("kitty-query-foreground", "foreground color"),
+    ("kitty-query-background", "background color"),
+    ("kitty-query-background_opacity", "background opacity"),
+    ("kitty-query-clipboard_control", "clipboard control"),
+    ("kitty-query-os_name", "OS name"),
+    # String capabilities -- extended attributes
+    ("Smulx", "Styled underline"),
     ("Setulc", "Set underline color"),
+    ("Ss", "Set underline style"),
+    ("Se", "Reset underline style"),
+    ("Smol", "Set overline mode"),
+    ("Rmol", "Reset overline mode"),
+    ("Smxx", "Enter extended modes"),
+    ("Rmxx", "Exit extended modes"),
+    ("acsc", "Alternate character set"),
+    ("smacs", "Enter alternate charset mode"),
+    ("rmacs", "Exit alternate charset mode"),
+    # String capabilities -- terminal features
+    ("Ms", "Clipboard set"),
+    ("Sync", "Synchronized output"),
+    ("E3", "Erase scrollback"),
+    ("Cr", "Set cursor color"),
+    ("Cs", "Reset cursor color"),
+    # String capabilities -- editing
+    ("ht", "Horizontal tab"),
+    ("hts", "Set tab stop"),
+    ("tbc", "Clear all tabs"),
+    ("ich1", "Insert character"),
+    ("rep", "Repeat character"),
+    # String capabilities -- cursor
+    ("invis", "Invisible cursor"),
+    ("initc", "Initialize color"),
+    # String capabilities -- screen
+    ("oc", "Original colors"),
+    ("ri", "Reverse index"),
+    ("smir", "Enter insert mode"),
+    ("rmir", "Exit insert mode"),
+    ("rs1", "Reset string 1"),
+    ("rs2", "Reset string 2"),
+    ("dsl", "Disable status line"),
+    ("fsl", "From status line"),
+    ("tsl", "To status line"),
+    # String capabilities -- colors
+    ("setrgbb", "Set RGB background"),
+    ("setrgbf", "Set RGB foreground"),
+    ("sgr", "Set attributes"),
+    # String capabilities -- terminal features (continued)
+    ("Rect", "Rectangle operations"),
+    ("TS", "Terminal state query"),
+    ("nel", "Newline"),
+    ("rmm", "Reset meta mode"),
+    ("setal", "Set ANSI label"),
+    # String capabilities -- kitty extensions
+    ("BD", "Enter bold mode (kitty)"),
+    ("BE", "Exit bold mode (kitty)"),
+    ("PS", "Presentation start (kitty)"),
+    ("PE", "Presentation end (kitty)"),
+    ("XM", "Enter marks mode (kitty)"),
+    ("xm", "Exit marks mode (kitty)"),
+    ("RV", "Enter reverse mode (kitty)"),
+    ("rv", "Exit reverse mode (kitty)"),
+    ("XR", "Enter reset mode (kitty)"),
+    ("xr", "Exit reset mode (kitty)"),
+    ("fe", "Exit font mode (kitty)"),
+    ("fd", "Enter font mode (kitty)"),
+    ("kxIN", "Keyboard in (kitty)"),
+    ("kxOUT", "Keyboard out (kitty)"),
+    ("is2", "Init 2 string"),
+    # String capabilities -- modifier key sequences (kitty keyboard protocol)
+    ("kDC3", "Alt delete-char key"),
+    ("kDC4", "Alt-Shift delete-char key"),
+    ("kDC5", "Ctrl delete-char key"),
+    ("kDC6", "Ctrl-Shift delete-char key"),
+    ("kDC7", "Ctrl-Alt delete-char key"),
+    ("kDN3", "Alt down-arrow key"),
+    ("kDN4", "Alt-Shift down-arrow key"),
+    ("kDN5", "Ctrl down-arrow key"),
+    ("kDN6", "Ctrl-Shift down-arrow key"),
+    ("kDN7", "Ctrl-Alt down-arrow key"),
+    ("kEND3", "Alt end key"),
+    ("kEND4", "Alt-Shift end key"),
+    ("kEND5", "Ctrl end key"),
+    ("kEND6", "Ctrl-Shift end key"),
+    ("kEND7", "Ctrl-Alt end key"),
+    ("kHOM3", "Alt home key"),
+    ("kHOM4", "Alt-Shift home key"),
+    ("kHOM5", "Ctrl home key"),
+    ("kHOM6", "Ctrl-Shift home key"),
+    ("kHOM7", "Ctrl-Alt home key"),
+    ("kIC3", "Alt insert-char key"),
+    ("kIC4", "Alt-Shift insert-char key"),
+    ("kIC5", "Ctrl insert-char key"),
+    ("kIC6", "Ctrl-Shift insert-char key"),
+    ("kIC7", "Ctrl-Alt insert-char key"),
+    ("kLFT3", "Alt left-arrow key"),
+    ("kLFT4", "Alt-Shift left-arrow key"),
+    ("kLFT5", "Ctrl left-arrow key"),
+    ("kLFT6", "Ctrl-Shift left-arrow key"),
+    ("kLFT7", "Ctrl-Alt left-arrow key"),
+    ("kNXT3", "Alt next-page key"),
+    ("kNXT4", "Alt-Shift next-page key"),
+    ("kNXT5", "Ctrl next-page key"),
+    ("kNXT6", "Ctrl-Shift next-page key"),
+    ("kNXT7", "Ctrl-Alt next-page key"),
+    ("kPRV3", "Alt previous-page key"),
+    ("kPRV4", "Alt-Shift previous-page key"),
+    ("kPRV5", "Ctrl previous-page key"),
+    ("kPRV6", "Ctrl-Shift previous-page key"),
+    ("kPRV7", "Ctrl-Alt previous-page key"),
+    ("kRIT3", "Alt right-arrow key"),
+    ("kRIT4", "Alt-Shift right-arrow key"),
+    ("kRIT5", "Ctrl right-arrow key"),
+    ("kRIT6", "Ctrl-Shift right-arrow key"),
+    ("kRIT7", "Ctrl-Alt right-arrow key"),
+    ("kUP3", "Alt up-arrow key"),
+    ("kUP4", "Alt-Shift up-arrow key"),
+    ("kUP5", "Ctrl up-arrow key"),
+    ("kUP6", "Ctrl-Shift up-arrow key"),
+    ("kUP7", "Ctrl-Alt up-arrow key"),
 )
 
 
@@ -320,7 +551,7 @@ class TermcapResponse:
         <https://invisible-island.net/xterm/ctlseqs/ctlseqs.html>`_
     """
 
-    def __init__(self, supported: bool,
+    def __init__(self, supported: bool = False,
                  capabilities: Optional[Dict[str, str]] = None) -> None:
         """Initialize TermcapResponse with support status and capabilities."""
         self.supported = supported
@@ -344,12 +575,20 @@ class TermcapResponse:
 
     @property
     def terminal_name(self) -> Optional[str]:
-        """Terminal name from ``TN`` capability, or ``None``."""
+        """
+        Terminal name from ``TN`` capability, or ``None``.
+
+        .. deprecated:: This alias is not very useful or used by blessed.
+        """
         return self.capabilities.get('TN')
 
     @property
     def num_colors(self) -> Optional[int]:
-        """Number of colors from ``colors`` capability, or ``None``."""
+        """
+        Number of colors from ``colors`` capability, or ``None``.
+
+        .. deprecated:: This value is not very useful or used by blessed.
+        """
         val = self.capabilities.get('colors')
         if val is not None:
             try:
@@ -409,7 +648,7 @@ class ITerm2Capabilities:
         'Sx': ('sixel', 'bool', 0),
     }
 
-    def __init__(self, supported: bool,
+    def __init__(self, supported: bool = False,
                  features: Optional[Dict[str, typing.Any]] = None) -> None:
         """Initialize ITerm2Capabilities with support status and features."""
         self.supported = supported
@@ -428,12 +667,14 @@ class ITerm2Capabilities:
                     name, ftype, bits = ITerm2Capabilities.FEATURE_MAP[code]
                     pos += code_len
                     if ftype == 'int' and bits > 0:
+                        # parse integer value
                         digits = ''
                         while pos < len(feature_str) and feature_str[pos].isdigit():
                             digits += feature_str[pos]
                             pos += 1
                         features[name] = int(digits) if digits else 0
                     else:
+                        # non-ints are bools, when present
                         features[name] = True
                     matched = True
                     break

--- a/blessed/formatters.py
+++ b/blessed/formatters.py
@@ -2,22 +2,43 @@
 from __future__ import annotations
 
 # std imports
-import platform
-from typing import TYPE_CHECKING, Set, Dict, List, Tuple, Union, Callable, Optional
+import os
+import pkgutil
+import warnings
+import importlib
+from typing import TYPE_CHECKING, Set, List, Tuple, Union, Callable
 
 # local
 from blessed.colorspace import CGA_COLORS, X11_COLORNAMES_TO_RGB
+from blessed._capabilities import CAPABILITY_DATABASE
 
 if TYPE_CHECKING:  # pragma: no cover
     # local
     from blessed.terminal import Terminal
 
-# isort: off
-# curses
-if platform.system() == 'Windows':
-    import jinxed as curses
-else:
-    import curses
+# 3rd party
+import jinxed
+import jinxed.terminfo
+
+
+def _build_known_capability_names() -> 'frozenset[str]':
+    """Return frozenset of all terminal capability names known to jinxed."""
+    caps: set[str] = set(jinxed.terminfo.BOOL_CAPS)
+    caps.update(jinxed.terminfo.NUM_CAPS)
+    for _, modname, _ in pkgutil.iter_modules(jinxed.terminfo.__path__):
+        if modname.startswith('_'):
+            continue
+        mod = importlib.import_module(f'jinxed.terminfo.{modname}')
+        caps.update(getattr(mod, 'STR_CAPS', {}).keys())
+    # Also include attribute names from blessed's own capability database.
+    for _name, (attr, _) in CAPABILITY_DATABASE.items():
+        caps.add(attr)
+    return frozenset(caps)
+
+
+_KNOWN_CAPABILITY_NAMES = _build_known_capability_names()
+
+_NOWARN_UNKNOWN_CAPS = bool(os.environ.get('BLESSED_NOWARN_UNKNOWN_CAPS'))
 
 
 def _make_colors() -> Set[str]:
@@ -49,7 +70,7 @@ COLORS: Set[str] = _make_colors()
 
 #: Attributes that may be compounded with colors, by underscore, such as
 #: 'reverse_indigo'.
-COMPOUNDABLES: Set[str] = set('bold underline reverse blink italic standout'.split())
+COMPOUNDABLES: Set[str] = set('bold underline reverse blink dim italic standout'.split())
 
 
 class ParameterizingString(str):
@@ -70,7 +91,7 @@ class ParameterizingString(str):
         """
         Class constructor accepting 3 positional arguments.
 
-        :arg str cap: parameterized string suitable for curses.tparm()
+        :arg str cap: parameterized string suitable for jinxed.tparm()
         :arg str normal: terminating sequence for this capability (optional).
         :arg str name: name of this terminal capability (optional).
         """
@@ -88,7 +109,7 @@ class ParameterizingString(str):
         a :class:`FormattingString` capable of being called.
 
         :raises TypeError: Mismatch between capability and arguments
-        :raises curses.error: :func:`curses.tparm` raised an exception
+        :raises jinxed.error: :func:`jinxed.tparm` raised an exception
         :rtype: :class:`FormattingString` or :class:`NullCallableString`
         :returns: Callable string for given parameters
         """
@@ -96,7 +117,7 @@ class ParameterizingString(str):
             # Re-encode the cap, because tparm() takes a bytestring in Python
             # 3. However, appear to be a plain Unicode string otherwise so
             # concats work.
-            attr = curses.tparm(self.encode('latin1'), *args).decode('latin1')
+            attr = jinxed.tparm(self.encode('latin1'), *args).decode('latin1')
             return FormattingString(attr, self._normal)
         except TypeError as err:
             # If the first non-int (i.e. incorrect) arg was a string, suggest
@@ -108,7 +129,7 @@ class ParameterizingString(str):
             # Somebody passed a non-string; I don't feel confident
             # guessing what they were trying to do.
             raise
-        except curses.error as err:
+        except jinxed.error as err:  # pragma: no cover
             # ignore 'tparm() returned NULL', you won't get any styling,
             # even if does_styling is True. This happens on win32 platforms
             # with http://www.lfd.uci.edu/~gohlke/pythonlibs/#curses installed
@@ -121,11 +142,14 @@ class ParameterizingProxyString(str):
     r"""
     A Unicode string which can be called to proxy missing termcap entries.
 
-    This class supports the function :func:`get_proxy_string`, and mirrors
-    the behavior of :class:`ParameterizingString`, except that instead of
-    a capability name, receives a format string, and callable to filter the
-    given positional ``*args`` of :meth:`ParameterizingProxyString.__call__`
-    into a terminal sequence.
+    .. deprecated 1.40::
+
+        All previously-proxied terminfo(5) capabilities are now provided directly by the capability
+        database in jinxed.  This class is unused by blessed but kept for API compatibility.
+
+    This class mirrors the behavior of :class:`ParameterizingString`, except that instead of a
+    capability name, receives a format string, and callable to filter the given positional ``*args``
+    of :meth:`ParameterizingProxyString.__call__` into a terminal sequence.
 
     For example::
 
@@ -311,45 +335,20 @@ class NullCallableString(str):
         return ''.join(args)
 
 
-def get_proxy_string(term: 'Terminal', attr: str) -> Optional[ParameterizingProxyString]:
+def get_proxy_string(  # pylint: disable=unused-argument
+        term: 'Terminal', attr: str) -> None:
     """
     Proxy and return callable string for proxied attributes.
 
-    :arg Terminal term: :class:`~.Terminal` instance.
-    :arg str attr: terminal capability name that may be proxied.
-    :rtype: None or :class:`ParameterizingProxyString`.
-    :returns: :class:`ParameterizingProxyString` for some attributes
-        of some terminal types that support it, where the terminfo(5)
-        database would otherwise come up empty, such as ``move_x``
-        attribute for ``term.kind`` of ``screen``.  Otherwise, None.
+    .. deprecated 1.40::
+
+        All previously-proxied terminfo(5) capabilities are now provided directly by the capability
+        database in jinxed as "patches" in
+        https://github.com/Rockhopper-Technologies/jinxed/blob/main/terminals.toml.
+
+        This function always returns ``None``.
     """
-    # normalize 'screen-256color', or 'ansi.sys' to its basic names
-    term_kind = next(iter(_kind for _kind in ('screen', 'ansi',)
-                          if term.kind.startswith(_kind)), term.kind)
-    _proxy_table: Dict[str, Dict[str, object]] = {  # pragma: no cover
-        'screen': {
-            # proxy move_x/move_y for 'screen' terminal type, used by tmux(1).
-            'hpa': ParameterizingProxyString(
-                ('\x1b[{0}G', lambda *arg: (arg[0] + 1,)), term.normal, attr),
-            'vpa': ParameterizingProxyString(
-                ('\x1b[{0}d', lambda *arg: (arg[0] + 1,)), term.normal, attr),
-        },
-        'ansi': {
-            # proxy show/hide cursor for 'ansi' terminal type.  There is some
-            # demand for a richly working ANSI terminal type for some reason.
-            'civis': ParameterizingProxyString(
-                ('\x1b[?25l', lambda *arg: ()), term.normal, attr),
-            'cnorm': ParameterizingProxyString(
-                ('\x1b[?25h', lambda *arg: ()), term.normal, attr),
-            'hpa': ParameterizingProxyString(
-                ('\x1b[{0}G', lambda *arg: (arg[0] + 1,)), term.normal, attr),
-            'vpa': ParameterizingProxyString(
-                ('\x1b[{0}d', lambda *arg: (arg[0] + 1,)), term.normal, attr),
-            'sc': '\x1b[s',
-            'rc': '\x1b[u',
-        }
-    }
-    return _proxy_table.get(term_kind, {}).get(attr, None)
+    return None
 
 
 def split_compound(compound: str) -> List[str]:
@@ -388,10 +387,18 @@ def resolve_capability(term: 'Terminal', attr: str) -> str:
     """
     if not term.does_styling:
         return ''
-    val = curses.tigetstr(term._sugar.get(attr, attr))  # pylint: disable=protected-access
+    capname = term._sugar.get(attr, attr)  # pylint: disable=protected-access
+    val = term._jinxed_term.tigetstr(capname)  # pylint: disable=protected-access
+    if val is None:
+        if capname not in _KNOWN_CAPABILITY_NAMES and not _NOWARN_UNKNOWN_CAPS:
+            warnings.warn(
+                f"unknown terminal capability: {capname!r}",
+                stacklevel=4,
+            )
+        return ''
     # Decode sequences as latin1, as they are always 8-bit bytes, so when
     # b'\xff' is returned, this is decoded as '\xff'.
-    return '' if val is None else val.decode('latin1')
+    return val.decode('latin1')
 
 
 def resolve_color(term: 'Terminal', color: str) -> Union[NullCallableString, FormattingString]:
@@ -424,7 +431,7 @@ def resolve_color(term: 'Terminal', color: str) -> Union[NullCallableString, For
         # bright colors at 8-15:
         offset = 8 if 'bright_' in color else 0
         base_color = color.rsplit('_', 1)[-1]
-        fmt_attr = vga_color_cap(getattr(curses, f'COLOR_{base_color.upper()}') + offset)
+        fmt_attr = vga_color_cap(getattr(jinxed, f'COLOR_{base_color.upper()}') + offset)
         return FormattingString(fmt_attr, term.normal)
 
     assert base_color in X11_COLORNAMES_TO_RGB, (
@@ -484,13 +491,4 @@ def resolve_attribute(term: 'Terminal', attr: str) -> Union[ParameterizingString
     # that when called, performs and returns the final string after curses
     # capability lookup is performed.
     tparm_capseq = resolve_capability(term, attr)
-    if not tparm_capseq:
-        # and, for special terminals, such as 'screen', provide a Proxy
-        # ParameterizingString for attributes they do not claim to support,
-        # but actually do! (such as 'hpa' and 'vpa').
-        proxy = get_proxy_string(term,
-                                 term._sugar.get(attr, attr))  # pylint: disable=protected-access
-        if proxy is not None:
-            return proxy
-
     return ParameterizingString(tparm_capseq, term.normal, attr)

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -5,10 +5,13 @@ import os
 import re
 import time
 import typing
-import platform
 import functools
 from typing import TYPE_CHECKING, Set, Dict, Match, Tuple, TypeVar, Optional
 from collections import OrderedDict, namedtuple
+
+# 3rd party
+import jinxed
+from jinxed.has_key import _capability_names as capability_names
 
 if TYPE_CHECKING:  # pragma: no cover
     # local
@@ -24,15 +27,8 @@ from blessed.dec_modes import DecPrivateMode
 
 _T = TypeVar('_T', bound='Keystroke')
 
-
-# isort: off
-# curses
-if platform.system() == 'Windows':
-    import jinxed as curses
-    from jinxed.has_key import _capability_names as capability_names
-else:
-    import curses
-    from curses.has_key import _capability_names as capability_names
+TERMINAL_QUERY_TIMEOUT_SECONDS = 1.0
+"""Default timeout in seconds for terminal query operations (XTGETTCAP, OSC, DCS, etc.)."""
 
 
 # DEC event namedtuples
@@ -213,7 +209,7 @@ class Keystroke(str):
         """Class constructor."""
         new = str.__new__(cls, ucs)
         new._name = name
-        new._code = code  # curses keycode is exposed for legacy API
+        new._code = code  # curses/jinxed keycode is exposed for legacy API
         new._mode = mode  # Internal mode indicator for different protocols
         new._match = match  # regex match object for protocol-specific data
         new._modifiers = cls._infer_modifiers(ucs, mode, match)
@@ -1028,10 +1024,10 @@ class Keystroke(str):
     def _get_ascii_value(self) -> Optional[str]:
         """Get value for keys matched by curses-imitated keycodes."""
         return {
-            curses.KEY_ENTER: '\n',
+            jinxed.KEY_ENTER: '\n',
             KEY_TAB: '\t',
-            curses.KEY_BACKSPACE: '\x08',
-            curses.KEY_EXIT: '\x1b',
+            jinxed.KEY_BACKSPACE: '\x08',
+            jinxed.KEY_EXIT: '\x1b',
         }.get(self._code)
 
     @property
@@ -1246,21 +1242,21 @@ def get_curses_keycodes() -> Dict[str, int]:
         values and their mnemonic name. Such as code ``260``, with the value of
         its key-name identity, ``'KEY_LEFT'``.
     """
-    _keynames = [attr for attr in dir(curses)
+    _keynames = [attr for attr in dir(jinxed)
                  if attr.startswith('KEY_')]
-    return {keyname: getattr(curses, keyname) for keyname in _keynames}
+    return {keyname: getattr(jinxed, keyname) for keyname in _keynames}
 
 
 def get_keyboard_codes() -> Dict[int, str]:
     """
-    Return mapping of keycode integer values paired by their curses key- name.
+    Return mapping of keycode integer values paired by their curses key name.
 
     :rtype: dict
     :returns: Dictionary of (code, name) pairs for curses keyboard constant
         values and their mnemonic name. Such as key ``260``, with the value of
         its identity, ``'KEY_LEFT'``.
 
-    These keys are derived from the attributes by the same of the curses module,
+    These keys are derived from the attributes by the same of the curses(jinxed) module,
     with the following exceptions:
 
     * ``KEY_DELETE`` in place of ``KEY_DC``
@@ -1297,31 +1293,6 @@ def get_keyboard_codes() -> Dict[int, str]:
     return dict(zip(keycodes.values(), keycodes.keys()))
 
 
-def _alternative_left_right(term: 'Terminal') -> typing.Dict[str, int]:
-    r"""
-    Determine and return mapping of left and right arrow keys sequences.
-
-    :arg blessed.Terminal term: :class:`~.Terminal` instance.
-    :rtype: dict
-    :returns: Dictionary of sequences ``term._cuf1``, and ``term._cub1``,
-        valued as ``KEY_RIGHT``, ``KEY_LEFT`` (when appropriate).
-
-    This function supports :func:`get_terminal_sequences` to discover
-    the preferred input sequence for the left and right application keys.
-
-    It is necessary to check the value of these sequences to ensure we do not
-    use ``' '`` and ``'\b'`` for ``KEY_RIGHT`` and ``KEY_LEFT``,
-    preferring their true application key sequence, instead.
-    """
-    # pylint: disable=protected-access
-    keymap: typing.Dict[str, int] = {}
-    if term._cuf1 and term._cuf1 != ' ':
-        keymap[term._cuf1] = curses.KEY_RIGHT
-    if term._cub1 and term._cub1 != '\b':
-        keymap[term._cub1] = curses.KEY_LEFT
-    return keymap
-
-
 def get_keyboard_sequences(term: 'Terminal') -> typing.OrderedDict[str, int]:
     r"""
     Return mapping of keyboard sequences paired by keycodes.
@@ -1341,6 +1312,7 @@ def get_keyboard_sequences(term: 'Terminal') -> typing.OrderedDict[str, int]:
     The return value is an OrderedDict instance, with their keys
     sorted longest-first.
     """
+    # pylint: disable=protected-access
     # A small gem from curses.has_key that makes this all possible,
     # _capability_names: a lookup table of terminal capability names for
     # keyboard sequences (fe. kcub1, key_left), keyed by the values of
@@ -1354,11 +1326,10 @@ def get_keyboard_sequences(term: 'Terminal') -> typing.OrderedDict[str, int]:
     #
     sequence_map = {
         seq.decode('latin1'): val for seq, val in (
-            (curses.tigetstr(cap), val) for (val, cap) in capability_names.items()
+            (term._jinxed_term.tigetstr(cap), val) for (val, cap) in capability_names.items()
         ) if seq
     } if term.does_styling else {}
 
-    sequence_map.update(_alternative_left_right(term))
     sequence_map.update(DEFAULT_SEQUENCE_MIXIN)
 
     # This is for fast lookup matching of sequences, preferring
@@ -1462,7 +1433,7 @@ def resolve_sequence(text: str,
         and len(text) >= 2
         and (final or text[:2] not in prefixes)
         # pylint:disable=protected-access
-        and (ks is None or (ks.code == curses.KEY_EXIT and ks._mode is None))
+        and (ks is None or (ks.code == jinxed.KEY_EXIT and ks._mode is None))
     )
     if is_meta_escape:
         ks = Keystroke(ucs=text[:2])
@@ -1569,6 +1540,7 @@ def _match_dec_event(text: str,
     :rtype: Keystroke or None
     :returns: :class:`Keystroke` with DEC event data if matched, ``None`` otherwise
     """
+    # local
     from blessed.dec_modes import DecModeResponse  # pylint: disable=import-outside-toplevel
 
     if dec_mode_cache is None:
@@ -1785,9 +1757,9 @@ def _match_legacy_ss3_fkey_form(text: str) -> Optional[Keystroke]:
 
 
 # We invent a few to fixup for missing keys in curses, these aren't especially required or useful
-# except to survive as API compatibility for the earliest versions of this software, before
-# "synthesized names" were created. They must be these values in this order, used as constants for
-# equality checks to Keystroke.code.
+# except to survive as API compatibility for the earliest version of this software before
+# "synthesized names" were created. They must be these specific ordinal values, as enum-like
+# constants for equality checks to Keystroke.code.
 KEY_TAB = 512
 KEY_KP_MULTIPLY = 513
 KEY_KP_ADD = 514
@@ -1812,10 +1784,10 @@ KEY_MENU = 530
 # Maps common control character unicode values to their curses keycodes
 # so they get proper names when received via Kitty protocol
 _KITTY_CONTROL_CHAR_TO_KEYCODE = {
-    27: curses.KEY_EXIT,        # Escape
+    27: jinxed.KEY_EXIT,        # Escape
     9: KEY_TAB,                 # Tab
-    13: curses.KEY_ENTER,       # Enter/Return
-    127: curses.KEY_BACKSPACE,  # Backspace/Delete
+    13: jinxed.KEY_ENTER,       # Enter/Return
+    127: jinxed.KEY_BACKSPACE,  # Backspace/Delete
 }
 
 # Kitty keyboard protocol PUA (Private Use Area) key codes
@@ -1939,57 +1911,57 @@ def _is_kitty_functional_key(unicode_key: int) -> bool:
 #: Maps CSI final characters to curses keycodes for sequences
 #: like ESC [ 1 ; mod [ABCDEFHPQRS]
 CSI_FINAL_CHAR_TO_KEYCODE = {
-    'A': curses.KEY_UP,
-    'B': curses.KEY_DOWN,
-    'C': curses.KEY_RIGHT,
-    'D': curses.KEY_LEFT,
-    'E': curses.KEY_B2,      # Center/Begin
-    'F': curses.KEY_END,
-    'H': curses.KEY_HOME,
-    'P': curses.KEY_F1,
-    'Q': curses.KEY_F2,
-    'R': curses.KEY_F3,
-    'S': curses.KEY_F4,
+    'A': jinxed.KEY_UP,
+    'B': jinxed.KEY_DOWN,
+    'C': jinxed.KEY_RIGHT,
+    'D': jinxed.KEY_LEFT,
+    'E': jinxed.KEY_B2,      # Center/Begin
+    'F': jinxed.KEY_END,
+    'H': jinxed.KEY_HOME,
+    'P': jinxed.KEY_F1,
+    'Q': jinxed.KEY_F2,
+    'R': jinxed.KEY_F3,
+    'S': jinxed.KEY_F4,
 }
 
 #: Maps CSI tilde numbers to curses keycodes for sequences
 #: like ESC [ num ; mod ~
 CSI_TILDE_NUM_TO_KEYCODE = {
-    2: curses.KEY_IC,        # Insert
-    3: curses.KEY_DC,        # Delete
-    5: curses.KEY_PPAGE,     # Page Up
-    6: curses.KEY_NPAGE,     # Page Down
-    7: curses.KEY_HOME,      # Home
-    8: curses.KEY_END,       # End
-    11: curses.KEY_F1,       # F1
-    12: curses.KEY_F2,       # F2
-    13: curses.KEY_F3,       # F3
-    14: curses.KEY_F4,       # F4
-    15: curses.KEY_F5,       # F5
-    17: curses.KEY_F6,       # F6
-    18: curses.KEY_F7,       # F7
-    19: curses.KEY_F8,       # F8
-    20: curses.KEY_F9,       # F9
-    21: curses.KEY_F10,      # F10
-    23: curses.KEY_F11,      # F11
-    24: curses.KEY_F12,      # F12
-    25: curses.KEY_F13,      # F13
-    26: curses.KEY_F14,      # F14
-    28: curses.KEY_F15,      # F15
+    2: jinxed.KEY_IC,        # Insert
+    3: jinxed.KEY_DC,        # Delete
+    5: jinxed.KEY_PPAGE,     # Page Up
+    6: jinxed.KEY_NPAGE,     # Page Down
+    7: jinxed.KEY_HOME,      # Home
+    8: jinxed.KEY_END,       # End
+    11: jinxed.KEY_F1,       # F1
+    12: jinxed.KEY_F2,       # F2
+    13: jinxed.KEY_F3,       # F3
+    14: jinxed.KEY_F4,       # F4
+    15: jinxed.KEY_F5,       # F5
+    17: jinxed.KEY_F6,       # F6
+    18: jinxed.KEY_F7,       # F7
+    19: jinxed.KEY_F8,       # F8
+    20: jinxed.KEY_F9,       # F9
+    21: jinxed.KEY_F10,      # F10
+    23: jinxed.KEY_F11,      # F11
+    24: jinxed.KEY_F12,      # F12
+    25: jinxed.KEY_F13,      # F13
+    26: jinxed.KEY_F14,      # F14
+    28: jinxed.KEY_F15,      # F15
     29: KEY_MENU,            # Menu
-    31: curses.KEY_F17,      # F17
-    32: curses.KEY_F18,      # F18
-    33: curses.KEY_F19,      # F19
-    34: curses.KEY_F20,      # F20
+    31: jinxed.KEY_F17,      # F17
+    32: jinxed.KEY_F18,      # F18
+    33: jinxed.KEY_F19,      # F19
+    34: jinxed.KEY_F20,      # F20
 }
 
 #: Maps SS3 final characters to curses keycodes for sequences
 #: like ESC O mod [PQRS]
 SS3_FKEY_TO_KEYCODE = {
-    'P': curses.KEY_F1,      # F1
-    'Q': curses.KEY_F2,      # F2
-    'R': curses.KEY_F3,      # F3
-    'S': curses.KEY_F4,      # F4
+    'P': jinxed.KEY_F1,      # F1
+    'Q': jinxed.KEY_F2,      # F2
+    'R': jinxed.KEY_F3,      # F3
+    'S': jinxed.KEY_F4,      # F4
 }
 
 #: In a perfect world, terminal emulators would always send exactly what
@@ -2010,35 +1982,35 @@ SS3_FKEY_TO_KEYCODE = {
 DEFAULT_SEQUENCE_MIXIN = (
     # these common control characters (and 127, ctrl+'?') mapped to
     # an application key definition.
-    (chr(10), curses.KEY_ENTER),
-    (chr(13), curses.KEY_ENTER),
-    (chr(8), curses.KEY_BACKSPACE),
+    (chr(10), jinxed.KEY_ENTER),
+    (chr(13), jinxed.KEY_ENTER),
+    (chr(8), jinxed.KEY_BACKSPACE),
     (chr(9), KEY_TAB),  # noqa
-    (chr(27), curses.KEY_EXIT),
-    (chr(127), curses.KEY_BACKSPACE),
+    (chr(27), jinxed.KEY_EXIT),
+    (chr(127), jinxed.KEY_BACKSPACE),
 
-    ("\x1b[A", curses.KEY_UP),
-    ("\x1b[B", curses.KEY_DOWN),
-    ("\x1b[C", curses.KEY_RIGHT),
-    ("\x1b[D", curses.KEY_LEFT),
-    ("\x1b[E", curses.KEY_B2),  # Center/Begin key
-    ("\x1b[1;2A", curses.KEY_SR),
-    ("\x1b[1;2B", curses.KEY_SF),
-    ("\x1b[1;2C", curses.KEY_SRIGHT),
-    ("\x1b[1;2D", curses.KEY_SLEFT),
-    ("\x1b[F", curses.KEY_END),
-    ("\x1b[H", curses.KEY_HOME),
+    ("\x1b[A", jinxed.KEY_UP),
+    ("\x1b[B", jinxed.KEY_DOWN),
+    ("\x1b[C", jinxed.KEY_RIGHT),
+    ("\x1b[D", jinxed.KEY_LEFT),
+    ("\x1b[E", jinxed.KEY_B2),  # Center/Begin key
+    ("\x1b[1;2A", jinxed.KEY_SR),
+    ("\x1b[1;2B", jinxed.KEY_SF),
+    ("\x1b[1;2C", jinxed.KEY_SRIGHT),
+    ("\x1b[1;2D", jinxed.KEY_SLEFT),
+    ("\x1b[F", jinxed.KEY_END),
+    ("\x1b[H", jinxed.KEY_HOME),
     # not sure where these are from .. please report
-    ("\x1b[K", curses.KEY_END),
-    ("\x1b[U", curses.KEY_NPAGE),
-    ("\x1b[V", curses.KEY_PPAGE),
+    ("\x1b[K", jinxed.KEY_END),
+    ("\x1b[U", jinxed.KEY_NPAGE),
+    ("\x1b[V", jinxed.KEY_PPAGE),
 
     # keys sent after term.smkx (keypad_xmit) is emitted, source:
     # http://www.xfree86.org/current/ctlseqs.html#PC-Style%20Function%20Keys
     # http://fossies.org/linux/rxvt/doc/rxvtRef.html#KeyCodes
     #
     # keypad, numlock on
-    ("\x1bOM", curses.KEY_ENTER),
+    ("\x1bOM", jinxed.KEY_ENTER),
     ("\x1bOj", KEY_KP_MULTIPLY),
     ("\x1bOk", KEY_KP_ADD),
     ("\x1bOl", KEY_KP_SEPARATOR),
@@ -2058,53 +2030,53 @@ DEFAULT_SEQUENCE_MIXIN = (
     ("\x1bOy", KEY_KP_9),
 
     # keypad, numlock off
-    ("\x1b[1~", curses.KEY_HOME),         # home
-    ("\x1b[2~", curses.KEY_IC),           # insert (0)
-    ("\x1b[3~", curses.KEY_DC),           # delete (.), "Execute"
-    ("\x1b[4~", curses.KEY_END),          # end
-    ("\x1b[5~", curses.KEY_PPAGE),        # pgup   (9)
-    ("\x1b[6~", curses.KEY_NPAGE),        # pgdown (3)
-    ("\x1b[7~", curses.KEY_HOME),         # home
-    ("\x1b[8~", curses.KEY_END),          # end
-    ("\x1b[OA", curses.KEY_UP),           # up     (8)
-    ("\x1b[OB", curses.KEY_DOWN),         # down   (2)
-    ("\x1b[OC", curses.KEY_RIGHT),        # right  (6)
-    ("\x1b[OD", curses.KEY_LEFT),         # left   (4)
-    ("\x1b[OF", curses.KEY_END),          # end    (1)
-    ("\x1b[OH", curses.KEY_HOME),         # home   (7)
+    ("\x1b[1~", jinxed.KEY_HOME),         # home
+    ("\x1b[2~", jinxed.KEY_IC),           # insert (0)
+    ("\x1b[3~", jinxed.KEY_DC),           # delete (.), "Execute"
+    ("\x1b[4~", jinxed.KEY_END),          # end
+    ("\x1b[5~", jinxed.KEY_PPAGE),        # pgup   (9)
+    ("\x1b[6~", jinxed.KEY_NPAGE),        # pgdown (3)
+    ("\x1b[7~", jinxed.KEY_HOME),         # home
+    ("\x1b[8~", jinxed.KEY_END),          # end
+    ("\x1b[OA", jinxed.KEY_UP),           # up     (8)
+    ("\x1b[OB", jinxed.KEY_DOWN),         # down   (2)
+    ("\x1b[OC", jinxed.KEY_RIGHT),        # right  (6)
+    ("\x1b[OD", jinxed.KEY_LEFT),         # left   (4)
+    ("\x1b[OF", jinxed.KEY_END),          # end    (1)
+    ("\x1b[OH", jinxed.KEY_HOME),         # home   (7)
 
     # The vt220 placed F1-F4 above the keypad, in place of actual
     # F1-F4 were local functions (hold screen, print screen,
     # set up, data/talk, break).
-    ("\x1bOP", curses.KEY_F1),
-    ("\x1bOQ", curses.KEY_F2),
-    ("\x1bOR", curses.KEY_F3),
-    ("\x1bOS", curses.KEY_F4),
+    ("\x1bOP", jinxed.KEY_F1),
+    ("\x1bOQ", jinxed.KEY_F2),
+    ("\x1bOR", jinxed.KEY_F3),
+    ("\x1bOS", jinxed.KEY_F4),
 
     # Kitty disambiguate mode F-keys (CSI form instead of SS3)
-    ("\x1b[P", curses.KEY_F1),
-    ("\x1b[Q", curses.KEY_F2),
-    ("\x1b[13~", curses.KEY_F3),
-    ("\x1b[S", curses.KEY_F4),
+    ("\x1b[P", jinxed.KEY_F1),
+    ("\x1b[Q", jinxed.KEY_F2),
+    ("\x1b[13~", jinxed.KEY_F3),
+    ("\x1b[S", jinxed.KEY_F4),
 )
 
 #: Override mixins for a few curses constants with easier
 #: mnemonics: there may only be a 1:1 mapping when only a
 #: keycode (int) is given, where these phrases are preferred.
 CURSES_KEYCODE_OVERRIDE_MIXIN = (
-    ('KEY_DELETE', curses.KEY_DC),
-    ('KEY_INSERT', curses.KEY_IC),
-    ('KEY_PGUP', curses.KEY_PPAGE),
-    ('KEY_PGDOWN', curses.KEY_NPAGE),
-    ('KEY_ESCAPE', curses.KEY_EXIT),
-    ('KEY_SUP', curses.KEY_SR),
-    ('KEY_SDOWN', curses.KEY_SF),
-    ('KEY_UP_LEFT', curses.KEY_A1),
-    ('KEY_UP_RIGHT', curses.KEY_A3),
-    ('KEY_CENTER', curses.KEY_B2),
-    ('KEY_BEGIN', curses.KEY_BEG),
-    ('KEY_DOWN_LEFT', curses.KEY_C1),
-    ('KEY_DOWN_RIGHT', curses.KEY_C3),
+    ('KEY_DELETE', jinxed.KEY_DC),
+    ('KEY_INSERT', jinxed.KEY_IC),
+    ('KEY_PGUP', jinxed.KEY_PPAGE),
+    ('KEY_PGDOWN', jinxed.KEY_NPAGE),
+    ('KEY_ESCAPE', jinxed.KEY_EXIT),
+    ('KEY_SUP', jinxed.KEY_SR),
+    ('KEY_SDOWN', jinxed.KEY_SF),
+    ('KEY_UP_LEFT', jinxed.KEY_A1),
+    ('KEY_UP_RIGHT', jinxed.KEY_A3),
+    ('KEY_CENTER', jinxed.KEY_B2),
+    ('KEY_BEGIN', jinxed.KEY_BEG),
+    ('KEY_DOWN_LEFT', jinxed.KEY_C1),
+    ('KEY_DOWN_RIGHT', jinxed.KEY_C3),
 )
 
 #: PUA keycode overrides to remove _PUA suffix from user-facing names.

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -9,15 +9,18 @@ import base64
 import codecs
 import locale
 import select
+import signal
 import struct
 import asyncio
 import platform
 import warnings
 import contextlib
 import collections
-from typing import IO, Dict, List, Match, Tuple, Union, Optional, Generator, SupportsIndex
+from typing import IO, Dict, List, Match, Tuple, Union, Callable, Optional, Generator, SupportsIndex
 
 # 3rd party
+import jinxed
+import jinxed.terminfo
 from wcwidth import TextSizing, TextSizingParams
 from wcwidth import wrap as wcwidth_wrap
 from wcwidth import ljust as wcwidth_ljust
@@ -28,6 +31,7 @@ from wcwidth import center as wcwidth_center
 # local
 from .color import COLOR_DISTANCE_ALGORITHMS, xterm256gray_from_rgb, xterm256color_from_rgb
 from .keyboard import (DEFAULT_ESCDELAY,
+                       TERMINAL_QUERY_TIMEOUT_SECONDS,
                        Keystroke,
                        ResizeEvent,
                        DeviceAttribute,
@@ -63,21 +67,17 @@ from ._capabilities import (CAPABILITY_DATABASE,
                             TextSizingResult,
                             ITerm2Capabilities)
 
-# isort: off
-
 HAS_TTY = True  # pylint: disable=invalid-name
-if platform.system() == 'Windows':
-    IS_WINDOWS = True
-    import jinxed as curses
+IS_WINDOWS = platform.system() == 'Windows'
+if IS_WINDOWS:
+    # 3rd party
     from jinxed.win32 import get_console_input_encoding
 else:
-    IS_WINDOWS = False
-    import curses
-
     try:
+        # std imports
+        import tty
         import fcntl
         import termios
-        import tty
     except ImportError:
         _TTY_METHODS = ('setraw', 'cbreak', 'kbhit', 'height', 'width')
         _MSG_NOSUPPORT = (
@@ -89,7 +89,6 @@ else:
         warnings.warn(_MSG_NOSUPPORT)
         HAS_TTY = False  # pylint: disable=invalid-name
 
-_CUR_TERM = None  # See comments at end of file
 RE_GET_FGCOLOR_RESPONSE = re.compile(
     '\x1b]10;rgb:([0-9a-fA-F]+)/([0-9a-fA-F]+)/([0-9a-fA-F]+)(?:\x07|\x1b\\\\)')
 RE_GET_BGCOLOR_RESPONSE = re.compile(
@@ -104,8 +103,6 @@ _RE_XTWINOPS_14_RESPONSE = re.compile(r'\x1b\[4;(\d+);(\d+)t')
 _RE_XTWINOPS_16_RESPONSE = re.compile(r'\x1b\[6;(\d+);(\d+)t')
 _RE_GET_DEVICE_ATTR_RESPONSE = re.compile('\x1b\\[\\?([0-9]+)((?:;[0-9]+)*)c')
 _RE_GET_SOFTWARE_VERSION_RESPONSE = re.compile('\x1bP>\\|(.+?)\x1b\\\\')
-_RE_XTGETTCAP_RESPONSE = re.compile(
-    r'\x1bP([01])\+r([0-9a-fA-F]+)(?:=([0-9a-fA-F]*))?\x1b\\')
 _RE_KITTY_GRAPHICS_RESPONSE = re.compile(r'\x1b_Gi=31;(.+?)\x1b\\')
 _RE_ITERM2_CAPABILITIES_RESPONSE = re.compile(
     r'\x1b\]1337;Capabilities=([^\x07\x1b]+)(?:\x07|\x1b\\)')
@@ -119,6 +116,9 @@ _RE_OSC52_RESPONSE = re.compile(r'\x1b\]52;[a-z]*;([^\x07\x1b]*)(?:\x07|\x1b\\)'
 _RE_COLOR_SCHEME_MODE_RESPONSE = re.compile(r'\x1b\[\?997;([12])n')
 # DECRQSS: DCS Ps $ r Pt ST (Ps=1 means valid)
 _RE_DECRQSS_RESPONSE = re.compile(r'\x1bP([01])\$r([^\x1b]*)\x1b\\')
+# XTGETTCAP: DCS Ps + r Pt ST (Ps=1 means valid, Pt=hex-encoded capname=value)
+_RE_XTGETTCAP_RESPONSE = re.compile(
+    r'\x1bP([01])\+r([0-9a-fA-F]+)(?:=([0-9a-fA-F]*))?\x1b\\')
 
 
 class Terminal():  # pylint: disable=attribute-defined-outside-init
@@ -185,15 +185,16 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
     def __init__(self,
                  kind: Optional[str] = None,
                  stream: Optional[IO[str]] = None,
-                 force_styling: Union[bool, None] = False) -> None:
+                 force_styling: Union[bool, None] = False,
+                 kind_fallback: str = 'xterm-256color',
+                 _xtgettcap_data: Optional[TermcapResponse] = None
+                 ) -> None:
         """
         Initialize the terminal.
 
-        :arg str kind: A terminal string as taken by :func:`curses.setupterm`.
-            Defaults to the value of the ``TERM`` environment variable.
-
-            .. note:: Terminals within a single process must share a common
-                ``kind``. See :obj:`_CUR_TERM`.
+        :arg str kind: A terminal string used for capability database, defaults to the value of the
+            ``TERM`` environment variable when undefined. If the terminal supports XTGETTCAP
+            extension, the 'TN' capability name reported has precedence over 'kind'.
 
         :arg file stream: A file-like object representing the Terminal output.
             Defaults to the original value of :obj:`sys.__stdout__`, like
@@ -218,19 +219,24 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
             Conversely, When OS Environment variable NO_COLOR_ is *non-empty*,
             styling is **not** used no matter the value specified by
-            ``force_styling`` and has precedence over FORCE_COLOR_ and
-            CLICOLOR_FORCE_.
+            ``force_styling``, FORCE_COLOR_, or CLICOLOR_FORCE_.
 
             .. _FORCE_COLOR: https://force-color.org/
             .. _CLICOLOR_FORCE: https://bixense.com/clicolors/
             .. _NO_COLOR: https://no-color.org/
+
+        :arg str kind_fallback: Terminal kind to use as fallback when the requested ``kind`` is not
+            found in jinxed_ virtual terminfo database.  Defaults to ``'xterm-256color'`` which is
+            well supported for all capabilities used by blessed on all modern terminals.
+
+        .. _jinxed: https://github.com/rockhopper-Technologies/jinxed
         """
-        # pylint: disable=global-statement
-        global _CUR_TERM
         self.errors = [
-            f'parameters: kind={kind!r}, stream={stream!r}, force_styling={force_styling!r}',
+            f'parameters: kind={kind!r}, stream={stream!r}, force_styling={force_styling!r}, '
+            f'kind_fallback: {kind_fallback!r}, _xtgettcap_data: {_xtgettcap_data!r}'
         ]
-        self._normal = None  # cache normal attr, preventing recursive lookups
+        self._normal = None
+
         # we assume our input stream to be line-buffered until either the
         # cbreak of raw context manager methods are entered with an attached tty.
         self._line_buffered = True
@@ -238,54 +244,95 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         self._stream = stream
         self._keyboard_fd = None
         self._keyboard_eof = False
+        self._encoding = 'UTF-8'
         self._init_descriptor = None
         self._is_a_tty = False
+        self._keyboard_buf: 'collections.deque[str]' = collections.deque()
+        self._dec_mode_cache: Dict[int, int] = {}
         self.__init__streams()
-
-        if IS_WINDOWS and self._init_descriptor is not None:
-            self._kind = kind or curses.get_term(self._init_descriptor)
-        else:
-            self._kind = kind or os.environ.get('TERM', 'dumb') or 'dumb'
-
         self.__init_set_styling(force_styling)
         if self.does_styling:
-            # Initialize curses (call setupterm), so things like tigetstr() work.
-            try:
-                curses.setupterm(self._kind, self._init_descriptor)
-            except curses.error as err:
-                msg = f'Failed to setupterm(kind={self._kind!r}): {err}'
-                warnings.warn(msg)
-                self.errors.append(msg)
-                self._kind = None
-                self._does_styling = False
-            else:
-                if _CUR_TERM is None or self._kind == _CUR_TERM:
-                    _CUR_TERM = self._kind
-                else:
-                    # termcap 'kind' is immutable in a python process! Once
-                    # initialized by setupterm, it is unsupported by the
-                    # 'curses' module to change the terminal type again. If you
-                    # are a downstream developer and you need this
-                    # functionality, consider sub-processing, instead.
-                    warnings.warn(
-                        f'A terminal of kind "{kind}" has been requested; due to an'
-                        ' internal python curses bug, terminal capabilities'
-                        f' for a terminal of kind "{_CUR_TERM}" will continue to be'
-                        ' returned for the remainder of this process.'
-                    )
+            # Initialize keyboard state needed for XTGETTCAP probe
+            self.__init__keyboard_state()
 
-        self.__init__color_capabilities()
-        self.__init__capabilities()
+            # Step 1: XTGETTCAP capability negotiation
+            self._xtgettcap_cache: Optional[TermcapResponse] = None
+            self._xtgettcap_first_query_failed = False
+            self._xtgettcap_cache = (
+                _xtgettcap_data if _xtgettcap_data is not None
+                else self.__init__xtgettcap())
+
+            # Step 2: Initialize using jinxed for its terminfo(5) database.
+            self.__init_termcap_kind(kind_preferred=kind, kind_fallback=kind_fallback)
+
+        # Step 3: Initialize keyboard infrastructure
         self.__init__keycodes()
-        self.__init__dec_private_modes()
 
+        # Step 5: Finalize capabilities using best available data
+        self.number_of_colors = self.__init__color_capabilities()
+        self.__init__capabilities()
         self.__init__query_caches()
 
+    def __init__keyboard_state(self) -> None:
+        """Initialize minimal keyboard state needed for XTGETTCAP probe."""
+        # Build database of int code <=> KEY_NAME (static, no jinxed deps).
+        self._keycodes = get_keyboard_codes()
+
+        # Store attributes as: self.KEY_NAME = code.
+        for key_code, key_name in self._keycodes.items():
+            setattr(self, key_name, key_code)
+
+        # Empty sequence maps -- __init__keycodes will fill these after jinxed init.
+        self._keymap: collections.OrderedDict[str, int] = collections.OrderedDict()
+        self._keymap_prefixes: set[str] = set()
+
+    def __init__xtgettcap(self) -> TermcapResponse:
+        """XTGETTCAP probing happens lazily on first call to get_xtgettcap()."""
+        return None
+
+    def __init_termcap_kind(self, kind_preferred: Optional[str], kind_fallback: str) -> None:
+        """Determine terminal 'kind' jinxed.setupterm() capability database."""
+        # Previous to 1.40, blessed could fallback to 'dumb' when it could not find a meaningful
+        # type, but now kind_fallback='xterm-256color' is always guaranteed available and used
+        # instead of 'dumb'.
+        #
+        # I believe now xterm-256 sequences are safe as unknown fallback for the year 2026. If dumb
+        # *is*, use NO_COLOR or force_styling=False which has the same general result.
+        tn_kind = (self._xtgettcap_cache.capabilities.get('TN')
+                   if self._xtgettcap_cache is not None else None)
+        term_kind = (jinxed.get_term(self._init_descriptor)
+                     if IS_WINDOWS and self._init_descriptor is not None
+                     else os.environ.get('TERM'))
+        kind_resolution_order = list(dict.fromkeys(
+            filter(None, [kind_preferred, tn_kind, term_kind, kind_fallback])))
+        last_exc = None
+        for idx, _kind in enumerate(kind_resolution_order):
+            try:
+                self._jinxed_term = jinxed.Terminal(_kind, self._init_descriptor)
+            except jinxed.error as exc:
+                last_exc = exc
+                _left_msg = ('; will try another'
+                             if idx < len(kind_resolution_order) - 1
+                             else '')
+                self.errors.append(
+                    f'jinxed.Terminal({_kind!r}, {self._init_descriptor}):'
+                    f' {exc}{_left_msg}')
+            else:
+                self._kind = _kind
+                return
+        raise last_exc  # type: ignore[misc]
+
     def __init__query_caches(self) -> None:
-        # Initialize Kitty keyboard protocol tracking
+        # So many terminal capabilities are static, except those queries through `get_decrqss()`.
+        # For that reason, to avoid unnecessary initialization to "query everything, use little",
+        # and to avoid latency to allow for for often-repeated overhead like
+        # `Terminal.does_synchronized_output()`, we memoize lots of caches to remember the state of
+        # our connected terminal when asked.  Initialize Kitty keyboard protocol tracking.
         self._kitty_kb_first_query_failed = False
 
         # Device Attributes (DA1) cache and sticky failure tracking
+        self._dec_first_query_failed = False
+        self._dec_any_query_succeeded = False
         self._device_attributes_cache: Optional[DeviceAttribute] = None
         self._device_attributes_first_query_failed = False
 
@@ -308,37 +355,22 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         # terminal dimensions from resize events
         self._preferred_size_cache: Optional["WINSZ"] = None
 
-        # XTGETTCAP cache and sticky failure tracking
-        self._xtgettcap_cache: Optional[TermcapResponse] = None
-        self._xtgettcap_first_query_failed = False
-
         # Kitty Graphics protocol detection cache
         self._kitty_graphics_supported: Optional[bool] = None
-
         # iTerm2 capabilities cache
         self._iterm2_capabilities_cache: Optional["ITerm2Capabilities"] = None
-
         # Kitty notifications (OSC 99) detection cache
         self._kitty_notifications_supported: Optional[bool] = None
-
         # Kitty clipboard protocol (DECRQM 5522) detection cache
         self._kitty_clipboard_supported: Optional[bool] = None
-
         # Kitty pointer shapes (OSC 22) detection cache
         self._kitty_pointer_shapes_result: Optional[Tuple[bool, str]] = None
-
         # Text sizing (OSC 66) detection cache
         self._text_sizing_cache: Optional[TextSizingResult] = None
-
         # OSC 52 clipboard detection cache
         self._osc52_clipboard_supported: Optional[bool] = None
-
         # Color scheme (dark/light mode) -- whether query is supported
         self._color_scheme_supported: Optional[bool] = None
-
-        # Kitty XTGETTCAP query extensions detection cache
-        self._kitty_query_supported: Optional[bool] = None
-
         # DECRQSS detection cache
         self._decrqss_supported: Optional[bool] = None
 
@@ -385,7 +417,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         # Keyboard valid as stdin only when output stream is stdout or stderr and is a tty.
         if self._stream in (sys.__stdout__, sys.__stderr__):
             try:
-                self._keyboard_fd = sys.__stdin__.fileno()  # type: ignore[union-attr]
+                self._keyboard_fd = sys.__stdin__.fileno()  # type: ignore[union-attr,assignment]
             except (AttributeError, ValueError) as err:
                 self.errors.append(f'Unable to determine input stream file descriptor: {err}')
             else:
@@ -400,21 +432,47 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             self.errors.append('Output stream is not a default stream')
 
         # The descriptor to direct terminal initialization sequences to.
-        self._init_descriptor = stream_fd
+        self._init_descriptor = stream_fd  # type: ignore[assignment]
         if stream_fd is None:
             try:
-                self._init_descriptor = sys.__stdout__.fileno()  # type: ignore[union-attr]
+                self._init_descriptor = \
+                    sys.__stdout__.fileno()  # type: ignore[union-attr,assignment]
             except ValueError as err:
-                self.errors.append(f'Unable to determine __stdout__ file descriptor: {err}')
+                self.errors.append(
+                    f'sys.__stdout__.fileno() failed, stdout may be detached or closed: {err}')
 
-    def __init__color_capabilities(self) -> None:
+        # Determine keyboard encoding early so XTGETTCAP probe can use it.
+        if self._keyboard_fd is not None:
+            if IS_WINDOWS:
+                self._encoding = get_console_input_encoding() \
+                    or locale.getpreferredencoding() or 'UTF-8'
+            else:
+                self._encoding = locale.getpreferredencoding() or 'UTF-8'
+            try:
+                self._keyboard_decoder = codecs.getincrementaldecoder(self._encoding)()
+            except LookupError as err:
+                err_msg = f'LookupError: {err}, defaulting to UTF-8 for keyboard.'
+                warnings.warn(err_msg)
+                self.errors.append(err_msg)
+                self._encoding = 'UTF-8'
+                self._keyboard_decoder = codecs.getincrementaldecoder(self._encoding)()
+
+    def __init__color_capabilities(self) -> int:
+        """Initialize color distance algorithm and determine Terminal.number_of_colors."""
+        # Resolution order:
+        # - COLORTERM environment value
+        # - termcap 'colors' (jinxed)
+        # - Windows native console (vtwin10) gets 24-bit boost
         self._color_distance_algorithm = 'cie2000'
         if not self.does_styling:
-            self.number_of_colors = 0
-        elif IS_WINDOWS or os.environ.get('COLORTERM') in {'truecolor', '24bit'}:
-            self.number_of_colors = 1 << 24
-        else:
-            self.number_of_colors = max(0, curses.tigetnum('colors') or -1)
+            return 0
+        if os.environ.get('COLORTERM') in {'truecolor', '24bit'}:
+            return 1 << 24
+        _win_build = tuple(int(n) for n in platform.version().split('.')
+                           if n.isdigit()) if IS_WINDOWS else 0
+        if IS_WINDOWS and self._kind == 'vtwin10' and _win_build >= (10, 0, 14931):
+            return 1 << 24
+        return max(0, self._jinxed_term.tigetnum('colors'))
 
     def __clear_color_capabilities(self) -> None:
         for cached_color_cap in set(dir(self)) & COLORS:
@@ -490,44 +548,14 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
         # Add DEC event prefixes (mouse, bracketed paste, focus tracking) These
         # are not in the keymap but need to be recognized as valid "prefixes",
-        # so that they are not detected early as metaSendsEscape sequence until
+        # so that they are *not* detected as a 'metaSendsEscape' sequence until
         # after esc_delay has elapsed.
         self._keymap_prefixes.update([
             '\x1b[M',     # Legacy mouse (needs 3 more bytes)
             '\x1b[<',     # SGR mouse (variable length)
             '\x1b[200',   # Bracketed paste start and its starting prefixes,
             '\x1b[20',
-            '\x1b[2',
-        ])
-
-        # keyboard stream buffer
-        self._keyboard_buf: collections.deque[str] = collections.deque()
-
-        if self._keyboard_fd is not None:
-            # set input encoding and initialize incremental decoder
-
-            if IS_WINDOWS:
-                # pylint: disable-next=possibly-used-before-assignment
-                self._encoding = get_console_input_encoding() \
-                    or locale.getpreferredencoding() or 'UTF-8'
-            else:
-                self._encoding = locale.getpreferredencoding() or 'UTF-8'
-
-            try:
-                self._keyboard_decoder = codecs.getincrementaldecoder(self._encoding)()
-            except LookupError as err:
-                # encoding is illegal or unsupported, use 'UTF-8'
-                warnings.warn(f'LookupError: {err}, defaulting to UTF-8 for keyboard.')
-                self._encoding = 'UTF-8'
-                self._keyboard_decoder = codecs.getincrementaldecoder(self._encoding)()
-
-    def __init__dec_private_modes(self) -> None:
-        """Initialize DEC Private Mode caching and state tracking."""
-        # Cache for queried DEC private modes to avoid repeated queries
-        self._dec_mode_cache: Dict[int, int] = {}
-        # Global timeout tracking state
-        self._dec_any_query_succeeded = False
-        self._dec_first_query_failed = False
+            '\x1b[2'])
 
     def __getattr__(self,
                     attr: str) -> Union[NullCallableString,
@@ -555,8 +583,10 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         <https://invisible-island.net/ncurses/man/terminfo.5.html>`_ for a
         complete list of capabilities and their arguments.
         """
-        if not self._does_styling:
+        if not self.does_styling:
             return NullCallableString()
+        if attr.startswith('_'):
+            raise AttributeError(attr)
         # Fetch the missing 'attribute' into some kind of curses-resolved
         # capability, and cache by attaching to this Terminal class instance.
         #
@@ -767,7 +797,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         """
         if not self.is_a_tty:
             return None
-        if requires_styling and not self._does_styling:
+        if requires_styling and not self.does_styling:
             return None
 
         # Send feature query + CPR request. We always wait for the CPR
@@ -854,7 +884,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             self.stream.write(self.restore)
             self.stream.flush()
 
-    def get_location(self, timeout: float = 1) -> Tuple[int, int]:
+    def get_location(self, timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS) -> Tuple[int, int]:
         r"""
         Return tuple (row, column) of cursor position.
 
@@ -926,7 +956,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         # check or filters, such as if (x, y) != (-1, -1) or max(0, y).
         return -1, -1
 
-    def get_fgcolor(self, timeout: float = 1, bits: int = 16) -> Tuple[int, int, int]:
+    def get_fgcolor(self, timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS,
+                    bits: int = 16) -> Tuple[int, int, int]:
         """
         Return tuple (r, g, b) of default foreground color.
 
@@ -965,7 +996,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             return (-1, -1, -1)
         return tuple(xparse_color(val, bits=bits) for val in match.groups())
 
-    def get_bgcolor(self, timeout: float = 1, bits: int = 16) -> Tuple[int, int, int]:
+    def get_bgcolor(self, timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS,
+                    bits: int = 16) -> Tuple[int, int, int]:
         """
         Return tuple (r, g, b) of default background color.
 
@@ -1004,7 +1036,10 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             return (-1, -1, -1)
         return tuple(xparse_color(val, bits=bits) for val in match.groups())
 
-    def get_fgcolor_hex(self, timeout: float = 1, maybe_short: bool = False) -> str:
+    def get_fgcolor_hex(
+            self,
+            timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS,
+            maybe_short: bool = False) -> str:
         """
         Return default foreground color as hex string.
 
@@ -1022,7 +1057,10 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             return ''
         return rgb_to_hex(*rgb, maybe_short=maybe_short)
 
-    def get_bgcolor_hex(self, timeout: float = 1, maybe_short: bool = False) -> str:
+    def get_bgcolor_hex(
+            self,
+            timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS,
+            maybe_short: bool = False) -> str:
         """
         Return default background color as hex string.
 
@@ -1040,7 +1078,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             return ''
         return rgb_to_hex(*rgb, maybe_short=maybe_short)
 
-    def get_device_attributes(self, timeout: Optional[float] = 1,
+    def get_device_attributes(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                               force: bool = False) -> Optional[DeviceAttribute]:
         """
         Query the terminal's Device Attributes (DA1).
@@ -1072,7 +1110,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             term = Terminal()
 
             # Query device attributes
-            da = term.get_device_attributes(timeout=1.0)
+            da = term.get_device_attributes(timeout=TERMINAL_QUERY_TIMEOUT_SECONDS)
             if da is not None:
                 print(f"Service class: {da.service_class}")
                 print(f"Supports sixel: {da.supports_sixel}")
@@ -1094,14 +1132,10 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             self._device_attributes_first_query_failed = True
             return None
 
-        result = DeviceAttribute.from_match(match)
+        self._device_attributes_cache = DeviceAttribute.from_match(match)
+        return self._device_attributes_cache
 
-        if result is not None:
-            self._device_attributes_cache = result
-
-        return result
-
-    def get_software_version(self, timeout: Optional[float] = 1,
+    def get_software_version(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                              force: bool = False) -> Optional[SoftwareVersion]:
         """
         Query the terminal's software name and version using XTVERSION.
@@ -1133,7 +1167,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             term = Terminal()
 
             # Query software version
-            sv = term.get_software_version(timeout=1.0)
+            sv = term.get_software_version(timeout=TERMINAL_QUERY_TIMEOUT_SECONDS)
             if sv is not None:
                 print(f"Terminal: {sv.name} {sv.version}")
         """
@@ -1164,7 +1198,10 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
         return None
 
-    def does_sixel(self, timeout: Optional[float] = 1, force: bool = False) -> bool:
+    def does_sixel(
+            self,
+            timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
+            force: bool = False) -> bool:
         """
         Query whether the terminal supports sixel graphics.
 
@@ -1184,12 +1221,17 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         :rtype: bool
         :returns: ``True`` if terminal supports sixel graphics, ``False`` otherwise
         """
+        # Although there are additional checks that could be done, such as
+        # get_iterm2_capabilities().features.get('Sx'), it is superfluous to DA1.
         if not self.does_styling:
             return False
         da = self.get_device_attributes(timeout=timeout, force=force)
         return da.supports_sixel if da is not None else False
 
-    def detect_ambiguous_width(self, timeout: float = 1, fallback: int = 1) -> int:
+    def detect_ambiguous_width(
+            self,
+            timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS,
+            fallback: int = 1) -> int:
         r"""
         Detect whether terminal renders ambiguous width characters as width 1 or 2.
 
@@ -1251,8 +1293,11 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         width = new_col - initial_col
         return width if width in {1, 2} else fallback
 
-    def get_dec_mode(self, mode: Union[int, _DecPrivateMode],
-                     timeout: float = 1, force: bool = False) -> DecModeResponse:
+    def get_dec_mode(self,
+                     mode: Union[int,
+                                 _DecPrivateMode],
+                     timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS,
+                     force: bool = False) -> DecModeResponse:
         """
         Query the state of a DEC Private Mode (DECRQM).
 
@@ -1349,8 +1394,10 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         return DecModeResponse(mode, response_value)
 
     @contextlib.contextmanager
-    def dec_modes_enabled(self, *modes: Union[int, _DecPrivateMode],
-                          timeout: Optional[float] = 1) -> Generator[None, None, None]:
+    def dec_modes_enabled(self,
+                          *modes: Union[int, _DecPrivateMode],
+                          timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS
+                          ) -> Generator[None, None, None]:
         """
         Context manager for temporarily enabling DEC Private Modes.
 
@@ -1400,8 +1447,10 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             self._dec_mode_set_disabled(*enabled_modes)
 
     @contextlib.contextmanager
-    def dec_modes_disabled(self, *modes: Union[int, _DecPrivateMode],
-                           timeout: Optional[float] = 1) -> Generator[None, None, None]:
+    def dec_modes_disabled(self,
+                           *modes: Union[int, _DecPrivateMode],
+                           timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS
+                           ) -> Generator[None, None, None]:
         """
         Context manager for temporarily disabling DEC Private Modes.
 
@@ -1438,7 +1487,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
     def does_mouse(self, *, clicks: bool = True, report_pixels: bool = False,
                    report_drag: bool = False, report_motion: bool = False,
-                   timeout: float = 1.0) -> bool:
+                   timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS) -> bool:
         """
         Check if the terminal supports the specified mouse tracking features.
 
@@ -1482,7 +1531,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
         return True
 
-    def does_inband_resize(self, timeout: float = 1.0) -> bool:
+    def does_inband_resize(self, timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS) -> bool:
         """
         Check if the terminal supports in-band window resize notifications.
 
@@ -1505,10 +1554,9 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
                 # Fall back to SIGWINCH or other methods
                 pass
         """
-        response = self.get_dec_mode(_DecPrivateMode.IN_BAND_WINDOW_RESIZE, timeout=timeout)
-        return response.supported
+        return self.get_dec_mode(_DecPrivateMode.IN_BAND_WINDOW_RESIZE, timeout=timeout).supported
 
-    def does_bracketed_paste(self, timeout: float = 1.0) -> bool:
+    def does_bracketed_paste(self, timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS) -> bool:
         """
         Check if the terminal supports bracketed paste mode.
 
@@ -1521,10 +1569,9 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         :returns: True if bracketed paste mode is supported.
         :rtype: bool
         """
-        response = self.get_dec_mode(_DecPrivateMode.BRACKETED_PASTE, timeout=timeout)
-        return response.supported
+        return self.get_dec_mode(_DecPrivateMode.BRACKETED_PASTE, timeout=timeout).supported
 
-    def does_synchronized_output(self, timeout: float = 1.0) -> bool:
+    def does_synchronized_output(self, timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS) -> bool:
         """
         Check if the terminal supports synchronized output.
 
@@ -1537,10 +1584,9 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         :returns: True if synchronized output is supported.
         :rtype: bool
         """
-        response = self.get_dec_mode(_DecPrivateMode.SYNCHRONIZED_OUTPUT, timeout=timeout)
-        return response.supported
+        return self.get_dec_mode(_DecPrivateMode.SYNCHRONIZED_OUTPUT, timeout=timeout).supported
 
-    def does_grapheme_clustering(self, timeout: float = 1.0) -> bool:
+    def does_grapheme_clustering(self, timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS) -> bool:
         """
         Check if the terminal supports grapheme clustering.
 
@@ -1553,10 +1599,9 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         :returns: True if grapheme clustering is supported.
         :rtype: bool
         """
-        response = self.get_dec_mode(_DecPrivateMode.GRAPHEME_CLUSTERING, timeout=timeout)
-        return response.supported
+        return self.get_dec_mode(_DecPrivateMode.GRAPHEME_CLUSTERING, timeout=timeout).supported
 
-    def does_focus_events(self, timeout: float = 1.0) -> bool:
+    def does_focus_events(self, timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS) -> bool:
         """
         Check if the terminal supports focus in/out event reporting.
 
@@ -1569,11 +1614,11 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         :returns: True if focus event reporting is supported.
         :rtype: bool
         """
-        response = self.get_dec_mode(_DecPrivateMode.FOCUS_IN_OUT_EVENTS, timeout=timeout)
-        return response.supported
+        return self.get_dec_mode(_DecPrivateMode.FOCUS_IN_OUT_EVENTS, timeout=timeout).supported
 
-    def get_xtgettcap(self, timeout: Optional[float] = 1,
+    def get_xtgettcap(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                       force: bool = False) -> Optional[TermcapResponse]:
+        # pylint: disable=too-complex
         """
         Query terminal capabilities via XTGETTCAP (DCS +q).
 
@@ -1597,10 +1642,12 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         if not self.is_a_tty:
             return None
 
-        if self._xtgettcap_cache is not None and not force:
-            return self._xtgettcap_cache
-
         if self._xtgettcap_first_query_failed and not force:
+            return None
+
+        if self._xtgettcap_cache is not None and not force:
+            if self._xtgettcap_cache.supported:
+                return self._xtgettcap_cache
             return None
 
         # Phase 1: Probe with single capability via _query_with_boundary,
@@ -1614,8 +1661,9 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         if match is None:
             self._xtgettcap_first_query_failed = True
             # Erase any visible garbage from unsupported terminals
-            self.stream.write(f'\r{self.clear_eol}')
-            self.stream.flush()
+            if hasattr(self, '_jinxed_term'):
+                self.stream.write(f'\r{self.clear_eol}')
+                self.stream.flush()
             return None
 
         capabilities: Dict[str, str] = {}
@@ -1667,7 +1715,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         for match in _RE_XTGETTCAP_RESPONSE.finditer(raw):
             Terminal._parse_single_xtgettcap(match, capabilities)
 
-    def does_xtgettcap(self, timeout: Optional[float] = 1,
+    def does_xtgettcap(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                        force: bool = False) -> bool:
         """
         Check if the terminal supports XTGETTCAP (DCS +q) queries.
@@ -1677,9 +1725,9 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         :rtype: bool
         """
         result = self.get_xtgettcap(timeout=timeout, force=force)
-        return result is not None and result.supported
+        return result is not None
 
-    def does_kitty_graphics(self, timeout: Optional[float] = 1,
+    def does_kitty_graphics(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                             force: bool = False) -> bool:
         """
         Check if the terminal supports the Kitty graphics protocol.
@@ -1706,7 +1754,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         self._kitty_graphics_supported = supported
         return supported
 
-    def get_iterm2_capabilities(self, timeout: Optional[float] = 1,
+    def get_iterm2_capabilities(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                                 force: bool = False
                                 ) -> Optional["ITerm2Capabilities"]:
         """
@@ -1747,7 +1795,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         self._iterm2_capabilities_cache = result
         return result
 
-    def does_iterm2(self, timeout: Optional[float] = 1,
+    def does_iterm2(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                     force: bool = False) -> bool:
         """
         Check if the terminal supports any iTerm2 protocols.
@@ -1759,7 +1807,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         result = self.get_iterm2_capabilities(timeout=timeout, force=force)
         return result is not None and result.supported
 
-    def does_iterm2_graphics(self, timeout: Optional[float] = 1,
+    def does_iterm2_graphics(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                              force: bool = False) -> bool:
         """
         Check if the terminal supports iTerm2 inline image protocol.
@@ -1775,7 +1823,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         """
         return self.does_iterm2(timeout=timeout, force=force)
 
-    def does_kitty_notifications(self, timeout: Optional[float] = 1,
+    def does_kitty_notifications(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                                  force: bool = False) -> bool:
         """
         Check if the terminal supports Kitty desktop notifications (OSC 99).
@@ -1803,7 +1851,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         self._kitty_notifications_supported = supported
         return supported
 
-    def does_kitty_clipboard(self, timeout: Optional[float] = 1,
+    def does_kitty_clipboard(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                              force: bool = False) -> bool:
         """
         Check if the terminal supports the Kitty clipboard protocol (mode 5522).
@@ -1828,7 +1876,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         self._kitty_clipboard_supported = supported
         return supported
 
-    def does_kitty_pointer_shapes(self, timeout: Optional[float] = 1,
+    def does_kitty_pointer_shapes(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                                   force: bool = False
                                   ) -> Optional[str]:
         """
@@ -1857,7 +1905,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         self._kitty_pointer_shapes_result = (False, '')
         return None
 
-    def does_osc52_clipboard(self, timeout: Optional[float] = 1,
+    def does_osc52_clipboard(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                              force: bool = False) -> bool:
         r"""
         Detect OSC 52 clipboard support without reading the clipboard.
@@ -1881,7 +1929,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             return True
 
         # Strategy 2: XTGETTCAP Ms capability
-        tcap = self.get_xtgettcap(timeout=timeout)
+        tcap = self.get_xtgettcap(timeout=timeout, force=force)
         if tcap is not None and 'Ms' in tcap.capabilities:
             self._osc52_clipboard_supported = True
             return True
@@ -1947,7 +1995,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         except ValueError:
             return None
 
-    def get_color_scheme(self, timeout: Optional[float] = 1,
+    def get_color_scheme(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                          force: bool = False) -> Optional[str]:
         """
         Query the terminal's color scheme preference (dark or light mode).
@@ -1980,42 +2028,40 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         self._color_scheme_supported = False
         return None
 
-    def does_kitty_query(self, timeout: Optional[float] = 1,
+    def does_kitty_query(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                          force: bool = False) -> bool:
         """
-        Detect Kitty XTGETTCAP query extensions.
+        Detect Kitty with XTGETTCAP query extensions.
 
-        Kitty extends the standard ``XTGETTCAP`` (``DCS +q``) mechanism
-        with ``kitty-query-*`` keys that expose runtime metadata such as
-        the terminal name, version, font family, DPI, and clipboard
-        control policy.
+        This is a trifle convenience wrapper of :meth:`get_xtgettcap()`.
 
-        This method probes for ``kitty-query-name`` support.  A
-        successful response indicates the full set of Kitty query
-        extensions is available.
+        This method probes for ``kitty-query-name`` support.  A successful response indicates that
+        some set of Kitty query extensions are available.
 
-        .. seealso::
+        To retrieve their values, follow up with :meth:`get_xtgettcap` directly, for example:
 
-            `Query terminal -- kitty
-            <https://sw.kovidgoyal.net/kitty/kittens/query_terminal/>`_
+        .. code-block:: python
+
+            >>> term = Terminal()
+            >>> term.does_kitty_query()
+            True
+            >>> term.get_xtgettcap(caps=[f"kitty-query-{key}" for key in [
+                "font_family", "font_size", "dpi_x", "dpi_y"]])
+            TermcapResponse(supported=True, capabilities={
+                'kitty-query-font_family': 'NotoSansMono-Regular',
+                'kitty-query-font_size': '19',
+                'kitty-query-dpi_x': '96',
+                'kitty-query-dpi_y': '96'})
 
         :arg float timeout: Timeout in seconds.
         :arg bool force: Bypass cached result.
         :rtype: bool
         """
-        if self._kitty_query_supported is not None and not force:
-            return self._kitty_query_supported
-
-        capname = 'kitty-query-name'
-        query = f'\x1bP+q{TermcapResponse.hex_encode(capname)}\x1b\\'
-        match = self._query_with_boundary(
-            query, _RE_XTGETTCAP_RESPONSE, timeout)
-        supported = match is not None and match.group(1) == '1'
-        self._kitty_query_supported = supported
-        return supported
+        result = self.get_xtgettcap(timeout=timeout, force=force)
+        return result is not None and 'kitty-query-name' in result.capabilities
 
     def get_decrqss(self, setting_id: str = Decrqss.SGR,
-                    timeout: Optional[float] = 1) -> Optional[str]:
+                    timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS) -> Optional[str]:
         """
         Query terminal state via DECRQSS (Request Status String).
 
@@ -2052,7 +2098,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             return pt
         return None
 
-    def does_decrqss(self, timeout: Optional[float] = 1,
+    def does_decrqss(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                      force: bool = False) -> bool:
         """
         Detect DECRQSS (Request Status String) support.
@@ -2076,7 +2122,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         self._decrqss_supported = supported
         return supported
 
-    def does_styled_underlines(self, timeout: Optional[float] = 1,
+    def does_styled_underlines(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                                force: bool = False) -> bool:
         """
         Detect extended underline style support (curly, dotted, dashed).
@@ -2092,7 +2138,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         tc = self.get_xtgettcap(timeout=timeout, force=force)
         return tc is not None and 'Smulx' in tc
 
-    def does_colored_underlines(self, timeout: Optional[float] = 1,
+    def does_colored_underlines(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                                 force: bool = False) -> bool:
         """
         Detect colored underline support (``CSI 58;2;r;g;b m``).
@@ -2106,7 +2152,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         tc = self.get_xtgettcap(timeout=timeout, force=force)
         return tc is not None and 'Setulc' in tc
 
-    def does_text_sizing(self, timeout: float = 1,
+    def does_text_sizing(self, timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS,
                          force: bool = False) -> TextSizingResult:
         """
         Detect Kitty text sizing protocol support (OSC 66).
@@ -2123,7 +2169,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         :rtype: TextSizingResult
         :returns: Result with ``.width`` and ``.scale`` boolean attributes.
         """
-        if not self.is_a_tty or not self._does_styling:
+        if not self.is_a_tty or not self.does_styling:
             return TextSizingResult()
         if self._text_sizing_cache is not None and not force:
             return self._text_sizing_cache
@@ -2161,7 +2207,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
     @contextlib.contextmanager
     def mouse_enabled(self, *, clicks: bool = True, report_pixels: bool = False,
                       report_drag: bool = False, report_motion: bool = False,
-                      timeout: float = 1.0) -> Generator[None, None, None]:
+                      timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS
+                      ) -> Generator[None, None, None]:
         """
         Context manager for enabling mouse tracking with various reporting modes.
 
@@ -2211,7 +2258,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             yield
 
     @contextlib.contextmanager
-    def bracketed_paste(self, timeout: float = 1.0) -> Generator[None, None, None]:
+    def bracketed_paste(
+            self, timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS) -> Generator[None, None, None]:
         """
         Context manager for enabling bracketed paste mode.
 
@@ -2232,7 +2280,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             yield
 
     @contextlib.contextmanager
-    def synchronized_output(self, timeout: float = 1.0) -> Generator[None, None, None]:
+    def synchronized_output(
+            self, timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS) -> Generator[None, None, None]:
         """
         Context manager for enabling synchronized output mode.
 
@@ -2245,7 +2294,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             yield
 
     @contextlib.contextmanager
-    def focus_events(self, timeout: float = 1.0) -> Generator[None, None, None]:
+    def focus_events(
+            self, timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS) -> Generator[None, None, None]:
         """
         Context manager for enabling focus event reporting.
 
@@ -2258,7 +2308,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             yield
 
     @contextlib.contextmanager
-    def notify_on_resize(self, timeout: float = 1.0) -> Generator[None, None, None]:
+    def notify_on_resize(
+            self, timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS) -> Generator[None, None, None]:
         """
         Context manager for enabling in-band window resize notifications.
 
@@ -2374,7 +2425,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         for mode_num in mode_numbers:
             self._dec_mode_cache[mode_num] = DecModeResponse.RESET
 
-    def get_sixel_height_and_width(self, timeout: Optional[float] = 1,
+    def get_sixel_height_and_width(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                                    force: bool = False) -> Tuple[int, int]:
         # pylint: disable=too-complex,too-many-branches
         """
@@ -2458,7 +2509,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         # All methods failed
         return (-1, -1)
 
-    def get_sixel_colors(self, timeout: Optional[float] = 1,
+    def get_sixel_colors(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                          force: bool = False) -> int:
         """
         Query number of sixel color registers (XTSMGRAPHICS).
@@ -2496,7 +2547,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
         return self._xtsmgraphics_colors_cache
 
-    def get_cell_height_and_width(self, timeout: Optional[float] = 1,
+    def get_cell_height_and_width(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                                   force: bool = False) -> Tuple[int, int]:
         """
         Query character cell pixel dimensions (XTWINOPS).
@@ -2572,7 +2623,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
         return int(match.group(1))
 
-    def get_kitty_keyboard_state(self, timeout: Optional[float] = 1,
+    def get_kitty_keyboard_state(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                                  force: bool = False) -> Optional[KittyKeyboardProtocol]:
         """
         Query the current Kitty keyboard protocol flags.
@@ -2626,7 +2677,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
     def enable_kitty_keyboard(self, *, disambiguate: bool = True, report_events: bool = False,
                               report_alternates: bool = False, report_all_keys: bool = False,
                               report_text: bool = False, mode: int = 1,
-                              timeout: Optional[float] = 1,
+                              timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                               force: bool = False) -> Generator[None, None, None]:
         """
         Context manager that enables Kitty keyboard protocol features.
@@ -2922,7 +2973,6 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         color will be determined using :py:attr:`color_distance_algorithm`.
         """
         if self.number_of_colors == 1 << 24:
-            # "truecolor" 24-bit
             fmt_attr = f'\x1b[38;2;{red};{green};{blue}m'
             return FormattingString(fmt_attr, self.normal)
 
@@ -3071,7 +3121,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         """
         if self._normal:
             return self._normal
-        self._normal = resolve_capability(self, 'normal')
+        self._normal = resolve_capability(self, 'normal')  # type: ignore[assignment]
         return self._normal
 
     def link(self, url: str, text: str, url_id: str = '') -> str:
@@ -3219,7 +3269,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
     @number_of_colors.setter
     def number_of_colors(self, value: int) -> None:
-        assert value in (0, 4, 8, 16, 88, 256, 1 << 24)
+        assert value in (0, 4, 8, 16, 88, 256, 1 << 24), value
         # Because 88 colors is rare and we can't guarantee consistent behavior,
         # when 88 colors is detected, it is treated as 16 colors
         self._number_of_colors = 16 if value == 88 else value
@@ -3364,27 +3414,31 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             raise ValueError("'text' must not contain control codes or terminal sequences, "
                              f"got ESC (\\x1b) at index {pos_esc}")
 
-        if isinstance(vertical_align, int):
-            if not 0 <= vertical_align <= 2:
-                raise ValueError(f"'vertical_align' out of range (0-2), got {vertical_align}")
-        else:
-            mapping_vert = {'top': 0, 'bottom': 1, 'center': 2, 'default': 0}
-            if vertical_align not in mapping_vert:
-                expected_vert = ', '.join(mapping_vert)
-                raise ValueError(f"'vertical_align' invalid, expected: {expected_vert}, "
-                                 f"got {vertical_align}")
-            vertical_align = mapping_vert[vertical_align]
+        def _validate(name: str, value: Union[int, str],
+                      string_values: Dict[str, int]) -> int:
+            if isinstance(value, int):
+                if not 0 <= value <= 2:
+                    raise ValueError(f"'{name}' out of range (0-2), got {value}")
+                return value
+            if value not in string_values:
+                expected = ', '.join(string_values)
+                raise ValueError(f"'{name}' invalid, expected: {expected}, got {value}")
+            return string_values[value]
 
-        if isinstance(horizontal_align, int):
-            if not 0 <= horizontal_align <= 2:
-                raise ValueError(f"'horizontal_align' out of range (0-2), got {horizontal_align}")
-        else:
-            mapping_horz = {'left': 0, 'right': 1, 'center': 2, 'default': 0}
-            if horizontal_align not in mapping_horz:
-                expected_horz = ', '.join(mapping_horz)
-                raise ValueError(f"'horizontal_align' invalid, expected: {expected_horz}, "
-                                 f"got {horizontal_align}")
-            horizontal_align = mapping_horz[horizontal_align]
+        _vert_map = {'top': 0, 'bottom': 1, 'center': 2, 'default': 0}
+        _horz_map = {'left': 0, 'right': 1, 'center': 2, 'default': 0}
+        vertical_align = _validate('vertical_align', vertical_align, _vert_map)
+        horizontal_align = _validate('horizontal_align', horizontal_align, _horz_map)
+
+        # Kitty text sizing protocol: alignment only applies when fractional
+        # scaling is in effect (0 < numerator < denominator).  When there is
+        # no fractional scaling, alignment describes how the scaled render area
+        # fits inside the cell grid — which has no meaning and can cause
+        # flickering/artifacts if passed unconditionally.
+        is_fractional = 0 < numerator < denominator
+        if not is_fractional:
+            vertical_align = 0
+            horizontal_align = 0
 
         params = TextSizingParams(scale=scale, width=width, numerator=numerator,
                                   denominator=denominator, vertical_align=vertical_align,
@@ -3608,8 +3662,11 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         if self._keyboard_eof:
             return False
 
+        if self._keyboard_fd is None:
+            return False
+
         ready_r = [None, ]
-        check_r = [self._keyboard_fd] if self._keyboard_fd is not None else []
+        check_r = [self._keyboard_fd]
 
         if HAS_TTY:
             ready_r, _, _ = select.select(check_r, [], [], timeout)
@@ -3647,24 +3704,32 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             see http://www.unixwiz.net/techtips/termios-vmin-vtime.html
         """
         if HAS_TTY and self._keyboard_fd is not None:
-            # Save current terminal mode:
+            # pylint: disable=possibly-used-before-assignment
+            # why is pylint only noticing an error here, but not in raw() ?!
+            with self._enter_termios_mode(tty.setcbreak):
+                yield
+        else:
+            yield
+
+    @contextlib.contextmanager
+    def _enter_termios_mode(self, setter: Callable[[int, int], None]
+                            ) -> Generator[None, None, None]:
+        """Put the keyboard terminal into mode using 'setter', guarding against SIGTTOU."""
+        old_sigttou = signal.signal(signal.SIGTTOU, signal.SIG_IGN)
+        try:
             save_mode = termios.tcgetattr(self._keyboard_fd)
             save_line_buffered = self._line_buffered
-            # pylint: disable-next=possibly-used-before-assignment
-            tty.setcbreak(self._keyboard_fd, termios.TCSANOW)
+            setter(self._keyboard_fd, termios.TCSANOW)
             try:
                 self._line_buffered = False
                 yield
             finally:
-                # Restore prior mode.  TCSADRAIN (not TCSAFLUSH) so that
-                # keystrokes buffered during the mode switch are preserved;
-                # TCSAFLUSH discards unread input, dropping user keystrokes.
                 termios.tcsetattr(self._keyboard_fd,
                                   termios.TCSADRAIN,
                                   save_mode)
                 self._line_buffered = save_line_buffered
-        else:
-            yield
+        finally:
+            signal.signal(signal.SIGTTOU, old_sigttou)
 
     @contextlib.contextmanager
     def raw(self) -> Generator[None, None, None]:
@@ -3687,21 +3752,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
                 print("printing in raw mode", end="\r\n")
         """
         if HAS_TTY and self._keyboard_fd is not None:
-            # Save current terminal mode:
-            save_mode = termios.tcgetattr(self._keyboard_fd)
-            save_line_buffered = self._line_buffered
-            tty.setraw(self._keyboard_fd, termios.TCSANOW)
-            try:
-                self._line_buffered = False
+            with self._enter_termios_mode(tty.setraw):
                 yield
-            finally:
-                # Restore prior mode.  TCSADRAIN (not TCSAFLUSH) so that
-                # keystrokes buffered during the mode switch are preserved;
-                # TCSAFLUSH discards unread input, dropping user keystrokes.
-                termios.tcsetattr(self._keyboard_fd,
-                                  termios.TCSADRAIN,
-                                  save_mode)
-                self._line_buffered = save_line_buffered
         else:
             yield
 
@@ -3913,7 +3965,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             indefinitely.
         :arg float esc_delay: Time in seconds to wait after Escape key
             is received to disambiguate bare Escape from escape sequences.
-        :arg bool capture_cpr: TODO
+        :arg bool capture_cpr: Prefer matches of ``CPR_RESPONSE`` over conflicting vt220 Legacy
+            function keys (eg. ``KEY_F3``, ``KEY_SHIFT_F3``).
         :rtype: :class:`~.Keystroke`
         :returns: :class:`~.Keystroke`, which may be empty (``''``) if
             ``timeout`` is specified and keystroke is not received.
@@ -4058,25 +4111,3 @@ class WINSZ(collections.namedtuple('WINSZ', (
     _FMT = 'hhhh'
     #: buffer of termios structure appropriate for ioctl argument
     _BUF = '\x00' * struct.calcsize(_FMT)
-
-
-#: _CUR_TERM = None
-#: From libcurses/doc/ncurses-intro.html (ESR, Thomas Dickey, et. al)::
-#:
-#:   "After the call to setupterm(), the global variable cur_term is set to
-#:    point to the current structure of terminal capabilities. By calling
-#:    setupterm() for each terminal, and saving and restoring cur_term, it
-#:    is possible for a program to use two or more terminals at once."
-#:
-#: However, if you study Python's ``./Modules/_cursesmodule.c``, you'll find::
-#:
-#:   if (!initialised_setupterm && setupterm(termstr,fd,&err) == ERR) {
-#:
-#: Python - perhaps wrongly - will not allow for re-initialisation of new
-#: terminals through :func:`curses.setupterm`, so the value of cur_term cannot
-#: be changed once set: subsequent calls to :func:`curses.setupterm` have no
-#: effect.
-#:
-#: Therefore, the :attr:`Terminal.kind` of each :class:`Terminal` is
-#: essentially a singleton. This global variable reflects that, and a warning
-#: is emitted if somebody expects otherwise.

--- a/blessed/win_terminal.py
+++ b/blessed/win_terminal.py
@@ -14,10 +14,12 @@ from typing import IO, List, Union, Optional, Generator
 from jinxed import win32
 
 # local
+from .keyboard import TERMINAL_QUERY_TIMEOUT_SECONDS
 from .terminal import WINSZ
 from .terminal import Terminal as _Terminal
 from .dec_modes import DecPrivateMode as _DecPrivateMode
 from .dec_modes import DecModeResponse
+from ._capabilities import TermcapResponse
 
 # Maximum time to block in WaitForSingleObject before returning
 # to Python for signal processing (e.g. KeyboardInterrupt).
@@ -110,9 +112,14 @@ class Terminal(_Terminal):
     def __init__(self,
                  kind: Optional[str] = None,
                  stream: Optional[IO[str]] = None,
-                 force_styling: Union[bool, None] = False) -> None:
+                 force_styling: Union[bool, None] = False,
+                 kind_fallback: str = 'vtwin10',
+                 _xtgettcap_data: Optional[TermcapResponse] = None
+                 ) -> None:
         """Initialize Windows terminal instance."""
-        super().__init__(kind=kind, stream=stream, force_styling=force_styling)
+        super().__init__(kind=kind, stream=stream, force_styling=force_styling,
+                         kind_fallback=kind_fallback,
+                         _xtgettcap_data=_xtgettcap_data)
         self._event_buf: collections.deque[str] = collections.deque()
         self._prev_button_state: int = 0
         self._native_mouse: bool = False
@@ -316,7 +323,8 @@ class Terminal(_Terminal):
     @contextlib.contextmanager
     def mouse_enabled(self, *, clicks: bool = True, report_pixels: bool = False,
                       report_drag: bool = False, report_motion: bool = False,
-                      timeout: float = 1.0) -> Generator[None, None, None]:
+                      timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS
+                      ) -> Generator[None, None, None]:
         """
         Context manager for enabling mouse tracking.
 
@@ -367,7 +375,7 @@ class Terminal(_Terminal):
 
     def does_mouse(self, *, clicks: bool = True, report_pixels: bool = False,
                    report_drag: bool = False, report_motion: bool = False,
-                   timeout: float = 1.0) -> bool:
+                   timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS) -> bool:
         """
         Check if the terminal supports mouse tracking.
 
@@ -381,7 +389,8 @@ class Terminal(_Terminal):
         return True
 
     @contextlib.contextmanager
-    def notify_on_resize(self, timeout: float = 1.0) -> Generator[None, None, None]:
+    def notify_on_resize(
+            self, timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS) -> Generator[None, None, None]:
         """
         Context manager for enabling in-band window resize notifications.
 
@@ -426,7 +435,7 @@ class Terminal(_Terminal):
             self._preferred_size_cache = None  # pylint: disable=attribute-defined-outside-init
             win32.set_console_mode(filehandle, save_mode)
 
-    def does_inband_resize(self, timeout: float = 1.0) -> bool:
+    def does_inband_resize(self, timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS) -> bool:
         """
         Check if the terminal supports in-band window resize notifications.
 

--- a/docs/api/terminal.rst
+++ b/docs/api/terminal.rst
@@ -5,4 +5,3 @@ terminal.py
    :members:
    :undoc-members:
    :special-members: __getattr__
-.. autodata:: _CUR_TERM

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,9 +3,6 @@ import os
 import sys
 import runpy
 import datetime
-import functools
-
-# 3rd party
 import sphinx.environment
 from docutils.utils import get_source_line
 
@@ -34,23 +31,6 @@ def _warn_node(self, msg, node):
 sphinx.environment.BuildEnvironment.warn_node = _warn_node
 
 
-def no_op_wraps(func):
-    """Replaces functools.wraps in order to undo wrapping when generating Sphinx documentation."""
-    if func.__module__ is None or 'blessed' not in func.__module__:
-        return functools.orig_wraps(func)
-
-    def wrapper(decorator):
-        sys.stderr.write(f'patched for function signature: {func!r}\n')
-        return func
-    return wrapper
-
-
-# Monkey-patch functools.wraps and contextlib.wraps
-# https://github.com/sphinx-doc/sphinx/issues/1711#issuecomment-93126473
-functools.orig_wraps = functools.wraps
-functools.wraps = no_op_wraps
-import contextlib  # isort:skip # noqa
-contextlib.wraps = no_op_wraps
 from blessed.terminal import *  # isort:skip # noqa
 
 # and finally, don't you just wish readthedocs.org could run tox? :) it can't,

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,22 @@
 Version History
 ===============
 
+1.40
+  * improved: jinxed_ is **now required on all platforms**, providing a curses-free and
+    `singleton-free <https://jinxed.readthedocs.io/en/stable/capabilities.html#singleton-free>`_
+    implementation of the subset of curses_ used by blessed.  The jinxed_ 1.5.0 release provides a
+    terminal `capability database
+    <https://jinxed.readthedocs.io/en/stable/capabilities.html#database>` of 45 terminals and their
+    common aliases.
+  * introduced: A :exc:`UserWarning` is emitted when :meth:`~.Terminal.__getattr__` resolves an
+    unknown terminal capability name, helping developers catch typos like ``term.bld``
+    (missing ``bold``).  The warning can be suppressed by setting the environment variable
+    ``BLESSED_NOWARN_UNKNOWN_CAPS``.
+  * bugfix: Fixed internal typo ``susimpleript`` to the correct terminfo name ``ssubm`` for the
+    ``enter_susimpleript_mode`` capability.  This was previously masked by curses_ returning
+    an empty string for unknown capabilities.
+
+
 1.39
   * introduced: :meth:`~.Terminal.progress_bar` for `OSC 9;4 sequence
     <https://ghostty.org/docs/vt/osc/conemu#change-progress-state-(osc-94)>`_.
@@ -496,4 +512,5 @@ Version History
 .. _FORCE_COLOR: https://force-color.org/
 .. _CLICOLOR_FORCE: https://bixense.com/clicolors/
 .. _NO_COLOR: https://no-color.org/
-
+.. _jinxed: https://jinxed.readthedocs.io/en/stable/
+.. _XTGETTCAP: https://codeberg.org/dnkl/foot#xtgettcap

--- a/docs/terminal.rst
+++ b/docs/terminal.rst
@@ -25,7 +25,6 @@ Support for :doc:`colors`:
     256
 
 And create printable strings containing sequences_ for :doc:`colors`:
-
     >>> term.green_reverse('ALL SYSTEMS GO')
     '\x1b[32m\x1b[7mALL SYSTEMS GO\x1b[m'
 
@@ -52,6 +51,23 @@ of these will return an empty string, as they are not supported by your terminal
 used, but have no effect. For example, ``blink`` only works on a few terminals, does yours?
 
     >>> print(term.blink("Insert System disk into drive A:"))
+
+Capability Resolution Order
+---------------------------
+
+At time of :class:`Terminal()` initialization, Blessed tries terminal the terminal kind
+automatically.
+
+1. **'kind'** parameter: an explicit ``kind`` to :class:`~.Terminal` is used first, defaults to
+   None.
+
+2. **XTGETTCAP** The remote terminal's automatic response to ``TN`` (Terminal Name) queried by the
+   ``DCS +q`` protocol, supported by most terminals.
+
+3. **TERM** environment variable, or legacy ConHost.exe windows terminal descriptor.
+
+4. **'kind_fallback'** (defaults to ``'xterm-256color'``).  This terminal capability is used when
+   all other methods are exhausted or not found in the jinxed_ virtual terminal capability database.
 
 Compound Formatting
 -------------------
@@ -402,3 +418,15 @@ from drawing progress bars and other frippery and just stick to content:
         with term.location(x=0, y=term.height - 1):
             print('Progress: [=======>   ]')
     print(term.bold("60%"))
+
+.. _jinxed: https://pypi.org/project/jinxed
+
+Singleton-Free
+--------------
+
+Beginning 1.40, blessed now uses jinxed_ instead of :mod:`curses`, and is no longer subject to the
+per-process terminal-kind restriction that curses imposes, `"Singleton-free"
+<https://jinxed.readthedocs.io/en/stable/capabilities.html#singleton-free>`_.
+
+Multiple :class:`~.Terminal` instances with different ``kind`` values can coexist within the same
+process. This might also be considered asyncio or thread-safe.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
 ]
 dependencies = [
     'wcwidth>=0.7',
-    'jinxed>=1.4.0; platform_system == "Windows"',
+    'jinxed>=1.5',
 ]
 dynamic = ['version']
 license = 'MIT'

--- a/tests/accessories.py
+++ b/tests/accessories.py
@@ -13,33 +13,55 @@ import warnings
 # local
 from blessed import Terminal
 from blessed.dec_modes import DecModeResponse
-# local
+from blessed._capabilities import TermcapResponse
 from .conftest import IS_WINDOWS
 
-if IS_WINDOWS:
-    # 3rd party
-    import jinxed as curses
-else:
+# 3rd party
+import jinxed
+if not IS_WINDOWS:
     # std imports
     import pty
-    import curses
     import termios
 
 MAX_SUBPROC_TIME_SECONDS = 2  # no test should ever take over 2 seconds
 # extra time given for timeout-related tests for CI/slow machines, by percent
-PCT_MAXWAIT_KEYSTROKE = 1.5
+PCT_MAXWAIT_KEYSTROKE = 1.7
+# Short timeout value for tests that only need to verify timeout behavior,
+# not specific timing.  select() on an empty PTY resolves near-instantly.
+TEST_TIMEOUT_SHORT = 0.10
 
-test_kind = 'vtwin10' if IS_WINDOWS else 'xterm-256color'
 
+def assert_timeout_elapsed(elapsed, timeout):
+    """Assert elapsed time is within expected range for a timeout operation.
 
-def TestTerminal(is_a_tty=None, **kwargs):  # type: (...) -> Terminal
+    The floor is timeout * 0.5 (some overhead always exists).  The ceiling is
+    timeout * PCT_MAXWAIT_KEYSTROKE (tolerance for CI/slow machines).
     """
-    Create a Terminal instance with optional is_a_tty override.
+    assert timeout * 0.5 <= elapsed <= timeout * PCT_MAXWAIT_KEYSTROKE, (
+        f'elapsed={elapsed:.4f} not in [{timeout * 0.5:.4f}, '
+        f'{timeout * PCT_MAXWAIT_KEYSTROKE:.4f}]'
+    )
 
-    'is_a_tty' is useful to pass "is a tty" tests without pty_test
-    """
+
+TEST_KIND = 'vtwin10' if IS_WINDOWS else 'xterm-256color'
+
+DEFAULT_TERMCAP_RESPONSE = TermcapResponse(
+    supported=True, capabilities={'TN': TEST_KIND, 'colors': '256', 'RGB': '8'})
+
+# Sentinel to distinguish "use default fake XTGETTCAP" from "force real probe"
+NO_XTGETTCAP_DATA = object()
+
+
+def TestTerminal(is_a_tty=None, _xtgettcap_data=DEFAULT_TERMCAP_RESPONSE,
+                 _xtgettcap_timeout=None, **kwargs) -> Terminal:
+    """Create a Terminal instance with optional is_a_tty override and default _xtgettcap_data."""
     if 'kind' not in kwargs:
-        kwargs['kind'] = test_kind
+        kwargs['kind'] = TEST_KIND
+    if _xtgettcap_data is not NO_XTGETTCAP_DATA:
+        kwargs['_xtgettcap_data'] = _xtgettcap_data
+    if _xtgettcap_timeout is not None:
+        import blessed.terminal
+        blessed.terminal.TERMINAL_QUERY_TIMEOUT_SECONDS = _xtgettcap_timeout
     term = Terminal(**kwargs)
     if is_a_tty is not None:
         term._is_a_tty = is_a_tty
@@ -239,7 +261,6 @@ def read_until_eof(fd, encoding='utf8'):
 def echo_off(fd):
     """Ensure any bytes written to pty fd are not duplicated as output."""
     if not IS_WINDOWS:
-        # pylint: disable=possibly-used-before-assignment
         try:
             attrs = termios.tcgetattr(fd)
             attrs[3] = attrs[3] & ~termios.ECHO
@@ -252,27 +273,17 @@ def echo_off(fd):
         yield
 
 
-def unicode_cap(cap):
+def unicode_cap(cap, term):
     """Return the result of ``tigetstr`` except as Unicode."""
-    try:
-        val = curses.tigetstr(cap)
-    except curses.error:
-        val = None
-
+    val = term._jinxed_term.tigetstr(cap)
     return val.decode('latin1') if val else ''
 
 
-def unicode_parm(cap, *parms):
+def unicode_parm(cap, term, *parms):
     """Return the result of ``tparm(tigetstr())`` except as Unicode."""
-    try:
-        cap = curses.tigetstr(cap)
-    except curses.error:
-        cap = None
-    if cap:
-        try:
-            val = curses.tparm(cap, *parms)
-        except curses.error:
-            val = None
+    cap_str = term._jinxed_term.tigetstr(cap)
+    if cap_str:
+        val = jinxed.tparm(cap_str, *parms)
         if val:
             return val.decode('latin1')
     return ''
@@ -289,7 +300,8 @@ def _setwinsize(fd, rows, cols):
     fcntl.ioctl(fd, TIOCSWINSZ, s)
 
 
-def pty_test(child_func, parent_func=None, test_name=None, rows=24, cols=80):
+def pty_test(child_func, parent_func=None, test_name=None, rows=24, cols=80,
+             _xtgettcap_data=None, _xtgettcap_timeout=None):
     """
     Wrapper for PTY-based tests to reduce boilerplate.
 
@@ -324,9 +336,15 @@ def pty_test(child_func, parent_func=None, test_name=None, rows=24, cols=80):
     """
     # pylint: disable=too-complex,too-many-branches,too-many-locals
     # pylint: disable=missing-raises-doc,missing-type-doc,too-many-statements
+    # assert False, _xtgettcap_data
+    if _xtgettcap_data is not NO_XTGETTCAP_DATA:
+        _xtgettcap_data = (_xtgettcap_data if _xtgettcap_data is not None
+                           else DEFAULT_TERMCAP_RESPONSE)
     if IS_WINDOWS:
         # On Windows, just run child_func directly without PTY
-        term = TestTerminal()
+        term = TestTerminal(_xtgettcap_data=_xtgettcap_data,
+                            _xtgettcap_timeout=_xtgettcap_timeout,
+                            force_styling=True)
         result = child_func(term)
         return result.decode('utf-8') if isinstance(result, bytes) else (result or '')
 
@@ -353,7 +371,9 @@ def pty_test(child_func, parent_func=None, test_name=None, rows=24, cols=80):
         read_until_semaphore(sys.__stdin__.fileno(), semaphore=SEMAPHORE)
         cov = init_subproc_coverage(test_name)
         try:
-            term = TestTerminal()
+            term = TestTerminal(_xtgettcap_data=_xtgettcap_data,
+                                _xtgettcap_timeout=_xtgettcap_timeout,
+                                force_styling=True)
             result = child_func(term)
 
             # Write result to stdout if provided
@@ -416,13 +436,13 @@ def pty_test(child_func, parent_func=None, test_name=None, rows=24, cols=80):
 
 class MockTigetstr():
     """
-    Wraps curses.tigetstr() to override specific capnames
+    Wraps jinxed.tigetstr() to override specific capnames
 
     Capnames and return values are provided as keyword arguments
     """
 
     def __init__(self, **kwargs):
-        self.callable = curses.tigetstr
+        self.callable = jinxed.tigetstr
         self.kwargs = kwargs
 
     def __call__(self, capname):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,21 @@
 """Configure test fixtures"""
 
 # std imports
+import itertools
 import os
 import platform
-import subprocess
 
 # 3rd party
 import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Normalize environment for consistent test results outside of tox."""
+    os.environ.pop('TERM', None)
+    os.environ.pop('COLORTERM', None)
+    os.environ.pop('TERM_PROGRAM', None)
+    os.environ.pop('TERM_PROGRAM_VERSION', None)
+
 
 try:
     from pytest_codspeed import BenchmarkFixture  # noqa: F401  pylint: disable=unused-import
@@ -20,7 +29,6 @@ except ImportError:
 
 IS_WINDOWS = platform.system() == 'Windows'
 
-all_terms_params = 'xterm screen ansi vt220 rxvt cons25 linux'.split()
 many_lines_params = [40, 80]
 # we must test a '1' column for conditional in _handle_long_word
 many_columns_params = [1, 10]
@@ -61,92 +69,32 @@ if not TEST_BENCHMARK:
     collect_ignore.append('test_benchmarks.py')
 
 
-if TEST_FULL:
-    try:
-        all_terms_params = [
-            # use all values of the first column of data in output of 'toe -a'
-            _term.split(None, 1)[0] for _term in
-            subprocess.Popen(('toe', '-a'),  # pylint: disable=consider-using-with
-                             stdout=subprocess.PIPE,
-                             close_fds=True)
-            .communicate()[0].splitlines()]
-    except OSError:
-        pass
-elif IS_WINDOWS:
-    all_terms_params = ['vtwin10', ]
-elif TEST_QUICK:
-    all_terms_params = 'xterm screen ansi linux'.split()
-
-
 if TEST_QUICK:
     many_lines_params = [80, ]
     many_columns_params = [25, ]
 
 
-@pytest.fixture(autouse=True)
-def detect_curses_contamination(request):
-    """
-    Detect when Terminal() is instantiated in parent pytest process.
+# Full list of terminal types available in jinxed's virtual database.
+_JINXED_TERMINALS = [
+    'xterm', 'xterm_256color', 'xterm_16color',
+    'screen', 'screen_256color',
+    'tmux', 'tmux_256color',
+    'rxvt', 'rxvt_256color', 'rxvt_unicode', 'rxvt_unicode_256color',
+    'putty', 'putty_256color',
+    'st', 'st_256color',
+    'ansi', 'ansi_bbs', 'ansicon',
+    'linux', 'linux_16color',
+    'vt220', 'vtwin10',
+    'cons25', 'syncterm',
+]
 
-    The curses module can only call setupterm() once per process. If a test
-    instantiates Terminal() in the parent pytest process (instead of within
-    @as_subprocess), it contaminates all subsequent tests that try to use
-    a different terminal kind.
-
-    This fixture runs automatically for all tests and fails any test that
-    initializes curses in the parent process.
-    """
-    if IS_WINDOWS:
-        # Windows doesn't have the curses singleton limitation
-        yield
-        return
-
-    if TEST_BENCHMARK:
-        # Benchmark tests intentionally instantiate Terminal in parent process
-        yield
-        return
-
-    # Import here to avoid issues if module not yet imported
-    import blessed.terminal  # pylint: disable=import-outside-toplevel
-
-    # Record the state before the test
-    before = blessed.terminal._CUR_TERM
-
-    # Run the test
-    yield
-
-    # Check if curses was initialized during the test
-    after = blessed.terminal._CUR_TERM
-
-    if before is None and after is not None:
-        # Curses was initialized during this test in the parent process
-        test_name = request.node.nodeid
-        pytest.fail(
-            f"\n{'=' * 70}\n"
-            f"CURSES CONTAMINATION DETECTED in parent pytest process!\n"
-            f"Test: {test_name}\n"
-            f"Terminal kind initialized: {after}\n"
-            f"\n"
-            f"This test instantiated Terminal() or TestTerminal() in the parent\n"
-            f"pytest process instead of within @as_subprocess. This causes curses\n"
-            f"to be initialized with a specific terminal kind, which cannot be\n"
-            f"changed for the remainder of the test session, breaking later tests!\n"
-            f"\n"
-            f"FIX: Ensure Terminal() instantiation is within @as_subprocess:\n"
-            f"  @as_subprocess\n"
-            f"  def child():\n"
-            f"      term = TestTerminal(...)\n"
-            f"      ...\n"
-            f"      assert ..\n"
-            f"  child()\n"
-            f"{'=' * 70}\n"
-        )
+_term_cycle = itertools.cycle(_JINXED_TERMINALS)
 
 
-@pytest.fixture(params=all_terms_params)
-def all_terms(request):
-    """Common kind values for all kinds of terminals."""
-    return request.param
+@pytest.fixture
+def any_term():
+    """A single deterministically rotated terminal kind from jinxed's database."""
+    return next(_term_cycle)
 
 
 @pytest.fixture(params=many_lines_params)

--- a/tests/test_async_inkey.py
+++ b/tests/test_async_inkey.py
@@ -12,7 +12,7 @@ import pytest
 
 # local
 from .conftest import IS_WINDOWS
-from .accessories import SEMAPHORE, TestTerminal, pty_test, as_subprocess, read_until_semaphore
+from .accessories import SEMAPHORE, TestTerminal, pty_test, read_until_semaphore
 
 pytestmark = pytest.mark.skipif(IS_WINDOWS, reason="no pty on Windows")
 
@@ -106,7 +106,7 @@ def test_async_inkey_mouse_x10():
             loop = asyncio.new_event_loop()
             try:
                 ks = loop.run_until_complete(
-                    term.async_inkey(timeout=2.0))
+                    term.async_inkey(timeout=0.5, esc_delay=0.01))
             finally:
                 loop.close()
             assert ks.is_mouse
@@ -132,7 +132,7 @@ def test_async_inkey_resize_event():
             loop = asyncio.new_event_loop()
             try:
                 ks = loop.run_until_complete(
-                    term.async_inkey(timeout=2.0))
+                    term.async_inkey(timeout=0.5))
             finally:
                 loop.close()
             assert ks.name == 'RESIZE_EVENT'
@@ -151,17 +151,13 @@ def test_async_inkey_resize_event():
 
 def test_async_read_byte_oserror_propagates():
     """OSError from os.read propagates through the future."""
-    @as_subprocess
     def child():
         term = TestTerminal()
         term._keyboard_fd = 0
 
         loop = asyncio.new_event_loop()
         try:
-            original_add_reader = loop.add_reader
-
             def mock_add_reader(fd, callback):
-                original_add_reader(fd, callback)
                 loop.call_soon(callback)
 
             with mock.patch.object(loop, 'add_reader', side_effect=mock_add_reader):
@@ -171,7 +167,6 @@ def test_async_read_byte_oserror_propagates():
                             term._async_read_byte(loop, timeout=1.0))
         finally:
             loop.close()
-
     child()
 
 
@@ -229,7 +224,7 @@ def test_async_inkey_arrow_key():
             loop = asyncio.new_event_loop()
             try:
                 ks = loop.run_until_complete(
-                    term.async_inkey(timeout=2.0))
+                    term.async_inkey(timeout=0.5))
             finally:
                 loop.close()
             assert ks.name == 'KEY_UP'
@@ -252,7 +247,7 @@ def test_async_inkey_buffered_multi_byte():
             loop = asyncio.new_event_loop()
             try:
                 ks = loop.run_until_complete(
-                    term.async_inkey(timeout=2.0))
+                    term.async_inkey(timeout=0.5))
                 assert str(ks) == 'x'
                 ks2 = loop.run_until_complete(
                     term.async_inkey(timeout=0.5))
@@ -322,7 +317,6 @@ def test_async_inkey_escape_then_arrow():
 
 def test_async_inkey_no_keyboard_fd():
     """_async_read_byte raises RuntimeError without keyboard fd."""
-    @as_subprocess
     def child():
         term = TestTerminal()
         term._keyboard_fd = None
@@ -333,5 +327,4 @@ def test_async_inkey_no_keyboard_fd():
                     term._async_read_byte(loop, timeout=1.0))
         finally:
             loop.close()
-
     child()

--- a/tests/test_autoresponses.py
+++ b/tests/test_autoresponses.py
@@ -13,7 +13,7 @@ except ImportError:
 # local
 from blessed._capabilities import ITerm2Capabilities, TextSizingResult
 from .conftest import IS_WINDOWS
-from .accessories import TestTerminal, as_subprocess, pty_test
+from .accessories import TestTerminal, pty_test
 
 pytestmark = pytest.mark.skipif(
     IS_WINDOWS, reason="ungetch and PTY testing not supported on Windows")
@@ -31,7 +31,6 @@ pytestmark = pytest.mark.skipif(
 ])
 def test_detection_not_a_tty(method_name, expected):
     """Detection methods return falsy default when not a TTY."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True,
                             is_a_tty=False)
@@ -50,7 +49,6 @@ def test_detection_not_a_tty(method_name, expected):
 ])
 def test_detection_no_styling(method_name, expected):
     """Detection methods return falsy default when does_styling is False."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=False)
         result = getattr(term, method_name)(timeout=0.01)
@@ -68,7 +66,6 @@ def test_detection_no_styling(method_name, expected):
 ])
 def test_detection_cached_bool(method_name, cache_attr, cached_value, expected):
     """Boolean detection methods return cached value."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -80,7 +77,6 @@ def test_detection_cached_bool(method_name, cache_attr, cached_value, expected):
 
 def test_get_iterm2_capabilities_cached():
     """get_iterm2_capabilities returns cached result."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -94,7 +90,6 @@ def test_get_iterm2_capabilities_cached():
 
 def test_does_kitty_pointer_shapes_cached_supported():
     """does_kitty_pointer_shapes returns cached shape string."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -106,7 +101,6 @@ def test_does_kitty_pointer_shapes_cached_supported():
 
 def test_does_kitty_pointer_shapes_cached_unsupported():
     """does_kitty_pointer_shapes returns None when cached unsupported."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -151,7 +145,6 @@ def test_get_iterm2_capabilities_force_bypass():
 
 def test_does_text_sizing_cached():
     """does_text_sizing returns cached result."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -288,7 +281,6 @@ def test_does_kitty_notifications_supported(terminator):
 ])
 def test_does_iterm2_delegates_cached(method_name, cached_supported):
     """does_iterm2 and does_iterm2_graphics return cached result."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -501,7 +493,6 @@ def test_does_text_sizing_scale_location_timeout():
 
 def test_does_text_sizing_cleanup_side_effect():
     """does_text_sizing writes cleanup (backspace+space+backspace) to erase probes."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -516,13 +507,11 @@ def test_does_text_sizing_cleanup_side_effect():
         output = stream.getvalue()
         # cleanup: _movement=4 backspaces, 4 spaces, 4 backspaces
         assert '\b' * 4 + ' ' * 4 + '\b' * 4 in output
-
     child()
 
 
 def test_does_text_sizing_no_cleanup_when_cached():
     """does_text_sizing does not write probes/cleanup when cached result exists."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -533,7 +522,6 @@ def test_does_text_sizing_no_cleanup_when_cached():
         result = term.does_text_sizing()
         assert result == TextSizingResult(width=True, scale=True)
         assert stream.getvalue() == ''
-
     child()
 
 
@@ -562,7 +550,6 @@ def _sizing_term(supported):
 ])
 def test_text_sized(supported, kwargs, expected, measured):
     """text_sized returns OSC 66-wrapped text when supported, as-is otherwise."""
-    @as_subprocess
     def child():
         from wcwidth import width as wcwidth_width
         term = _sizing_term(supported)
@@ -574,10 +561,8 @@ def test_text_sized(supported, kwargs, expected, measured):
 
 def test_text_sized_ValueError():
     """text_sized raises ValueError for text exceeding 4096 length limit."""
-    @as_subprocess
     def child():
         term = _sizing_term(True)
         with pytest.raises(ValueError):
             term.text_sized('X' * 4097, scale=2)
-
     child()

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -11,7 +11,7 @@ from blessed.color import COLOR_DISTANCE_ALGORITHMS
 from blessed.colorspace import RGBColor
 from blessed.formatters import FormattingString, NullCallableString
 # local
-from .accessories import TestTerminal, as_subprocess
+from .accessories import TestTerminal
 
 
 @pytest.fixture(params=COLOR_DISTANCE_ALGORITHMS.keys())
@@ -45,7 +45,6 @@ def test_different_color(all_algorithms):   # pylint: disable=redefined-outer-na
 
 def test_color_rgb():
     """Ensure expected sequence is returned"""
-    @as_subprocess
     def child():
         t = TestTerminal(force_styling=True)
         color_patterns = rf"{t.caps['color'].pattern}|{t.caps['color256'].pattern}"
@@ -58,13 +57,11 @@ def test_color_rgb():
         # This avoids user theme customizations of ANSI colors 0-15
         assert t.color_rgb(0, 0, 0)('smoo') == f'{t.color(16)}smoo{t.normal}'
         assert re.match(color_patterns, t.color_rgb(84, 192, 233))
-
     child()
 
 
 def test_on_color_rgb():
     """Ensure expected sequence is returned"""
-    @as_subprocess
     def child():
         t = TestTerminal(force_styling=True)
         color_patterns = rf"{t.caps['color'].pattern}|{t.caps['on_color256'].pattern}"
@@ -75,13 +72,11 @@ def test_on_color_rgb():
         t.number_of_colors = 256
         assert t.on_color_rgb(0, 0, 0)('smoo') == f'{t.on_color(16)}smoo{t.normal}'
         assert re.match(color_patterns, t.on_color_rgb(84, 192, 233))
-
     child()
 
 
 def test_set_number_of_colors():
     """Ensure number of colors is supported and cache is cleared"""
-    @as_subprocess
     def child():
         t = TestTerminal(force_styling=True)
         for num in (0, 4, 8, 16, 256, 1 << 24):
@@ -96,13 +91,11 @@ def test_set_number_of_colors():
 
         with pytest.raises(AssertionError):
             t.number_of_colors = 40
-
     child()
 
 
 def test_set_color_distance_algorithm():
     """Ensure algorithm is supported and cache is cleared"""
-    @as_subprocess
     def child():
         t = TestTerminal(force_styling=True)
         for algo in COLOR_DISTANCE_ALGORITHMS:
@@ -113,7 +106,6 @@ def test_set_color_distance_algorithm():
             assert 'aqua' not in dir(t)
         with pytest.raises(AssertionError):
             t.color_distance_algorithm = 'EenieMeenieMineyMo'
-
     child()
 
 
@@ -125,7 +117,6 @@ def test_RGBColor():
 
 def test_formatter():
     """Ensure return values match terminal attributes"""
-    @as_subprocess
     def child():
         t = TestTerminal(force_styling=True)
         t.number_of_colors = 1 << 24
@@ -153,7 +144,6 @@ def test_formatter():
 
 def test_formatter_invalid():
     """Ensure NullCallableString for invalid formatters"""
-    @as_subprocess
     def child():
         t = TestTerminal(force_styling=True)
         assert isinstance(t.formatter('csr'), NullCallableString)
@@ -162,7 +152,6 @@ def test_formatter_invalid():
 
 def test_rgb_to_xterm_cube_index():
     """Test RGB to xterm cube index mapping for 256-color terminals"""
-    @as_subprocess
     def child():
         t = TestTerminal(force_styling=True)
         t.number_of_colors = 256
@@ -185,13 +174,11 @@ def test_rgb_to_xterm_cube_index():
         # Test some colors that should prefer cube over grayscale
         cube_orange = t.rgb_downconvert(215, 135, 0)  # Should be in cube range
         assert 16 <= cube_orange <= 231
-
     child()
 
 
 def test_rgb_to_xterm_gray_index():
     """Test RGB to xterm grayscale index mapping for 256-color terminals"""
-    @as_subprocess
     def child():
         t = TestTerminal(force_styling=True)
         t.number_of_colors = 256
@@ -211,13 +198,11 @@ def test_rgb_to_xterm_gray_index():
             gray_val = 8 + 10 * i
             result_idx = t.rgb_downconvert(gray_val, gray_val, gray_val)
             assert result_idx == expected_idx
-
     child()
 
 
 def test_256_downconvert_cube_vs_gray_choice():
     """Test 256-color cube vs grayscale selection logic"""
-    @as_subprocess
     def child():
         t = TestTerminal(force_styling=True)
         t.number_of_colors = 256
@@ -247,13 +232,11 @@ def test_256_downconvert_cube_vs_gray_choice():
         dark_idx = t.rgb_downconvert(20, 20, 20)
         # Could be either cube (16) or early grayscale (232-235), both are valid
         assert dark_idx == 16 or 232 <= dark_idx <= 235
-
     child()
 
 
 def test_256_downconvert_preserves_distance_algorithm():
     """Test that 256-color fast path uses the selected distance algorithm"""
-    @as_subprocess
     def child():
         t = TestTerminal(force_styling=True)
         t.number_of_colors = 256
@@ -271,13 +254,11 @@ def test_256_downconvert_preserves_distance_algorithm():
             gray_idx = t.rgb_downconvert(128, 128, 128)
             # Result depends on algorithm, but should be reasonable
             assert gray_idx in range(256)  # Valid color index
-
     child()
 
 
 def test_256_vs_legacy_downconvert_compatibility():
     """Test that results are compatible between 256 and smaller palettes"""
-    @as_subprocess
     def child():
         t = TestTerminal(force_styling=True)
 
@@ -308,13 +289,11 @@ def test_256_vs_legacy_downconvert_compatibility():
         # - 256-color mode: uses cube red (index 196) to avoid theme interference
         assert red_16 == 9
         assert red_256 == 196  # Cube red
-
     child()
 
 
 def test_rgb_downconvert_zero_colors():
     """Test rgb_downconvert when number_of_colors == 0 returns color 7."""
-    @as_subprocess
     def child():
         t = TestTerminal(force_styling=True)
         t.number_of_colors = 0
@@ -327,7 +306,6 @@ def test_rgb_downconvert_zero_colors():
         assert t.rgb_downconvert(0, 0, 255) == 7
         assert t.rgb_downconvert(255, 255, 255) == 7
         assert t.rgb_downconvert(128, 64, 192) == 7
-
     child()
 
 
@@ -407,7 +385,6 @@ def test_xparse_color_errors():
 
 def test_color_hex():
     """Test color_hex with 3, 6, and 12 digit formats."""
-    @as_subprocess
     def child():
         t = TestTerminal(force_styling=True)
         t.number_of_colors = 1 << 24
@@ -421,7 +398,6 @@ def test_color_hex():
 
 def test_on_color_hex():
     """Test on_color_hex with 3, 6, and 12 digit formats."""
-    @as_subprocess
     def child():
         t = TestTerminal(force_styling=True)
         t.number_of_colors = 1 << 24
@@ -437,7 +413,6 @@ def test_get_fgcolor_hex(terminator):
     """Test get_fgcolor_hex returns hex string."""
     from io import StringIO
 
-    @as_subprocess
     def child():
         t = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
         t.ungetch('\x1b]10;rgb:ffff/ffff/ffff' + terminator)
@@ -461,7 +436,6 @@ def test_get_fgcolor_hex_timeout():
     """Test get_fgcolor_hex returns empty string on timeout."""
     from io import StringIO
 
-    @as_subprocess
     def child():
         t = TestTerminal(stream=StringIO())
         result = t.get_fgcolor_hex(timeout=0)
@@ -474,7 +448,6 @@ def test_get_bgcolor_hex(terminator):
     """Test get_bgcolor_hex returns hex string."""
     from io import StringIO
 
-    @as_subprocess
     def child():
         t = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
         t.ungetch('\x1b]11;rgb:2828/2c2c/3434' + terminator)
@@ -493,7 +466,6 @@ def test_get_bgcolor_hex_timeout():
     """Test get_bgcolor_hex returns empty string on timeout."""
     from io import StringIO
 
-    @as_subprocess
     def child():
         t = TestTerminal(stream=StringIO())
         result = t.get_bgcolor_hex(timeout=0)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,7 @@
 """Core blessed Terminal() tests."""
 
 # std imports
+import base64
 import io
 import os
 import sys
@@ -13,37 +14,37 @@ from io import StringIO
 from unittest import mock
 
 # 3rd party
+import jinxed
 import pytest
 
 # local
 from .conftest import IS_WINDOWS
-from .accessories import TestTerminal, unicode_cap, as_subprocess, pty_test
+from .accessories import TestTerminal, unicode_cap, pty_test, NO_XTGETTCAP_DATA, as_subprocess
+from blessed._capabilities import TermcapResponse
 
 
 def test_export_only_Terminal():
     "Ensure only expected names are exported for import * statements."
-    # local
+
     import blessed
     assert blessed.__all__ == ('Terminal', 'LineEditor', 'LineHistory')
 
 
-def test_null_location(all_terms):
+def test_null_location(any_term):
     """Make sure ``location()`` with no args just does position restoration."""
-    @as_subprocess
     def child(kind):
-        t = TestTerminal(stream=StringIO(), force_styling=True)
+        t = TestTerminal(kind=kind, stream=StringIO(), force_styling=True)
         with t.location():
             pass
         expected_output = ''.join(
-            (unicode_cap('sc'), unicode_cap('rc')))
+            (unicode_cap('sc', t), unicode_cap('rc', t)))
         assert t.stream.getvalue() == expected_output
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_location_to_move_xy(all_terms):
+def test_location_to_move_xy(any_term):
     """``location()`` and ``move_xy()`` receive complimentary arguments."""
-    @as_subprocess
     def child(kind):
         buf = StringIO()
         t = TestTerminal(stream=buf, force_styling=True)
@@ -53,22 +54,19 @@ def test_location_to_move_xy(all_terms):
             xy_val_from_location = buf.getvalue()[len(t.sc):]
             assert xy_val_from_move_xy == xy_val_from_location
 
-    child(all_terms)
+    child(any_term)
 
 
 def test_yield_keypad():
     """Ensure ``keypad()`` writes keyboard_xmit and keyboard_local."""
-    @as_subprocess
     def child(kind):
-        # given,
+
         t = TestTerminal(stream=StringIO(), force_styling=True)
         expected_output = ''.join((t.smkx, t.rmkx))
 
-        # exercise,
         with t.keypad():
             pass
 
-        # verify.
         assert t.stream.getvalue() == expected_output
 
     child(kind='xterm')
@@ -76,9 +74,8 @@ def test_yield_keypad():
 
 def test_null_fileno():
     """Make sure ``Terminal`` works when ``fileno`` is ``None``."""
-    @as_subprocess
     def child():
-        # This simulates piping output to another program.
+
         out = StringIO()
         out.fileno = None
         t = TestTerminal(stream=out)
@@ -93,36 +90,27 @@ def test_number_of_colors_without_tty():
     if 'COLORTERM' in os.environ:
         del os.environ['COLORTERM']
 
-    @as_subprocess
     def child_256_nostyle():
-        t = TestTerminal(stream=StringIO())
+        t = TestTerminal(stream=StringIO(), _xtgettcap_data=TermcapResponse(supported=False))
         assert t.number_of_colors == 0
 
-    @as_subprocess
     def child_256_forcestyle():
-        t = TestTerminal(stream=StringIO(), force_styling=True)
+        t = TestTerminal(stream=StringIO(), force_styling=True,
+                         _xtgettcap_data=TermcapResponse(supported=False))
         assert t.number_of_colors == 256
 
-    @as_subprocess
     def child_8_forcestyle():
         # 'ansi' on freebsd returns 0 colors. We use 'cons25', compatible with its kernel tty.c
         kind = 'cons25' if platform.system().lower() == 'freebsd' else 'ansi'
         t = TestTerminal(kind=kind, stream=StringIO(),
-                         force_styling=True)
+                         force_styling=True,
+                         _xtgettcap_data=TermcapResponse(supported=False))
         assert t.number_of_colors == 8
 
-    @as_subprocess
     def child_0_forcestyle():
-        t = TestTerminal(kind='vt220', stream=StringIO(),
-                         force_styling=True)
+        t = TestTerminal(kind='vt220', stream=StringIO(), force_styling=True,
+                         _xtgettcap_data=TermcapResponse(supported=False))
         assert t.number_of_colors == 0
-
-    @as_subprocess
-    def child_24bit_forcestyle_with_colorterm():
-        os.environ['COLORTERM'] = 'truecolor'
-        t = TestTerminal(kind='vt220', stream=StringIO(),
-                         force_styling=True)
-        assert t.number_of_colors == 1 << 24
 
     child_0_forcestyle()
     child_8_forcestyle()
@@ -130,24 +118,57 @@ def test_number_of_colors_without_tty():
     child_256_nostyle()
 
 
+def test_multiple_terminal_kinds():
+    """Multiple Terminal instances with different kinds retain correct capabilities."""
+    term_a = TestTerminal(kind='xterm-256color', force_styling=True,
+                          _xtgettcap_data=TermcapResponse(supported=False))
+    colors_a = term_a.number_of_colors
+    assert colors_a == 256
+
+    term_b = TestTerminal(kind='vt220', force_styling=True,
+                          _xtgettcap_data=TermcapResponse(supported=False))
+    colors_b = term_b.number_of_colors
+    assert colors_b == 0
+
+    assert term_a.number_of_colors == 256
+    assert term_b.number_of_colors == 0
+
+
+@pytest.mark.parametrize('colorterm_value', ['truecolor', '24bit'])
+def test_number_of_colors_colorterm(colorterm_value):
+    """COLORTERM=truecolor|24bit yields 1<<24 colors."""
+    os.environ['COLORTERM'] = colorterm_value
+    try:
+        t = TestTerminal(force_styling=True,
+                         _xtgettcap_data=TermcapResponse(supported=False))
+        assert t.number_of_colors == 1 << 24
+    finally:
+        del os.environ['COLORTERM']
+
+
+def test_number_of_colors_bad_rgb_value():
+    """Bad RGB value (non-numeric) is handled gracefully."""
+    t = TestTerminal(kind='xterm-256color', force_styling=True, stream=StringIO(),
+                     _xtgettcap_data=TermcapResponse(
+                         supported=True,
+                         capabilities={'RGB': 'not_a_number'}))
+    assert t.number_of_colors == 256
+
+
 @pytest.mark.skipif(IS_WINDOWS, reason="requires more than 1 tty")
 def test_number_of_colors_with_tty():
     """test ``number_of_colors`` 0, 8, and 256."""
-    @as_subprocess
     def child_256():
-        t = TestTerminal()
+        t = TestTerminal(force_styling=True, _xtgettcap_data=NO_XTGETTCAP_DATA)
         assert t.number_of_colors == 256
 
-    @as_subprocess
     def child_8():
-        # 'ansi' on freebsd returns 0 colors. We use 'cons25', compatible with its kernel tty.c
         kind = 'cons25' if platform.system().lower() == 'freebsd' else 'ansi'
-        t = TestTerminal(kind=kind)
+        t = TestTerminal(kind=kind, force_styling=True, _xtgettcap_data=NO_XTGETTCAP_DATA)
         assert t.number_of_colors == 8
 
-    @as_subprocess
     def child_0():
-        t = TestTerminal(kind='vt220')
+        t = TestTerminal(kind='vt220', force_styling=True, _xtgettcap_data=NO_XTGETTCAP_DATA)
         assert t.number_of_colors == 0
 
     child_0()
@@ -155,9 +176,8 @@ def test_number_of_colors_with_tty():
     child_256()
 
 
-def test_init_descriptor_always_initted(all_terms):
+def test_init_descriptor_always_initted(any_term):
     """Test height and width with non-tty Terminals."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(kind=kind, stream=StringIO())
         assert t._init_descriptor == sys.__stdout__.fileno()
@@ -166,22 +186,20 @@ def test_init_descriptor_always_initted(all_terms):
         assert t.height == t._height_and_width()[0]
         assert t.width == t._height_and_width()[1]
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_force_styling_none(all_terms):
+def test_force_styling_none(any_term):
     """If ``force_styling=None`` is used, don't ever do styling."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(force_styling=None)
         assert not t.does_styling
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_force_styling_none_but_FORCE_COLOR(all_terms):
+def test_force_styling_none_but_FORCE_COLOR(any_term):
     """``force_styling=None``, but FORCE_COLOR or CLICOLOR_FORCE is non-empty, does styling."""
-    @as_subprocess
     def child(envkey):
         os.environ[envkey] = '1'
         t = TestTerminal(force_styling=None)
@@ -192,11 +210,10 @@ def test_force_styling_none_but_FORCE_COLOR(all_terms):
     child('CLICOLOR_FORCE')
 
 
-def test_force_styling_none_and_unset_FORCE_COLOR(all_terms):
+def test_force_styling_none_and_unset_FORCE_COLOR(any_term):
     """
     ``force_styling=None``, but FORCE_COLOR/CLICOLOR_FORCE is set, but empty, do not style.
     """
-    @as_subprocess
     def child(envkey):
         os.environ[envkey] = ''
         t = TestTerminal(force_styling=None)
@@ -209,7 +226,6 @@ def test_force_styling_none_and_unset_FORCE_COLOR(all_terms):
 
 def test_force_styling_False_but_FORCE_COLOR():
     """``force_styling=False``, but FORCE_COLOR or CLICOLOR_FORCE is non-empty, do styling."""
-    @as_subprocess
     def child(envkey):
         os.environ[envkey] = '1'
         t = TestTerminal(force_styling=False)
@@ -222,7 +238,6 @@ def test_force_styling_False_but_FORCE_COLOR():
 
 def test_force_styling_True_but_NO_COLOR():
     """``force_styling=True``, but NO_COLOR is non-empty, do not style."""
-    @as_subprocess
     def child(envkey):
         os.environ[envkey] = '1'
         t = TestTerminal(force_styling=True)
@@ -233,85 +248,69 @@ def test_force_styling_True_but_NO_COLOR():
 
 
 def test_setupterm_singleton_issue_33():
-    """A warning is emitted if a new terminal ``kind`` is used per process."""
-    @as_subprocess
+    """Multiple Terminal instances with different kinds are supported."""
     def child():
         warnings.filterwarnings("error", category=UserWarning)
 
-        # instantiate first terminal, of type xterm-256color
         term = TestTerminal(force_styling=True)
-        first_kind = term.kind
         next_kind = 'xterm'
 
-        try:
-            # a second instantiation raises UserWarning
-            term = TestTerminal(kind=next_kind, force_styling=True)
-        except UserWarning as err:
-            assert (err.args[0].startswith(
-                f'A terminal of kind "{next_kind}" has been requested')
-            ), err.args[0]
-            assert (
-                f'a terminal of kind "{first_kind}" will continue to be returned' in err.args[0]
-            ), err.args[0]
-        else:
-            # unless term is not a tty and setupterm() is not called
-            assert not term.is_a_tty, 'Should have thrown exception'
-        warnings.resetwarnings()
+        term = TestTerminal(kind=next_kind, force_styling=True)
+        assert term.kind == next_kind
 
     child()
 
 
-def test_setupterm_invalid_issue39():
-    """A warning is emitted if TERM is invalid."""
-    # https://bugzilla.mozilla.org/show_bug.cgi?id=878089
-    #
-    # if TERM is unset, defaults to 'unknown', which should
-    # fail to lookup and emit a warning on *some* systems.
-    # freebsd actually has a termcap entry for 'unknown'
-    @as_subprocess
-    def child():
-        warnings.filterwarnings("error", category=UserWarning)
-
-        try:
-            term = TestTerminal(kind='unknown', force_styling=True)
-        except UserWarning as err:
-            assert err.args[0] in {
-                "Failed to setupterm(kind='unknown'): "
-                "setupterm: could not find terminal",
-                "Failed to setupterm(kind='unknown'): "
-                "Could not find terminal unknown",
-            }
-        else:
-            if platform.system().lower() != 'freebsd':
-                assert not term.is_a_tty and not term.does_styling, (
-                    'Should have thrown exception')
-        warnings.resetwarnings()
-
-    child()
+def test_kind_resolution_kind_preferred():
+    """kind= takes priority over TN, TERM, and kind_fallback."""
+    term = TestTerminal(kind='vt220', force_styling=True)
+    assert term.kind == 'vt220'
 
 
-def test_setupterm_invalid_has_no_styling():
-    """An unknown TERM type does not perform styling."""
-    # https://bugzilla.mozilla.org/show_bug.cgi?id=878089
+def test_kind_resolution_tn_via_xtgettcap():
+    """TN from XTGETTCAP used when kind is not specified."""
+    _xtgettcap_data = TermcapResponse(
+        supported=True, capabilities={'TN': 'ansi'})
+    term = TestTerminal(kind=None, force_styling=True,
+                        _xtgettcap_data=_xtgettcap_data)
+    assert term.kind == 'ansi'
 
-    # if TERM is unset, defaults to 'unknown', which should
-    # fail to lookup and emit a warning, only.
-    @as_subprocess
-    def child():
-        warnings.filterwarnings("ignore", category=UserWarning)
 
-        term = TestTerminal(kind='xxXunknownXxx', force_styling=True)
-        assert term.kind is None
-        assert not term.does_styling
-        assert term.number_of_colors == 0
-        warnings.resetwarnings()
+def test_kind_resolution_term_kind():
+    """kind_fallback used when kind is invalid and TERM is unset (xtgettcap path)."""
+    assert 'TERM' not in os.environ, (
+        'TERM is expected unset, check: tox.ini and conftest.py:pytest_configure')
+    term = TestTerminal(kind='unknown', force_styling=True, _xtgettcap_data=None)
+    if IS_WINDOWS:
+        assert term.kind == 'vtwin10'
+    else:
+        assert term.kind == 'xterm-256color'
 
-    child()
+
+def test_kind_resolution_kind_fallback():
+    """kind_fallback used when kind is invalid and TERM is unset."""
+    assert 'TERM' not in os.environ, (
+        'TERM is expected unset, check: tox.ini and conftest.py:pytest_configure')
+    term = TestTerminal(kind='unknown', force_styling=True)
+    if IS_WINDOWS:
+        assert term.kind == 'vtwin10'
+    else:
+        assert term.kind == 'xterm-256color'
+
+
+def test_kind_resolution_all_fail():
+    """jinxed.error raised when kind, TERM, and kind_fallback all fail."""
+    assert 'TERM' not in os.environ, (
+        'TERM is expected unset, check: tox.ini and conftest.py:pytest_configure')
+    with pytest.raises(jinxed.error, match='xxBadFallbackXx'):
+        TestTerminal(
+            kind='xxUnknownXx', force_styling=True,
+            kind_fallback='xxBadFallbackXx',
+            _xtgettcap_data=TermcapResponse(supported=False))
 
 
 def test_IOUnsupportedOperation():
     """Ensure stream that throws IOUnsupportedOperation results in non-tty."""
-    @as_subprocess
     def child():
 
         def side_effect():
@@ -331,7 +330,6 @@ def test_IOUnsupportedOperation():
 
 def test_stream_no_fileno():
     """Handle custom stream objects gracefully"""
-    @as_subprocess
     def child():
         stream = object()
         term = TestTerminal(stream=stream)
@@ -348,23 +346,33 @@ def test_stream_no_fileno():
 @pytest.mark.skipif(IS_WINDOWS, reason="has process-wide side-effects")
 def test_winsize_IOError_returns_environ():
     """When _winsize raises IOError, defaults from os.environ given."""
-    @as_subprocess
     def child():
         def side_effect(fd):
             raise OSError
 
         term = TestTerminal()
         term._winsize = side_effect
-        os.environ['COLUMNS'] = '1984'
-        os.environ['LINES'] = '1888'
-        assert term._height_and_width() == (1888, 1984, None, None)
+        save_cols = os.environ.get('COLUMNS')
+        save_lines = os.environ.get('LINES')
+        try:
+            os.environ['COLUMNS'] = '1984'
+            os.environ['LINES'] = '1888'
+            assert term._height_and_width() == (1888, 1984, None, None)
+        finally:
+            if save_cols is not None:
+                os.environ['COLUMNS'] = save_cols
+            else:
+                del os.environ['COLUMNS']
+            if save_lines is not None:
+                os.environ['LINES'] = save_lines
+            else:
+                del os.environ['LINES']
 
     child()
 
 
-def test_yield_fullscreen(all_terms):
+def test_yield_fullscreen(any_term):
     """Ensure ``fullscreen()`` writes enter_fullscreen and exit_fullscreen."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(stream=StringIO(), force_styling=True)
         t.enter_fullscreen = 'BEGIN'
@@ -374,12 +382,11 @@ def test_yield_fullscreen(all_terms):
         expected_output = ''.join((t.enter_fullscreen, t.exit_fullscreen))
         assert t.stream.getvalue() == expected_output
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_yield_hidden_cursor(all_terms):
+def test_yield_hidden_cursor(any_term):
     """Ensure ``hidden_cursor()`` writes hide_cursor and normal_cursor."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(stream=StringIO(), force_styling=True)
         t.hide_cursor = 'BEGIN'
@@ -389,7 +396,7 @@ def test_yield_hidden_cursor(all_terms):
         expected_output = ''.join((t.hide_cursor, t.normal_cursor))
         assert t.stream.getvalue() == expected_output
 
-    child(all_terms)
+    child(any_term)
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="windows lacks disable_line_wrap capability")
@@ -397,7 +404,6 @@ def test_yield_hidden_cursor(all_terms):
 # "Removed - These do not appear to be supported" for rmam + smam
 def test_yield_no_line_wrap():
     """Ensure ``no_line_wrap()`` writes disable and enable VT100 line wrap sequence."""
-    @as_subprocess
     def child():
         t = TestTerminal(stream=StringIO(), force_styling=True)
         with t.no_line_wrap():
@@ -414,11 +420,10 @@ def test_yield_no_line_wrap():
 @pytest.mark.skipif(IS_WINDOWS, reason="windows doesn't work like this")
 def test_no_preferredencoding_fallback():
     """Ensure empty preferredencoding value defaults to ascii."""
-    @as_subprocess
     def child():
         with mock.patch('locale.getpreferredencoding') as get_enc:
             get_enc.return_value = ''
-            t = TestTerminal()
+            t = TestTerminal(force_styling=True)
             assert t._encoding == 'UTF-8'
 
     child()
@@ -430,11 +435,11 @@ def test_unknown_preferredencoding_warned_and_fallback():
     @as_subprocess
     def child():
         with mock.patch('locale.getpreferredencoding') as get_enc:
-            get_enc.return_value = '---unknown--encoding---'
+            get_enc.return_value = 'unknown'
             with pytest.warns(UserWarning, match=(
-                    'LookupError: unknown encoding: ---unknown--encoding---, '
+                    'LookupError: unknown encoding: unknown, '
                     'defaulting to UTF-8 for keyboard.')):
-                t = TestTerminal()
+                t = TestTerminal(force_styling=True)
                 assert t._encoding == 'UTF-8'
 
     child()
@@ -443,7 +448,6 @@ def test_unknown_preferredencoding_warned_and_fallback():
 @pytest.mark.skipif(IS_WINDOWS, reason="requires fcntl")
 def test_win32_missing_tty_modules(monkeypatch):
     """Ensure dummy exception is used when io is without UnsupportedOperation."""
-    @as_subprocess
     def child():
         OLD_STYLE = False
         try:
@@ -469,20 +473,19 @@ def test_win32_missing_tty_modules(monkeypatch):
             else:
                 __builtins__['__import__'] = __import__
             try:
-                # local
+
                 import blessed.terminal
                 importlib.reload(blessed.terminal)
             except UserWarning as err:
                 assert err.args[0] == blessed.terminal._MSG_NOSUPPORT
 
             warnings.filterwarnings("ignore", category=UserWarning)
-            # local
+
             import blessed.terminal
             importlib.reload(blessed.terminal)
             assert not blessed.terminal.HAS_TTY
             term = blessed.terminal.Terminal('ansi')
-            # https://en.wikipedia.org/wiki/VGA-compatible_text_mode
-            # see section '#PC_common_text_modes'
+
             assert term.height == 25
             assert term.width == 80
 
@@ -492,7 +495,7 @@ def test_win32_missing_tty_modules(monkeypatch):
             else:
                 __builtins__['__import__'] = original_import
             warnings.resetwarnings()
-            # local
+
             import blessed.terminal
             importlib.reload(blessed.terminal)
 
@@ -501,44 +504,35 @@ def test_win32_missing_tty_modules(monkeypatch):
 
 def test_time_left():
     """test '_time_left' routine returns correct positive delta difference."""
-    # local
+
     from blessed.keyboard import _time_left
 
-    # given stime =~ "10 seconds ago"
     stime = time.time() - 10
 
-    # timeleft(now, 15s) = 5s remaining
     timeout = 15
     result = _time_left(stime=stime, timeout=timeout)
 
-    # we expect roughly 4.999s remain
     assert math.ceil(result) == 5.0
 
 
 def test_time_left_infinite_None():
     """keyboard '_time_left' routine returns None when given None."""
-    # local
+
     from blessed.keyboard import _time_left
     assert _time_left(stime=time.time(), timeout=None) is None
 
 
-@pytest.mark.skipif(IS_WINDOWS, reason="can't multiprocess")
 def test_termcap_repr():
-    """Ensure ``hidden_cursor()`` writes hide_cursor and normal_cursor."""
+    """Ensure Termcap repr includes escaped pattern string."""
 
     given_ttype = 'vt220'
     given_capname = 'cursor_up'
-    expected = [r"<Termcap cursor_up:'\x1b\\[A'>",
-                r"<Termcap cursor_up:'\\\x1b\\[A'>",
-                r"<Termcap cursor_up:'\\\x1b\\[A'>"]
+    expected = r"<Termcap cursor_up:'\x1b\\[A'>"
 
-    @as_subprocess
     def child():
-        # local
-        import blessed
-        term = blessed.Terminal(given_ttype)
+        term = TestTerminal(kind=given_ttype, force_styling=True)
         given = repr(term.caps[given_capname])
-        assert given in expected
+        assert given == expected
 
     child()
 
@@ -549,7 +543,6 @@ def test_termcap_repr():
 ])
 def test_query_methods_respect_does_styling_and_is_a_tty(force_styling, is_a_tty):
     """Test that all query methods respect does_styling and is_a_tty guardrails."""
-    @as_subprocess
     def child():
         stream = StringIO()
         term = TestTerminal(stream=stream, force_styling=force_styling)
@@ -595,7 +588,8 @@ def test_scroll_region_context_manager():
             pass
         return stream.getvalue()
 
-    output = pty_test(child, rows=24, cols=80)
+    output = pty_test(
+        child, rows=24, cols=80,)
     assert output == '\x1b[6;15r\x1b[1;24r'
 
 
@@ -620,3 +614,481 @@ def test_get_fgcolor_bgcolor_invalid_bits():
         term.get_fgcolor(bits=24)
     with pytest.raises(ValueError, match=r"bits must be 8 or 16, got 32"):
         term.get_bgcolor(bits=32)
+
+
+def test_multiple_terminal_kinds_bool_caps():
+    """String capability presence survives terminal kind switching."""
+    term_a = TestTerminal(kind='xterm-256color', force_styling=True)
+    assert term_a.dim != ''
+
+    term_b = TestTerminal(kind='vt220', force_styling=True)
+    assert term_b.dim == ''
+
+    assert term_a.dim != ''
+    assert term_b.dim == ''
+
+
+def test_multiple_terminal_kinds_alt_screen():
+    """Alternate screen capability survives terminal kind switching."""
+    term_a = TestTerminal(kind='xterm-256color', force_styling=True)
+    smcup_a = term_a.enter_fullscreen
+    assert smcup_a != ''
+
+    term_b = TestTerminal(kind='vt220', force_styling=True)
+    smcup_b = term_b.enter_fullscreen
+    assert smcup_b == ''
+
+    assert term_a.enter_fullscreen != ''
+    assert term_b.enter_fullscreen == ''
+
+
+def test_multiple_terminal_kinds_key_codes():
+    """Key codes survive terminal kind switching."""
+    term_a = TestTerminal(kind='xterm-256color', force_styling=True)
+    home_a = term_a.khome
+    assert home_a == '\x1bOH'
+
+    term_b = TestTerminal(kind='screen', force_styling=True)
+    home_b = term_b.khome
+    assert home_b == '\x1b[1~'
+
+    assert term_a.khome == '\x1bOH'
+    assert term_b.khome == '\x1b[1~'
+
+
+def test_force_styling_true_no_env_vars(monkeypatch):
+    """force_styling=True triggers does_styling=True via last elif branch (line 381)."""
+    monkeypatch.delenv('FORCE_COLOR', raising=False)
+    monkeypatch.delenv('CLICOLOR_FORCE', raising=False)
+    monkeypatch.delenv('NO_COLOR', raising=False)
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    assert term.does_styling is True
+
+
+def test_force_styling_none_is_a_tty():
+    """force_styling=None with is_a_tty=True logs 'force_styling is None' (line 381)."""
+    stream = StringIO()
+    stream.fileno = lambda: 1
+    with mock.patch('os.isatty', return_value=True):
+        term = TestTerminal(stream=stream, force_styling=None)
+        assert term.does_styling is False
+        assert any('force_styling is None' in err for err in term.errors)
+
+
+def test_force_styling_false_not_a_tty(monkeypatch):
+    """force_styling=False, no env vars, not a tty -> does_styling=False (line 382 elif False)."""
+    monkeypatch.delenv('FORCE_COLOR', raising=False)
+    monkeypatch.delenv('CLICOLOR_FORCE', raising=False)
+    monkeypatch.delenv('NO_COLOR', raising=False)
+    term = TestTerminal(stream=StringIO(), force_styling=False)
+    assert term.does_styling is False
+
+
+def test_getattr_underscore_prefix():
+    """__getattr__ raises AttributeError for _-prefixed attribute names."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    with pytest.raises(AttributeError):
+        _ = term._invalid_cap
+
+
+@pytest.mark.parametrize("is_a_tty,xtgettcap_supported,expected", [
+    (False, False, None),
+    (True, False, None),
+    (True, True, "supported"),
+])
+def test_get_xtgettcap_branches(is_a_tty, xtgettcap_supported, expected):
+    """get_xtgettcap returns None when not a tty or XTGETTCAP unsupported."""
+    xt_data = TermcapResponse(supported=xtgettcap_supported)
+    term = TestTerminal(stream=StringIO(), force_styling=True, _xtgettcap_data=xt_data)
+    term._is_a_tty = is_a_tty
+    result = term.get_xtgettcap(timeout=0.01)
+    if expected == "supported":
+        assert result is not None
+        assert result.supported is True
+    else:
+        assert result is None
+
+
+def test_does_osc52_clipboard_unsupported():
+    """does_osc52_clipboard returns False when neither DA1 nor XTGETTCAP supports it."""
+    xt_data = TermcapResponse(supported=True, capabilities={'TN': 'xterm-256color'})
+    term = TestTerminal(stream=StringIO(), force_styling=True, _xtgettcap_data=xt_data)
+    term._is_a_tty = True
+    term.ungetch('\x1b[?64;1;4c')
+    result = term.does_osc52_clipboard(timeout=0.01)
+    assert result is False
+
+
+def test_does_osc52_clipboard_da1_supports():
+    """does_osc52_clipboard returns True when DA1 has extension 52."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    term._is_a_tty = True
+    term.ungetch('\x1b[?64;1;2;4;52c')
+    result = term.does_osc52_clipboard(timeout=0.01)
+    assert result is True
+
+
+def test_does_osc52_clipboard_xtgettcap_supports():
+    """does_osc52_clipboard returns True when XTGETTCAP has Ms capability."""
+    xt_data = TermcapResponse(supported=True, capabilities={'TN': 'xterm-256color', 'Ms': '1'})
+    term = TestTerminal(stream=StringIO(), force_styling=True, _xtgettcap_data=xt_data)
+    term._is_a_tty = True
+    term.ungetch('\x1b[?64;1;4c')
+    result = term.does_osc52_clipboard(timeout=0.01)
+    assert result is True
+
+
+def test_does_osc52_clipboard_cached():
+    """does_osc52_clipboard uses cached result on second call."""
+    xt_data = TermcapResponse(supported=True, capabilities={'TN': 'xterm-256color', 'Ms': '1'})
+    term = TestTerminal(stream=StringIO(), force_styling=True, _xtgettcap_data=xt_data)
+    term._is_a_tty = True
+    term.ungetch('\x1b[?64;1c')
+    result1 = term.does_osc52_clipboard(timeout=0.01)
+    assert result1 is True
+    result2 = term.does_osc52_clipboard(timeout=0.01)
+    assert result2 is True
+
+
+def test_does_osc52_clipboard_force():
+    """does_osc52_clipboard with force=True bypasses cache."""
+    xt_data = TermcapResponse(supported=True, capabilities={'TN': 'xterm-256color', 'Ms': '1'})
+    term = TestTerminal(stream=StringIO(), force_styling=True, _xtgettcap_data=xt_data)
+    term._is_a_tty = True
+    term.ungetch('\x1b[?64;1c')
+    result1 = term.does_osc52_clipboard(timeout=0.01)
+    assert result1 is True
+    term._osc52_clipboard_supported = None
+    xt_empty = TermcapResponse(supported=True, capabilities={'TN': 'xterm-256color'})
+    term._xtgettcap_cache = xt_empty
+    term.ungetch('\x1b[?64;1c')
+    result2 = term.does_osc52_clipboard(timeout=0.01, force=True)
+    assert result2 is False
+
+
+@pytest.mark.parametrize("response,expected", [
+    (None, None),
+    ('', ''),
+    ('aGVsbG8=', 'hello'),
+])
+def test_clipboard_paste_branches(response, expected):
+    """clipboard_paste handles all response variants."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    term._is_a_tty = True
+    if response is None:
+        result = term.clipboard_paste(timeout=0.01)
+        assert result is None
+    else:
+        term.ungetch(f'\x1b]52;c;{response}\x07')
+        result = term.clipboard_paste(timeout=0.01)
+        assert result == expected
+
+
+def test_get_color_scheme_detects_dark():
+    """get_color_scheme returns 'dark' for Ps=1."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    term._is_a_tty = True
+    term.ungetch('\x1b[?997;1n')
+    result = term.get_color_scheme(timeout=0.01)
+    assert result == 'dark'
+
+
+def test_get_color_scheme_detects_light():
+    """get_color_scheme returns 'light' for Ps=2."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    term._is_a_tty = True
+    term.ungetch('\x1b[?997;2n')
+    result = term.get_color_scheme(timeout=0.01)
+    assert result == 'light'
+
+
+def test_get_color_scheme_cached_failure_sticky():
+    """get_color_scheme returns None when previous query failed (sticky failure)."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    term._is_a_tty = True
+    term._color_scheme_supported = False
+    result = term.get_color_scheme(timeout=0.01)
+    assert result is None
+
+
+def test_get_color_scheme_force_bypasses_sticky_failure():
+    """get_color_scheme with force=True bypasses sticky failure."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    term._is_a_tty = True
+    term._color_scheme_supported = False
+    term.ungetch('\x1b[?997;1n')
+    result = term.get_color_scheme(timeout=0.01, force=True)
+    assert result == 'dark'
+
+
+def test_get_location_percent_i_flag():
+    """get_location applies %i decrement when cursor_report contains %i."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    term._is_a_tty = True
+    term.ungetch('\x1b[2;6R')
+    term.caps['cursor_report'].attribute = '_mock_never_exists'
+    setattr(term, '_mock_never_exists', '\x1b[%i%d;%dR')
+    row, col = term.get_location(timeout=0.01)
+    assert row == 1
+    assert col == 5
+
+
+def test_get_location_no_percent_i():
+    """get_location does not decrement when cursor_report lacks %i."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    term._is_a_tty = True
+    term.ungetch('\x1b[2;6R')
+    term.caps['cursor_report'].attribute = '_mock_no_i'
+    setattr(term, '_mock_no_i', '\x1b[%d;%dR')
+    row, col = term.get_location(timeout=0.01)
+    assert row == 2
+    assert col == 6
+
+
+def test_split_seqs_maxsplit_with_xterm():
+    """split_seqs maxsplit truncates remaining text."""
+    term = TestTerminal(kind='xterm-256color', stream=StringIO(), force_styling=True)
+    result = list(term.split_seqs(term.bold('xy'), 1))
+    assert result == [term.bold, 'xy' + term.normal]
+
+
+def test_does_xtgettcap():
+    """does_xtgettcap returns True when XTGETTCAP is supported."""
+    xt_data = TermcapResponse(supported=True)
+    term = TestTerminal(stream=StringIO(), force_styling=True, _xtgettcap_data=xt_data)
+    term._is_a_tty = True
+    assert term.does_xtgettcap() is True
+
+
+def test_does_xtgettcap_unsupported():
+    """does_xtgettcap returns False when XTGETTCAP is not supported."""
+    xt_data = TermcapResponse(supported=False)
+    term = TestTerminal(stream=StringIO(), force_styling=True, _xtgettcap_data=xt_data)
+    term._is_a_tty = True
+    assert term.does_xtgettcap() is False
+
+
+def test_clipboard_paste_invalid_base64():
+    """clipboard_paste returns None for invalid base64 data."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    term._is_a_tty = True
+    term.ungetch('\x1b]52;c;!!!not-valid-base64!!!\x07')
+    result = term.clipboard_paste(timeout=0.01)
+    assert result is None
+
+
+def test_get_color_scheme_timeout():
+    """get_color_scheme returns None on timeout and sets sticky failure."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    term._is_a_tty = True
+    result = term.get_color_scheme(timeout=0.01)
+    assert result is None
+    assert term._color_scheme_supported is False
+
+
+def test_does_kitty_query():
+    """does_kitty_query returns True when XTGETTCAP has kitty-query-name."""
+    xt_data = TermcapResponse(supported=True, capabilities={'kitty-query-name': '1'})
+    term = TestTerminal(stream=StringIO(), force_styling=True, _xtgettcap_data=xt_data)
+    term._is_a_tty = True
+    assert term.does_kitty_query() is True
+
+
+def test_does_kitty_query_unsupported():
+    """does_kitty_query returns False when capability is missing."""
+    xt_data = TermcapResponse(supported=True, capabilities={})
+    term = TestTerminal(stream=StringIO(), force_styling=True, _xtgettcap_data=xt_data)
+    term._is_a_tty = True
+    assert term.does_kitty_query() is False
+
+
+def test_stream_fileno_valueerror(monkeypatch):
+    """__init__streams handles ValueError from stream.fileno()."""
+    stream = StringIO()
+    stream.fileno = lambda: (_ for _ in ()).throw(ValueError('detached'))
+    monkeypatch.delenv('FORCE_COLOR', raising=False)
+    monkeypatch.delenv('NO_COLOR', raising=False)
+    term = TestTerminal(stream=stream)
+    assert any('Unable to determine output stream' in err for err in term.errors)
+
+
+def test_sys_stdout_fileno_valueerror():
+    """__init__streams handles ValueError from sys.__stdout__.fileno()."""
+    stream = StringIO()
+    with mock.patch('sys.__stdout__.fileno', side_effect=ValueError('detached')):
+        term = TestTerminal(stream=stream)
+        assert any('sys.__stdout__.fileno() failed' in err for err in term.errors)
+
+
+def test_clipboard_copy_writes_to_stream():
+    """clipboard_copy writes the OSC 52 sequence to self.stream."""
+    stream = StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term.clipboard_copy('hello world')
+    output = stream.getvalue()
+    assert '\x1b]52;c;' in output
+    assert base64.b64encode(b'hello world').decode('ascii') in output
+
+
+def test_does_styled_underlines():
+    """does_styled_underlines returns True when XTGETTCAP has Smulx."""
+    xt_data = TermcapResponse(supported=True, capabilities={'Smulx': '1'})
+    term = TestTerminal(stream=StringIO(), force_styling=True, _xtgettcap_data=xt_data)
+    term._is_a_tty = True
+    assert term.does_styled_underlines() is True
+
+
+def test_does_styled_underlines_unsupported():
+    """does_styled_underlines returns False when Smulx is missing."""
+    xt_data = TermcapResponse(supported=True, capabilities={})
+    term = TestTerminal(stream=StringIO(), force_styling=True, _xtgettcap_data=xt_data)
+    term._is_a_tty = True
+    assert term.does_styled_underlines() is False
+
+
+def test_does_colored_underlines():
+    """does_colored_underlines returns True when XTGETTCAP has Setulc."""
+    xt_data = TermcapResponse(supported=True, capabilities={'Setulc': '1'})
+    term = TestTerminal(stream=StringIO(), force_styling=True, _xtgettcap_data=xt_data)
+    term._is_a_tty = True
+    assert term.does_colored_underlines() is True
+
+
+def test_does_colored_underlines_unsupported():
+    """does_colored_underlines returns False when Setulc is missing."""
+    xt_data = TermcapResponse(supported=True, capabilities={})
+    term = TestTerminal(stream=StringIO(), force_styling=True, _xtgettcap_data=xt_data)
+    term._is_a_tty = True
+    assert term.does_colored_underlines() is False
+
+
+def test_clipboard_copy_no_styling():
+    """clipboard_copy early-returns when does_styling is False."""
+    stream = StringIO()
+    term = TestTerminal(stream=stream, force_styling=False)
+    term.clipboard_copy('hello')
+    assert stream.getvalue() == ''
+
+
+def test_device_attributes_parse_failure():
+    """get_device_attributes returns None for malformed DA1 response."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    term._is_a_tty = True
+
+    term.ungetch('\x1b[?')
+    result = term.get_device_attributes(timeout=0.01)
+    assert result is None
+
+
+def test_software_version_env_fallback_standalone():
+    """get_software_version falls back to TERM_PROGRAM env vars (no XTVERSION)."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    term._is_a_tty = True
+    with mock.patch.dict(os.environ, {'TERM_PROGRAM': 'TestTerm', 'TERM_PROGRAM_VERSION': '1.0'}):
+        result = term.get_software_version(timeout=0.01)
+        assert result is not None
+        assert result.name == 'TestTerm'
+        assert result.version == '1.0'
+
+
+def test_software_version_no_response():
+    """get_software_version returns None with no XTVERSION and no env vars."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    term._is_a_tty = True
+    with mock.patch.dict(os.environ, {}, clear=True):
+        result = term.get_software_version(timeout=0.01)
+        assert result is None
+
+
+def test_software_version_cache_hit():
+    """get_software_version returns cached result without new query."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    term._is_a_tty = True
+    with mock.patch.dict(os.environ, {'TERM_PROGRAM': 'CachedTerm', 'TERM_PROGRAM_VERSION': '2.0'}):
+        result1 = term.get_software_version(timeout=0.01)
+        assert result1 is not None
+
+        result2 = term.get_software_version(timeout=0.01)
+        assert result2 is result1
+
+
+def test_software_version_xtversion_match():
+    """get_software_version parses XTVERSION response via ungetch."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    term._is_a_tty = True
+
+    term.ungetch('\x1bP>|WezTerm(20240203)\x1b\\')
+    result = term.get_software_version(timeout=0.01)
+    assert result is not None
+    assert result.name == 'WezTerm'
+    assert result.version == '20240203'
+
+
+def test_kbhit_without_tty(monkeypatch):
+    """kbhit returns False when HAS_TTY is False (no termios platform)."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    with mock.patch('blessed.terminal.HAS_TTY', False):
+        result = term.kbhit(timeout=0)
+        assert result is False
+
+
+@pytest.mark.parametrize('cpr1,cpr2,expected', [
+    ('\x1b[1;10R', '\x1b[1;11R', 1),
+    ('\x1b[1;10R', '\x1b[1;12R', 2),
+    ('\x1b[1;10R', '\x1b[1;10R', 1),
+    ('\x1b[1;10R', '\x1b[1;13R', 1),
+])
+def test_detect_ambiguous_width_unit(cpr1, cpr2, expected):
+    """detect_ambiguous_width returns measured width of U+00A7 via CPR."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    term._is_a_tty = True
+    term.ungetch(cpr1)
+    term.ungetch(cpr2)
+    result = term.detect_ambiguous_width(timeout=0.1, fallback=1)
+    assert result == expected
+
+
+def test_detect_ambiguous_width_first_timeout():
+    """detect_ambiguous_width returns fallback when first get_location times out."""
+    stream = StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+
+    result = term.detect_ambiguous_width(timeout=0.01, fallback=99)
+    assert result == 99
+
+
+def test_detect_ambiguous_width_second_timeout():
+    """detect_ambiguous_width returns fallback when second get_location times out."""
+    stream = StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+
+    term.ungetch('\x1b[1;10R')
+    result = term.detect_ambiguous_width(timeout=0.01, fallback=77)
+    assert result == 77
+
+
+@pytest.mark.skipif(not IS_WINDOWS, reason='requires jinxed.win32 (msvcrt)')
+def test_windows_init_streams_encoding():
+    """__init__streams uses get_console_input_encoding when IS_WINDOWS is True."""
+    import blessed.terminal as bt
+    with mock.patch.object(bt, 'IS_WINDOWS', True), \
+            mock.patch.object(bt, 'get_console_input_encoding', return_value='cp1252'), \
+            mock.patch('os.isatty', return_value=True):
+        term = TestTerminal(force_styling=True)
+        assert term._encoding == 'cp1252'
+
+
+def test_windows_vtwin10_truecolor():
+    """__init__color_capabilities returns 1<<24 for vtwin10 on modern Windows."""
+    import blessed.terminal as bt
+    original_is_windows = bt.IS_WINDOWS
+    try:
+        bt.IS_WINDOWS = True
+        with mock.patch('platform.version', return_value='10.0.19041'), \
+                mock.patch('platform.system', return_value='Windows'):
+            term = TestTerminal(stream=StringIO(), kind='vtwin10', force_styling=True)
+            assert term.number_of_colors == 1 << 24
+    finally:
+        bt.IS_WINDOWS = original_is_windows

--- a/tests/test_cursor_shape.py
+++ b/tests/test_cursor_shape.py
@@ -8,7 +8,7 @@ import pytest
 
 # local
 from blessed.cursor_shape import CursorShape
-from .accessories import TestTerminal, as_subprocess
+from .accessories import TestTerminal
 
 
 def test_constant_values():
@@ -102,9 +102,8 @@ def test_sequence_invalid_string():
         CursorShape.sequence('zigzag')
 
 
-def test_cursor_shape_writes_sequence(all_terms):
+def test_cursor_shape_writes_sequence(any_term):
     """Context manager writes enter and reset sequences."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(stream=StringIO(), force_styling=True)
         with t.cursor_shape(t.CursorShape.BLINKING_BAR):
@@ -112,12 +111,11 @@ def test_cursor_shape_writes_sequence(all_terms):
         output = t.stream.getvalue()
         assert output == '\x1b[5 q' + '\x1b[0 q'
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_cursor_shape_string_name(all_terms):
+def test_cursor_shape_string_name(any_term):
     """Context manager accepts string style names."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(stream=StringIO(), force_styling=True)
         with t.cursor_shape('steady_underline'):
@@ -125,12 +123,11 @@ def test_cursor_shape_string_name(all_terms):
         output = t.stream.getvalue()
         assert output == '\x1b[4 q' + '\x1b[0 q'
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_cursor_shape_default_style(all_terms):
+def test_cursor_shape_default_style(any_term):
     """Context manager with no argument uses DEFAULT_STYLE."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(stream=StringIO(), force_styling=True)
         with t.cursor_shape():
@@ -138,19 +135,18 @@ def test_cursor_shape_default_style(all_terms):
         output = t.stream.getvalue()
         assert output == '\x1b[2 q' + '\x1b[0 q'
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_cursor_shape_no_styling(all_terms):
+def test_cursor_shape_no_styling(any_term):
     """Context manager is a no-op when styling is disabled."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(stream=StringIO(), force_styling=False)
         with t.cursor_shape(t.CursorShape.BLINKING_BAR):
             pass
         assert t.stream.getvalue() == ''
 
-    child(all_terms)
+    child(any_term)
 
 
 def test_cursor_shape_accessible_as_class_attr():
@@ -161,23 +157,21 @@ def test_cursor_shape_accessible_as_class_attr():
 
 
 @pytest.mark.parametrize("style", [0, 1, 2, 3, 4, 5, 6])
-def test_length_strips_decscusr(all_terms, style):
+def test_length_strips_decscusr(any_term, style):
     """Terminal.length() excludes DECSCUSR sequences."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(force_styling=True)
         text = CursorShape.sequence(style) + 'hello'
         assert t.length(text) == 5
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_length_strips_color_reset_osc(all_terms):
+def test_length_strips_color_reset_osc(any_term):
     """Terminal.length() excludes COLOR_RESET_OSC sequence."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(force_styling=True)
         text = CursorShape.COLOR_RESET_OSC + 'hello'
         assert t.length(text) == 5
 
-    child(all_terms)
+    child(any_term)

--- a/tests/test_dec_modes.py
+++ b/tests/test_dec_modes.py
@@ -24,7 +24,7 @@ from blessed.keyboard import (
     get_leading_prefixes,
     DeviceAttribute,
 )
-from .accessories import TestTerminal, as_subprocess, make_enabled_dec_cache
+from .accessories import TestTerminal, make_enabled_dec_cache
 from .conftest import IS_WINDOWS
 
 # For backwards compatibility and convenience in tests
@@ -306,7 +306,6 @@ def test_dec_mode_response_description_fallback():
 
 def test_dec_mode_calls_with_no_styling():
     """Test _dec_mode_set_enabled does nothing when does_styling is False."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=False)
@@ -327,7 +326,6 @@ def test_dec_mode_calls_with_no_styling():
 
 def test_get_dec_mode_invalid_mode_type():
     """Test get_dec_mode raises TypeError for invalid mode types."""
-    @as_subprocess
     def child():
         term = TestTerminal()
         with pytest.raises(TypeError):
@@ -337,7 +335,6 @@ def test_get_dec_mode_invalid_mode_type():
 
 def test_get_dec_mode_successful_query():
     """Test successful DEC mode query with mocked response."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -365,7 +362,6 @@ def test_get_dec_mode_successful_query():
 
 def test_get_dec_mode_timeout():
     """Test DEC mode query timeout handling."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -388,7 +384,6 @@ def test_get_dec_mode_timeout():
 
 def test_get_dec_mode_cached_response():
     """Test that cached responses are returned without re-querying."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -409,7 +404,6 @@ def test_get_dec_mode_cached_response():
 
 def test_get_dec_mode_force_bypass_cache():
     """Test force=True bypasses cache and re-queries."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -436,7 +430,6 @@ def test_get_dec_mode_force_bypass_cache():
 
 def test_get_dec_mode_sticky_failure():
     """Test get_dec_mode returns NOT_QUERIED after first query fails."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -465,7 +458,6 @@ def test_get_dec_mode_sticky_failure():
 
 def test_get_dec_mode_no_response_after_success():
     """Test get_dec_mode returns NO_RESPONSE when query fails after previous success."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -502,7 +494,6 @@ def test_get_dec_mode_no_response_after_success():
 
 def test_dec_mode_set_enabled_with_styling():
     """Test _dec_mode_set_enabled writes correct sequence."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -516,7 +507,6 @@ def test_dec_mode_set_enabled_with_styling():
 
 def test_dec_mode_set_disabled_with_styling():
     """Test _dec_mode_set_disabled writes correct sequence."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -530,7 +520,6 @@ def test_dec_mode_set_disabled_with_styling():
 
 def test_dec_mode_set_enabled_invalid_mode_type():
     """Test _dec_mode_set_enabled raises TypeError for invalid mode types."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=False)
@@ -542,7 +531,6 @@ def test_dec_mode_set_enabled_invalid_mode_type():
 
 def test_dec_mode_set_disabled_invalid_mode_type():
     """Test _dec_mode_set_disabled raises TypeError for invalid mode types."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=False)
@@ -558,7 +546,6 @@ def test_dec_mode_set_disabled_invalid_mode_type():
 ])
 def test_dec_mode_set_with_dec_private_mode_enum(method_name, suffix):
     """Test _dec_mode_set_enabled/disabled with DecPrivateMode instance values."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -573,7 +560,6 @@ def test_dec_mode_set_with_dec_private_mode_enum(method_name, suffix):
 
 def test_dec_modes_enabled_with_invalid_type():
     """Test dec_modes_enabled raises TypeError with invalid mode type."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -590,7 +576,6 @@ def test_dec_modes_enabled_with_invalid_type():
 
 def test_dec_modes_disabled_with_invalid_type():
     """Test dec_modes_disabled raises TypeError with invalid mode type."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -609,7 +594,6 @@ def test_dec_modes_disabled_with_invalid_type():
 
 def test_dec_modes_enabled_context_manager():
     """Test dec_modes_enabled context manager behavior."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -632,7 +616,6 @@ def test_dec_modes_enabled_context_manager():
 
 def test_dec_modes_enabled_already_enabled():
     """Test dec_modes_enabled skips already enabled modes."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -655,7 +638,6 @@ def test_dec_modes_enabled_already_enabled():
 
 def test_dec_modes_enabled_unsupported_mode():
     """Test dec_modes_enabled skips unsupported modes."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -677,7 +659,6 @@ def test_dec_modes_enabled_unsupported_mode():
 
 def test_dec_modes_disabled_context_manager():
     """Test dec_modes_disabled context manager behavior."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -700,7 +681,6 @@ def test_dec_modes_disabled_context_manager():
 
 def test_dec_modes_disabled_already_disabled():
     """Test dec_modes_disabled skips already disabled modes."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -744,7 +724,6 @@ def test_context_manager_no_styling_and_invalid_args():
 
 def test_context_manager_exception_handling():
     """Test context managers properly restore state on exception."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -769,7 +748,6 @@ def test_context_manager_exception_handling():
 
 def test_multiple_modes_context_manager():
     """Test context managers work with multiple modes."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -799,7 +777,6 @@ def test_multiple_modes_context_manager():
 ])
 def test_dec_modes_context_with_dec_private_mode_enum(method_name, mock_response):
     """Test dec_modes_enabled/disabled with DecPrivateMode instance values."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -838,7 +815,6 @@ def test_int_mode_parameters():
 ])
 def test_sugary_context_managers(method_name, expected_mode):
     """Test sugary context managers enable correct modes."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -867,7 +843,6 @@ def test_sugary_context_managers(method_name, expected_mode):
 ])
 def test_sugary_context_managers_no_styling(method_name):
     """Test sugary context managers do nothing when does_styling is False."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=False)
@@ -1021,7 +996,6 @@ def test_mouse_event_name_with_non_mouse_mode():
 
 def test_query_response_with_line_buffered_mode():
     """Test _query_response with line buffering disabled."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -1075,7 +1049,6 @@ def test_resize_events(sequence, h_chars, w_chars, h_pix, w_pix):
 
 def test_notify_on_resize_context_manager():
     """Test notify_on_resize enables and disables mode correctly."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -1098,7 +1071,6 @@ def test_notify_on_resize_context_manager():
 
 def test_notify_on_resize_cache_cleared_on_exit():
     """Test preferred size cache is cleared when exiting context."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -1125,7 +1097,6 @@ def test_notify_on_resize_cache_cleared_on_exit():
 
 def test_height_width_use_preferred_cache():
     """Test height and width properties use preferred cache."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -1143,7 +1114,6 @@ def test_height_width_use_preferred_cache():
 
 def test_sixel_uses_preferred_cache():
     """Test get_sixel_height_and_width uses pixel dimensions from cache."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -1160,7 +1130,6 @@ def test_sixel_uses_preferred_cache():
 
 def test_sixel_ignores_zero_pixel_cache():
     """Test get_sixel_height_and_width falls back when pixel dimensions are zero."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -1187,7 +1156,6 @@ def test_sixel_ignores_zero_pixel_cache():
 ])
 def test_does_inband_resize(response_value, expected):
     """Test does_inband_resize returns expected value based on mode support."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -1204,7 +1172,6 @@ def test_does_inband_resize(response_value, expected):
 
 def test_does_inband_resize_not_a_tty():
     """Test does_inband_resize returns False when not a TTY."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True, is_a_tty=False)
 
@@ -1273,7 +1240,6 @@ def test_does_inband_resize_no_styling():
 ])
 def test_does_dec_mode_convenience(method_name, response_value, expected):
     """Boolean DEC mode convenience methods return correct values."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -1295,7 +1261,6 @@ def test_does_dec_mode_convenience(method_name, response_value, expected):
 ])
 def test_does_dec_mode_convenience_not_a_tty(method_name):
     """Boolean DEC mode convenience methods return False when not a TTY."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True, is_a_tty=False)
         result = getattr(term, method_name)(timeout=0.01)

--- a/tests/test_device_attribute.py
+++ b/tests/test_device_attribute.py
@@ -42,7 +42,6 @@ from .conftest import TEST_KEYBOARD, IS_WINDOWS
 from .accessories import (
     TestTerminal,
     pty_test,
-    as_subprocess,
 )
 from blessed.keyboard import DeviceAttribute
 
@@ -255,7 +254,6 @@ def test_device_attribute_raw_stored():
 
 def test_get_kitty_keyboard_state_boundary_no_response():
     """Kitty keyboard query sets sticky failure when no response."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -272,7 +270,6 @@ def test_get_kitty_keyboard_state_boundary_no_response():
 
 def test_get_kitty_keyboard_state_cpr_fast_negative():
     """Kitty keyboard query returns None quickly via CPR boundary."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -287,7 +284,6 @@ def test_get_kitty_keyboard_state_cpr_fast_negative():
 
 def test_enable_kitty_keyboard_after_query_failed():
     """Test enable_kitty_keyboard yields without emitting sequences after query failed."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,14 +1,13 @@
 """Tests string formatting functions."""
 # std imports
 import pickle
-import platform
 import multiprocessing
 
 # 3rd party
 import pytest
 
 # local
-from .accessories import TestTerminal, as_subprocess
+from .accessories import TestTerminal
 
 try:
     # std imports
@@ -17,12 +16,7 @@ except ImportError:
     # 3rd party
     import mock
 
-if platform.system() != 'Windows':
-    # std imports
-    import curses
-else:
-    # 3rd party
-    import jinxed as curses
+import jinxed
 
 
 def fn_tparm(*args):
@@ -39,7 +33,7 @@ def test_parameterizing_string_args_unspecified(monkeypatch):
 
     # first argument to tparm() is the sequence name, returned as-is;
     # subsequent arguments are usually Integers.
-    monkeypatch.setattr(curses, 'tparm', fn_tparm)
+    monkeypatch.setattr(jinxed, 'tparm', fn_tparm)
 
     # given,
     pstr = ParameterizingString('')
@@ -69,7 +63,7 @@ def test_parameterizing_string_args(monkeypatch):
 
     # first argument to tparm() is the sequence name, returned as-is;
     # subsequent arguments are usually Integers.
-    monkeypatch.setattr(curses, 'tparm', fn_tparm)
+    monkeypatch.setattr(jinxed, 'tparm', fn_tparm)
 
     # given,
     pstr = ParameterizingString('cap', 'norm', 'seq-name')
@@ -100,7 +94,7 @@ def test_parameterizing_string_type_error(monkeypatch):
     def tparm_raises_TypeError(*args):
         raise TypeError('custom_err')
 
-    monkeypatch.setattr(curses, 'tparm', tparm_raises_TypeError)
+    monkeypatch.setattr(jinxed, 'tparm', tparm_raises_TypeError)
 
     # given,
     pstr = ParameterizingString('cap', 'norm', 'cap-name')
@@ -211,9 +205,12 @@ def test_resolve_capability(monkeypatch):
     def tigetstr(attr):
         return f'seq-{attr}'.encode('latin1')
 
-    monkeypatch.setattr(curses, 'tigetstr', tigetstr)
+    monkeypatch.setattr(jinxed, 'tigetstr', tigetstr)
     term = mock.Mock()
     term._sugar = {'mnemonic': 'xyz'}
+    jinxed_mock = mock.Mock()
+    jinxed_mock.tigetstr = tigetstr
+    term._jinxed_term = jinxed_mock
 
     # exercise
     assert resolve_capability(term, 'mnemonic') == 'seq-xyz'
@@ -223,20 +220,124 @@ def test_resolve_capability(monkeypatch):
     def tigetstr_none(attr):
         return None
 
-    monkeypatch.setattr(curses, 'tigetstr', tigetstr_none)
+    jinxed_mock.tigetstr = tigetstr_none
 
     # exercise,
-    assert resolve_capability(term, 'natural') == ''
+    assert resolve_capability(term, 'am') == ''
 
     # given, where does_styling is False
     def raises_exception(*args):
         assert False, "Should not be called"
 
     term.does_styling = False
-    monkeypatch.setattr(curses, 'tigetstr', raises_exception)
+    monkeypatch.setattr(jinxed, 'tigetstr', raises_exception)
 
     # exercise,
     assert resolve_capability(term, 'natural') == ''
+
+
+def test_resolve_capability_warns_unknown():
+    """Test resolve_capability warns on unknown capability names."""
+    import warnings
+    from blessed.formatters import resolve_capability, _KNOWN_CAPABILITY_NAMES
+
+    term = mock.Mock()
+    term.does_styling = True
+    term._sugar = {}
+    jinxed_mock = mock.Mock()
+    jinxed_mock.tigetstr = lambda cap: (
+        None if cap not in _KNOWN_CAPABILITY_NAMES
+        else 'seq-known'.encode('latin1')
+    )
+    term._jinxed_term = jinxed_mock
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        result = resolve_capability(term, 'bold')
+        assert 'seq-known' == result
+        assert len(w) == 0
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        result = resolve_capability(term, 'nonexistent_capability_xyz')
+        assert result == ''
+        assert len(w) == 1
+        assert 'nonexistent_capability_xyz' in str(w[0].message)
+
+
+def test_resolve_capability_no_warn_on_absent_known():
+    """Test no warning when a known cap is absent from this terminal."""
+    import warnings
+    from blessed.formatters import resolve_capability, _KNOWN_CAPABILITY_NAMES
+
+    term = mock.Mock()
+    term.does_styling = True
+    term._sugar = {}
+    jinxed_mock = mock.Mock()
+    jinxed_mock.tigetstr = lambda cap: None
+    term._jinxed_term = jinxed_mock
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        result = resolve_capability(term, 'am')
+        assert result == ''
+        warning_texts = [str(x.message) for x in w]
+        assert not any('am' in t for t in warning_texts)
+
+
+def test_resolve_capability_nowarn_env(monkeypatch):
+    """Test BLESSED_NOWARN_UNKNOWN_CAPS suppresses the warning."""
+    import warnings
+    import blessed.formatters
+    resolve_capability = blessed.formatters.resolve_capability
+    monkeypatch.setattr(blessed.formatters, '_NOWARN_UNKNOWN_CAPS', True)
+
+    term = mock.Mock()
+    term.does_styling = True
+    term._sugar = {}
+    jinxed_mock = mock.Mock()
+    jinxed_mock.tigetstr = lambda cap: None
+    term._jinxed_term = jinxed_mock
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        result = resolve_capability(term, 'nonexistent_capability_xyz')
+        assert result == ''
+        assert len(w) == 0
+
+
+def test_resolve_capability_warns_unknown_sugar():
+    """Test warning names the resolved capname, not the sugar key."""
+    import warnings
+    from blessed.formatters import resolve_capability, _KNOWN_CAPABILITY_NAMES
+
+    term = mock.Mock()
+    term.does_styling = True
+    term._sugar = {'mnemonic': 'nonexistent_capability_xyz'}
+    jinxed_mock = mock.Mock()
+    jinxed_mock.tigetstr = lambda cap: None
+    term._jinxed_term = jinxed_mock
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        result = resolve_capability(term, 'mnemonic')
+        assert result == ''
+        assert len(w) == 1
+        assert 'nonexistent_capability_xyz' in str(w[0].message)
+
+
+def test_resolve_capability_empty_bytes_returns_empty():
+    """Test jinxed EMPTY_CAPS returning b'' produces '' with no warning."""
+    import warnings
+    from blessed.formatters import resolve_capability
+
+    term = TestTerminal(force_styling=True)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        result = resolve_capability(term, 'enacs')
+        assert result == ''
+        assert len(w) == 0
 
 
 def test_resolve_color(monkeypatch):
@@ -247,7 +348,7 @@ def test_resolve_color(monkeypatch):
     def color_cap(digit):
         return f'seq-{digit}'
 
-    monkeypatch.setattr(curses, 'COLOR_RED', 1984)
+    monkeypatch.setattr(jinxed, 'COLOR_RED', 1984)
 
     # given, terminal with color capabilities
     term = mock.Mock()
@@ -343,7 +444,7 @@ def test_resolve_attribute_non_compoundables(monkeypatch):
     monkeypatch.setattr(blessed.formatters,
                         'resolve_capability',
                         resolve_cap)
-    monkeypatch.setattr(curses, 'tparm', fn_tparm)
+    monkeypatch.setattr(jinxed, 'tparm', fn_tparm)
 
     term = mock.Mock()
     term.normal = 'seq-normal'
@@ -371,9 +472,9 @@ def test_resolve_attribute_recursive_compoundables(monkeypatch):
     monkeypatch.setattr(blessed.formatters,
                         'resolve_capability',
                         resolve_cap)
-    monkeypatch.setattr(curses, 'tparm', fn_tparm)
-    monkeypatch.setattr(curses, 'COLOR_RED', 6502)
-    monkeypatch.setattr(curses, 'COLOR_BLUE', 6800)
+    monkeypatch.setattr(jinxed, 'tparm', fn_tparm)
+    monkeypatch.setattr(jinxed, 'COLOR_RED', 6502)
+    monkeypatch.setattr(jinxed, 'COLOR_BLUE', 6800)
 
     def color_cap(digit):
         return f'seq-{digit}'
@@ -394,7 +495,6 @@ def test_resolve_attribute_recursive_compoundables(monkeypatch):
 
 def test_formattingstring_picklability():
     """Test pickle-ability of a FormattingString."""
-    @as_subprocess
     def child():
         t = TestTerminal(force_styling=True)
         # basic pickle
@@ -405,13 +505,11 @@ def test_formattingstring_picklability():
         r, w = multiprocessing.Pipe()
         w.send(t.normal)
         assert r.recv() == t.normal
-
     child()
 
 
 def test_formattingotherstring_picklability():
     """Test pickle-ability of a FormattingOtherString."""
-    @as_subprocess
     def child():
         t = TestTerminal(force_styling=True)
         # basic pickle
@@ -425,16 +523,15 @@ def test_formattingotherstring_picklability():
         assert r.recv()(3) == t.move_left(3)
         w.send(t.move_left(3))
         assert r.recv() == t.move_left(3)
-
     child()
 
 
 def test_paramterizingstring_picklability():
     """Test pickle-ability of ParameterizingString."""
-    @as_subprocess
+    # local
+    from blessed.formatters import ParameterizingString
+
     def child():
-        # local
-        from blessed.formatters import ParameterizingString
         t = TestTerminal(force_styling=True)
 
         color = ParameterizingString(t.color, t.normal, 'color')
@@ -450,7 +547,6 @@ def test_paramterizingstring_picklability():
         assert r.recv() == color(3)
         w.send(t.color)
         assert r.recv()(3) == t.color(3)
-
     child()
 
 
@@ -463,7 +559,7 @@ def test_pickled_parameterizing_string(monkeypatch):
     # pickle.loads(dumps(...)) did not reproduce this issue,
     # first argument to tparm() is the sequence name, returned as-is;
     # subsequent arguments are usually Integers.
-    monkeypatch.setattr(curses, 'tparm', fn_tparm)
+    monkeypatch.setattr(jinxed, 'tparm', fn_tparm)
 
     # given,
     pstr = ParameterizingString('seqname', 'norm', 'cap-name')
@@ -486,46 +582,13 @@ def test_pickled_parameterizing_string(monkeypatch):
     assert r.recv() == zero
 
 
-def test_tparm_returns_null(monkeypatch):
-    """Test 'tparm() returned NULL' is caught (win32 PDCurses systems)."""
-    # on win32, any calls to tparm raises curses.error with message,
-    # "tparm() returned NULL", function PyCurses_tparm of _cursesmodule.c
-    # local
-    from blessed.formatters import NullCallableString, ParameterizingString
-
-    def tparm(*args):
-        raise curses.error("tparm() returned NULL")
-
-    monkeypatch.setattr(curses, 'tparm', tparm)
-
-    term = mock.Mock()
-    term.normal = 'seq-normal'
-
-    pstr = ParameterizingString('cap', 'norm', 'seq-name')
-
-    value = pstr(0)
-    assert isinstance(value, NullCallableString)
-
-
-def test_tparm_other_exception(monkeypatch):
-    """Test 'tparm() returned NULL' is caught (win32 PDCurses systems)."""
-    # on win32, any calls to tparm raises curses.error with message,
-    # "tparm() returned NULL", function PyCurses_tparm of _cursesmodule.c
-    # local
-    from blessed.formatters import ParameterizingString
-
-    def tparm(*args):
-        raise curses.error("unexpected error in tparm()")
-
-    monkeypatch.setattr(curses, 'tparm', tparm)
-
-    term = mock.Mock()
-    term.normal = 'seq-normal'
-
-    pstr = ParameterizingString('cap', 'norm', 'seq-name')
-
-    try:
-        pstr('x')
-        assert False, "previous call should have raised curses.error"
-    except curses.error:
-        pass
+def test_parameterizing_proxy_string_legacy():
+    """ParameterizingProxyString.__new__ and __call__ (deprecated but kept for API compat)."""
+    from blessed.formatters import ParameterizingProxyString, FormattingString
+    fmt_pair = ('\x1b[{0}G', lambda *arg: (arg[0] + 1,))
+    proxy = ParameterizingProxyString(fmt_pair, '\x1b[m', 'hpa')
+    assert isinstance(proxy, str)
+    assert proxy == '\x1b[{0}G'
+    result = proxy(9)
+    assert isinstance(result, FormattingString)
+    assert result == '\x1b[10G'

--- a/tests/test_full_keyboard.py
+++ b/tests/test_full_keyboard.py
@@ -14,13 +14,14 @@ from unittest import mock
 import pytest
 
 # local
-from .conftest import TEST_RAW, IS_WINDOWS, TEST_QUICK, TEST_KEYBOARD
+from .conftest import IS_WINDOWS, TEST_KEYBOARD, TEST_RAW
 from .accessories import (SEMAPHORE,
                           RECV_SEMAPHORE,
                           SEND_SEMAPHORE,
+                          TEST_TIMEOUT_SHORT,
                           TestTerminal,
+                          assert_timeout_elapsed,
                           echo_off,
-                          as_subprocess,
                           read_until_eof,
                           read_until_semaphore,
                           init_subproc_coverage,
@@ -40,7 +41,6 @@ def assert_elapsed_range_ms(start_time, min_ms, max_ms):
     assert min_ms <= int(elapsed_ms) <= max_ms
 
 
-@pytest.mark.skipif(TEST_QUICK, reason="TEST_QUICK specified")
 def test_kbhit_interrupted():
     """kbhit() survives signal handler."""
     # this is a test for a legacy version of python, doesn't hurt to keep around
@@ -61,7 +61,7 @@ def test_kbhit_interrupted():
         read_until_semaphore(sys.__stdin__.fileno(), semaphore=SEMAPHORE)
         os.write(sys.__stdout__.fileno(), SEMAPHORE)
         with term.raw():
-            assert term.inkey(timeout=0.2) == ''
+            assert term.inkey(timeout=0.1) == ''
         os.write(sys.__stdout__.fileno(), b'complete')
         assert got_sigwinch
         if cov is not None:
@@ -73,17 +73,16 @@ def test_kbhit_interrupted():
         os.write(master_fd, SEND_SEMAPHORE)
         read_until_semaphore(master_fd)
         stime = time.time()
-        time.sleep(0.05)
+        time.sleep(0.01)
         os.kill(pid, signal.SIGWINCH)
         output = read_until_eof(master_fd)
 
     pid, status = os.waitpid(pid, 0)
     assert output == 'complete'
     assert os.WEXITSTATUS(status) == 0
-    assert_elapsed_range_ms(stime, 15, 80)
+    assert_elapsed_range_ms(stime, 8, 40)
 
 
-@pytest.mark.skipif(TEST_QUICK, reason="TEST_QUICK specified")
 def test_kbhit_interrupted_nonetype():
     """kbhit() should also allow interruption with timeout of None."""
     # pylint: disable=global-statement
@@ -136,19 +135,17 @@ def test_kbhit_interrupted_nonetype():
 
 def test_kbhit_no_kb():
     """kbhit() always immediately returns False without a keyboard."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO())
         stime = time.time()
         assert term._keyboard_fd is None
         assert not term.kbhit(timeout=0.3)
-        assert_elapsed_range_ms(stime, 25, 80)
+        assert_elapsed_range_ms(stime, 0, 5)
     child()
 
 
 def test_kbhit_no_tty():
     """kbhit() returns False immediately if HAS_TTY is False"""
-    @as_subprocess
     def child():
         with mock.patch('blessed.terminal.HAS_TTY', False):
             term = TestTerminal(stream=StringIO())
@@ -162,14 +159,11 @@ def test_kbhit_no_tty():
     'use_stream,timeout,expected_cs_range', [
         (False, 0, (0, 5)),
         (True, 0, (0, 5)),
-        pytest.param(False, 0.3, (25, 80), marks=pytest.mark.skipif(
-            TEST_QUICK, reason="TEST_QUICK specified")),
-        pytest.param(True, 0.3, (25, 80), marks=pytest.mark.skipif(
-            TEST_QUICK, reason="TEST_QUICK specified")),
+        (False, 0.1, (0, 5)),
+        (True, 0.1, (0, 5)),
     ])
 def test_keystroke_cbreak_noinput(use_stream, timeout, expected_cs_range):
     """Test keystroke without input with various timeout/stream combinations."""
-    @as_subprocess
     def child(use_stream, timeout, expected_cs_range):
         stream = StringIO() if use_stream else None
         term = TestTerminal(stream=stream)
@@ -218,11 +212,11 @@ def test_keystroke_cbreak_with_input_slowly():
     def parent(master_fd):
         os.write(master_fd, SEND_SEMAPHORE)
         os.write(master_fd, b'a')
-        time.sleep(0.1)
+        time.sleep(0.05)
         os.write(master_fd, b'b')
         time.sleep(0.1)
         os.write(master_fd, b'cdefgh')
-        time.sleep(0.1)
+        time.sleep(0.05)
         os.write(master_fd, b'X')
         read_until_semaphore(master_fd)
 
@@ -309,7 +303,6 @@ def test_keystroke_0s_cbreak_sequence():
     assert math.floor(time.time() - stime) == 0.0
 
 
-@pytest.mark.skipif(TEST_QUICK, reason="TEST_QUICK specified")
 def test_keystroke_20ms_cbreak_with_input():
     """1-second keystroke w/multibyte sequence; should return after ~1 second."""
     def child(term):
@@ -320,23 +313,22 @@ def test_keystroke_20ms_cbreak_with_input():
 
     def parent(master_fd):
         read_until_semaphore(master_fd)
-        time.sleep(0.2)
+        time.sleep(0.015)
         os.write(master_fd, '\x1b[C'.encode('ascii'))
 
     stime = time.time()
     output = pty_test(child, parent, 'test_keystroke_20ms_cbreak_with_input')
     assert output == 'KEY_RIGHT'
-    assert_elapsed_range_ms(stime, 19, 40)
+    assert_elapsed_range_ms(stime, 5, 25)
 
 
-@pytest.mark.skipif(TEST_QUICK, reason="TEST_QUICK specified")
-def test_esc_delay_cbreak_15ms():
-    r"""esc_delay=0.15 will cause a single ESC ('\x1b') to delay for 15ms"""
+def test_esc_delay_cbreak():
+    """esc_delay causes a single ESC ('\\x1b') to delay for the delay duration."""
     def child(term):
         os.write(sys.__stdout__.fileno(), SEMAPHORE)
         with term.cbreak():
             stime = time.time()
-            inp = term.inkey(timeout=1, esc_delay=0.15)
+            inp = term.inkey(timeout=1, esc_delay=TEST_TIMEOUT_SHORT)
             measured_time = (time.time() - stime) * 100
             return f'{inp.name} {measured_time:.0f}'.encode('ascii')
 
@@ -344,11 +336,11 @@ def test_esc_delay_cbreak_15ms():
         read_until_semaphore(master_fd)
         os.write(master_fd, '\x1b'.encode('ascii'))
 
-    output = pty_test(child, parent, 'test_esc_delay_cbreak_15ms')
+    output = pty_test(child, parent, 'test_esc_delay_cbreak')
     key_name, duration_ms = output.split()
 
     assert key_name == 'KEY_ESCAPE'
-    assert 14 <= int(duration_ms) <= 20, int(duration_ms)
+    assert_timeout_elapsed(float(duration_ms) / 100, TEST_TIMEOUT_SHORT)
 
 
 def test_esc_delay_cbreak_timout_0():
@@ -357,7 +349,7 @@ def test_esc_delay_cbreak_timout_0():
         os.write(sys.__stdout__.fileno(), SEMAPHORE)
         with term.cbreak():
             stime = time.time()
-            inp = term.inkey(timeout=0, esc_delay=0.15)
+            inp = term.inkey(timeout=0, esc_delay=TEST_TIMEOUT_SHORT)
             measured_time = (time.time() - stime) * 100
             return f'{inp.name} {measured_time:.0f}'.encode('ascii')
 
@@ -371,7 +363,7 @@ def test_esc_delay_cbreak_timout_0():
 
     assert key_name == 'KEY_ESCAPE'
     assert math.floor(time.time() - stime) == 0.0
-    assert 14 <= int(duration_ms) <= 25, int(duration_ms)
+    assert_timeout_elapsed(float(duration_ms) / 100, TEST_TIMEOUT_SHORT)
 
 
 def test_esc_delay_cbreak_nonprefix_sequence():
@@ -397,7 +389,6 @@ def test_esc_delay_cbreak_nonprefix_sequence():
     assert 0 <= int(duration_ms) <= 10, duration_ms
 
 
-@pytest.mark.skipif(TEST_QUICK, reason="TEST_QUICK specified")
 def test_flushinp_timeout_with_continuous_input():
     """flushinp() respects timeout even when keystrokes arrive continuously."""
     def child(term):
@@ -425,7 +416,6 @@ def test_flushinp_timeout_with_continuous_input():
 
 def test_get_location_0s():
     """0-second get_location call without response."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO())
         stime = time.time()
@@ -495,7 +485,6 @@ def test_get_location_0s_reply_via_ungetch_under_raw():
 
 def test_get_location_0s_reply_via_ungetch():
     """0-second get_location call with response."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
         stime = time.time()
@@ -513,7 +502,6 @@ def test_get_location_0s_nonstandard_u6():
     # local
     from blessed.formatters import ParameterizingString
 
-    @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
         stime = time.time()
@@ -530,7 +518,6 @@ def test_get_location_0s_nonstandard_u6():
 
 def test_get_location_styling_indifferent():
     """Ensure get_location() behavior is the same regardless of styling"""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
         term.ungetch('\x1b[10;10R')
@@ -546,7 +533,6 @@ def test_get_location_styling_indifferent():
 
 def test_get_location_timeout():
     """0-second get_location call with response."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO())
         stime = time.time()
@@ -567,7 +553,6 @@ def test_get_location_timeout():
 ])
 def test_detect_ambiguous_width(cpr1, cpr2, expected):
     """Test detect_ambiguous_width with various CPR responses."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
         term.ungetch(cpr1)
@@ -579,7 +564,6 @@ def test_detect_ambiguous_width(cpr1, cpr2, expected):
 
 def test_detect_ambiguous_width_not_a_tty():
     """Test detect_ambiguous_width returns fallback when not a TTY."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True)
         term._is_a_tty = False
@@ -604,7 +588,7 @@ def test_detect_ambiguous_width_second_timeout():
     def child(term):
         os.write(sys.__stdout__.fileno(), SEMAPHORE)
         with term.cbreak():
-            result = term.detect_ambiguous_width(timeout=0.1, fallback=77)
+            result = term.detect_ambiguous_width(timeout=TEST_TIMEOUT_SHORT, fallback=77)
             return f'RESULT={result}'.encode('ascii')
 
     def parent(master_fd):
@@ -619,7 +603,6 @@ def test_detect_ambiguous_width_second_timeout():
 
 def test_get_fgcolor_0s():
     """0-second get_fgcolor call without response."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO())
         stime = time.time()
@@ -632,7 +615,6 @@ def test_get_fgcolor_0s():
 @pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
 def test_get_fgcolor_0s_reply_via_ungetch(terminator):
     """0-second get_fgcolor call with BEL or ST terminated response."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
         stime = time.time()
@@ -647,7 +629,6 @@ def test_get_fgcolor_0s_reply_via_ungetch(terminator):
 @pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
 def test_get_fgcolor_requires_styling(terminator):
     """get_fgcolor returns (-1, -1, -1) when does_styling is False."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
         term.ungetch('\x1b]10;rgb:d2/b4/8c' + terminator)  # tan
@@ -663,7 +644,6 @@ def test_get_fgcolor_requires_styling(terminator):
 @pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
 def test_get_fgcolor_16bit_reply_via_ungetch(terminator):
     """get_fgcolor call with default 16-bit response."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
         term.ungetch('\x1b]10;rgb:a099/5277/2d44' + terminator)  # sienna-ish
@@ -674,7 +654,6 @@ def test_get_fgcolor_16bit_reply_via_ungetch(terminator):
 
 def test_get_bgcolor_0s():
     """0-second get_bgcolor call without response."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO())
         stime = time.time()
@@ -687,7 +666,6 @@ def test_get_bgcolor_0s():
 @pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
 def test_get_bgcolor_0s_reply_via_ungetch(terminator):
     """0-second get_bgcolor call with BEL or ST terminated response."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
         stime = time.time()
@@ -702,7 +680,6 @@ def test_get_bgcolor_0s_reply_via_ungetch(terminator):
 @pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
 def test_get_bgcolor_requires_styling(terminator):
     """get_bgcolor returns (-1, -1, -1) when does_styling is False."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
         term.ungetch('\x1b]11;rgb:ff/e4/c4' + terminator)  # bisque
@@ -718,7 +695,6 @@ def test_get_bgcolor_requires_styling(terminator):
 @pytest.mark.parametrize("terminator", ['\x07', '\x1b\\'])
 def test_get_bgcolor_16bit_reply_via_ungetch(terminator):
     """get_bgcolor call with default 16-bit response."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
         term.ungetch('\x1b]11;rgb:9988/3255/cc11' + terminator)  # darkorchid-ish
@@ -766,6 +742,32 @@ def test_cbreak_with_has_tty():
 
     output = pty_test(child, parent_func=None, test_name='test_cbreak_with_has_tty')
     assert 'CBREAK_OK' in output or 'RESTORED' in output
+
+
+@pytest.mark.skipif(not TEST_KEYBOARD or IS_WINDOWS, reason="Requires TTY")
+@pytest.mark.parametrize("mode", ['cbreak', 'raw'])
+def test_termios_mode_ignores_sigttou(mode):
+    """cbreak() and raw() set SIGTTOU to SIG_IGN while termios mode is active.
+
+    When a process in a background process group calls tcgetattr() or
+    tcsetattr() on its controlling terminal, the kernel sends SIGTTOU,
+    whose default action is to stop the process.  _enter_termios_mode
+    guards against this by temporarily ignoring SIGTTOU.
+    """
+    def child(term):
+        ctx = getattr(term, mode)()
+        before = signal.getsignal(signal.SIGTTOU)
+        with ctx:
+            inside = signal.getsignal(signal.SIGTTOU)
+            assert inside == signal.SIG_IGN, (
+                f'SIGTTOU not ignored inside {mode}: {inside}')
+        after = signal.getsignal(signal.SIGTTOU)
+        assert after == before, (
+            f'SIGTTOU not restored after {mode}: before={before} after={after}')
+        return b'SIGTTOU_OK'
+
+    output = pty_test(child, test_name=f'test_{mode}_ignores_sigttou')
+    assert 'SIGTTOU_OK' in output
 
 
 def test_inkey_with_csi_sequence_triggers_latin1_decoding():
@@ -816,11 +818,11 @@ def test_read_until_timeout_no_match():
         with term.cbreak():
             # This will test the timeout branch (963->965)
             stime = time.time()
-            match, _ = _read_until(term, r'\d+;\d+R', timeout=0.1)
+            match, _ = _read_until(term, r'\d+;\d+R', timeout=TEST_TIMEOUT_SHORT)
             elapsed = time.time() - stime
             # Verify timeout occurred
             assert match is None
-            assert 0.08 <= elapsed <= 0.15
+            assert_timeout_elapsed(elapsed, TEST_TIMEOUT_SHORT)
             return b'TIMEOUT'
 
     # Parent doesn't write any matching pattern - let it timeout
@@ -902,7 +904,9 @@ def test_read_until_max_buffer_size():
     term._line_buffered = False
     term._keyboard_fd = 0
 
-    chars = iter('x' * 70000)
+    # 9x7000 + 2536 = 65536 (not over max), then 1 more 'x' triggers overflow
+    chunks = (['x' * 7000] * 9) + ['x' * 2536, 'x']
+    chars = iter(chunks)
 
     def mock_inkey(timeout=None, esc_delay=None):
         try:
@@ -922,7 +926,7 @@ def test_esc_delay_while_loop_with_continued_input():
     def child(term):
         os.write(sys.__stdout__.fileno(), SEMAPHORE)
         with term.cbreak():
-            ks = term.inkey(timeout=1.0, esc_delay=0.2)
+            ks = term.inkey(timeout=1.0, esc_delay=TEST_TIMEOUT_SHORT)
             return ks.name.encode('ascii')
 
     def parent(master_fd):
@@ -941,7 +945,6 @@ def test_esc_delay_while_loop_with_continued_input():
     assert output == 'KEY_LEFT'
 
 
-@pytest.mark.skipif(TEST_QUICK, reason="TEST_QUICK specified")
 def test_esc_delay_long_sequence_prefix_slow_complete():
     """Long sequence sent slowly byte-by-byte should complete before esc_delay.
 
@@ -960,9 +963,9 @@ def test_esc_delay_long_sequence_prefix_slow_complete():
         os.write(sys.__stdout__.fileno(), SEMAPHORE)
         with term.cbreak():
             stime = time.time()
-            keystroke = term.inkey(timeout=6.0, esc_delay=esc_delay)
+            keystroke = term.inkey(timeout=1.0, esc_delay=esc_delay)
             duration_ms = (time.time() - stime) * 100
-            remaining = term.flushinp(timeout=0.15)
+            remaining = term.flushinp(timeout=0.05)
             result = f'{keystroke.name}|{keystroke.code}|{remaining!r}|{duration_ms:.0f}'
             return result.encode('ascii')
 
@@ -988,7 +991,6 @@ def test_esc_delay_long_sequence_prefix_slow_complete():
             int(100 * esc_delay * PCT_MAXWAIT_KEYSTROKE))
 
 
-@pytest.mark.skipif(TEST_QUICK, reason="TEST_QUICK specified")
 def test_esc_delay_incomplete_known_sequence():
     """Incomplete known sequence should timeout and be flushed.
 
@@ -1002,9 +1004,9 @@ def test_esc_delay_incomplete_known_sequence():
         os.write(sys.__stdout__.fileno(), SEMAPHORE)
         with term.cbreak():
             stime = time.time()
-            keystroke = term.inkey(timeout=5.0, esc_delay=esc_delay)
+            keystroke = term.inkey(timeout=1.0, esc_delay=esc_delay)
             duration_ms = (time.time() - stime) * 100
-            remaining = term.flushinp(0.15)
+            remaining = term.flushinp(0.05)
             result = f'{keystroke.name}|{remaining!r}|{duration_ms:.0f}'
             return result.encode('ascii')
 

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -2,7 +2,6 @@
 # std imports
 import io
 import os
-import platform
 import sys
 import tempfile
 import collections
@@ -10,23 +9,16 @@ from unittest import mock
 
 # 3rd party
 import pytest
+import jinxed
 
 # local
 from .conftest import IS_WINDOWS
 from .accessories import TestTerminal, as_subprocess
 
-# isort: off
-if platform.system() != 'Windows':
-    import tty  # pylint: disable=unused-import  # NOQA
-    import curses
-else:
-    import jinxed as curses
-
 
 @pytest.mark.skipif(IS_WINDOWS, reason="no tty module")
 def test_getch_raises_eoferror_on_eof():
     """getch() raises EOFError when keyboard fd is at EOF."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         read_fd, write_fd = os.pipe()
@@ -43,7 +35,6 @@ def test_getch_raises_eoferror_on_eof():
 @pytest.mark.skipif(IS_WINDOWS, reason="no tty module")
 def test_flushinp_handles_eof():
     """flushinp() returns buffered data when keyboard fd reaches EOF."""
-    @as_subprocess
     def child():
         import codecs
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
@@ -64,7 +55,6 @@ def test_flushinp_handles_eof():
 @pytest.mark.skipif(IS_WINDOWS, reason="no tty module")
 def test_getch_sets_eof_flag():
     """getch() sets _keyboard_eof flag on EOF."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         read_fd, write_fd = os.pipe()
@@ -83,7 +73,6 @@ def test_getch_sets_eof_flag():
 @pytest.mark.skipif(IS_WINDOWS, reason="no tty module")
 def test_kbhit_returns_false_after_eof():
     """kbhit() returns False once _keyboard_eof is set."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         read_fd, write_fd = os.pipe()
@@ -100,7 +89,6 @@ def test_kbhit_returns_false_after_eof():
 @pytest.mark.skipif(IS_WINDOWS, reason="no tty module")
 def test_inkey_raises_EOF():
     """inkey() returns empty Keystroke when keyboard fd is at EOF."""
-    @as_subprocess
     def child():
         import codecs
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
@@ -120,7 +108,6 @@ def test_inkey_raises_EOF():
 @pytest.mark.skipif(IS_WINDOWS, reason="no tty module")
 def test_break_input_no_kb():
     """cbreak() should not call tty.setcbreak() without keyboard."""
-    @as_subprocess
     def child():
         with tempfile.NamedTemporaryFile() as stream:
             term = TestTerminal(stream=stream)
@@ -134,7 +121,6 @@ def test_break_input_no_kb():
 @pytest.mark.skipif(IS_WINDOWS, reason="no tty module")
 def test_raw_input_no_kb():
     """raw should not call tty.setraw() without keyboard."""
-    @as_subprocess
     def child():
         with tempfile.NamedTemporaryFile() as stream:
             term = TestTerminal(stream=stream)
@@ -162,7 +148,6 @@ def test_stdout_notty_kb_is_None():
     """term._keyboard_fd should be None when os.isatty returns False for output."""
     # In this scenario, stream is sys.__stdout__, but os.isatty(1) is False
     # such as when piping output to less(1)
-    @as_subprocess
     def child():
         isatty = os.isatty
         with mock.patch('os.isatty') as mock_isatty:
@@ -178,7 +163,6 @@ def test_stdout_notty_kb_is_None():
 
 def test_stdin_fileno_is_None():
     """term._keyboard_fd should be None when stdin.fileno() raises an exception."""
-    @as_subprocess
     def child():
         with mock.patch.object(sys.__stdin__, 'fileno') as mock_fileno:
             mock_fileno.side_effect = ValueError('fileno is not implemented on this stream')
@@ -194,7 +178,6 @@ def test_stdin_as_bytesio_is_None():
     """term._keyboard_fd should be None when sys.__stdin__.fileno() raises exception."""
     # In this scenario, stream is sys.__stdout__, but sys.__stdin__ is BytesIO
     # This may happen in a test scenario or when the program is wrapped in another interface
-    @as_subprocess
     def child():
         with mock.patch('sys.__stdin__', new=io.BytesIO()):
             term = TestTerminal()
@@ -209,7 +192,6 @@ def test_stdin_notty_kb_is_None():
     """term._keyboard_fd should be None when os.isatty returns False for input."""
     # In this scenario, stream is sys.__stdout__, but os.isatty(0) is False,
     # such as when piping from another program
-    @as_subprocess
     def child():
         isatty = os.isatty
         with mock.patch('os.isatty') as mock_isatty:
@@ -252,7 +234,7 @@ def test_a_keystroke():
 
 
 def test_get_keyboard_codes():
-    """Test all values returned by get_keyboard_codes are from curses."""
+    """Test all values returned by get_keyboard_codes are from curses(jinxed)."""
     import blessed.keyboard
     exemptions = dict(blessed.keyboard.CURSES_KEYCODE_OVERRIDE_MIXIN)
     # Add PUA overrides to exemptions since they intentionally override curses keys
@@ -293,55 +275,16 @@ def test_get_keyboard_codes():
             assert value == exemptions[keycode]
             continue
         if keycode[4:] in homemade_keycodes:
-            assert not hasattr(curses, keycode)
+            assert not hasattr(jinxed, keycode)
             assert hasattr(blessed.keyboard, keycode)
             assert getattr(blessed.keyboard, keycode) == value
         else:
-            assert hasattr(curses, keycode)
-            assert getattr(curses, keycode) == value
-
-
-def test_alternative_left_right():
-    """Test _alternative_left_right behavior for space/backspace."""
-    from blessed.keyboard import _alternative_left_right
-    term = mock.Mock()
-    term._cuf1 = ''
-    term._cub1 = ''
-    assert not bool(_alternative_left_right(term))
-    term._cuf1 = ' '
-    term._cub1 = '\b'
-    assert not bool(_alternative_left_right(term))
-    term._cuf1 = 'seq-right'
-    term._cub1 = 'seq-left'
-    assert (_alternative_left_right(term) == {
-        'seq-right': curses.KEY_RIGHT,
-        'seq-left': curses.KEY_LEFT})
-
-
-def test_cuf1_and_cub1_as_RIGHT_LEFT(all_terms):
-    """Test that cuf1 and cub1 are assigned KEY_RIGHT and KEY_LEFT."""
-    from blessed.keyboard import get_keyboard_sequences
-
-    @as_subprocess
-    def child(kind):
-        term = TestTerminal(kind=kind, force_styling=True)
-        keymap = get_keyboard_sequences(term)
-        if term._cuf1:
-            assert term._cuf1 in keymap
-            assert keymap[term._cuf1] == term.KEY_RIGHT
-        if term._cub1:
-            assert term._cub1 in keymap
-            if term._cub1 == '\b':
-                assert keymap[term._cub1] == term.KEY_BACKSPACE
-            else:
-                assert keymap[term._cub1] == term.KEY_LEFT
-
-    child(all_terms)
+            assert hasattr(jinxed, keycode)
+            assert getattr(jinxed, keycode) == value
 
 
 def test_get_keyboard_sequences_sort_order():
     """ordereddict ensures sequences are ordered longest-first."""
-    @as_subprocess
     def child(kind):
         term = TestTerminal(kind=kind, force_styling=True)
         maxlen = None
@@ -360,17 +303,16 @@ def test_get_keyboard_sequence(monkeypatch):
 
     (KEY_SMALL, KEY_LARGE, KEY_MIXIN) = range(3)
     (CAP_SMALL, CAP_LARGE) = 'cap-small cap-large'.split()
-    (SEQ_SMALL, SEQ_LARGE, SEQ_MIXIN, SEQ_ALT_CUF1, SEQ_ALT_CUB1) = (
+    (SEQ_SMALL, SEQ_LARGE, SEQ_MIXIN) = (
         b'seq-small-a',
         b'seq-large-abcdefg',
-        b'seq-mixin',
-        b'seq-alt-cuf1',
-        b'seq-alt-cub1_')
+        b'seq-mixin')
 
-    # patch curses functions
-    monkeypatch.setattr(curses, 'tigetstr',
-                        lambda cap: {CAP_SMALL: SEQ_SMALL,
-                                     CAP_LARGE: SEQ_LARGE}[cap])
+    # patch jinxed functions
+    def tigetstr_func(cap):
+        return {CAP_SMALL: SEQ_SMALL, CAP_LARGE: SEQ_LARGE}[cap]
+
+    monkeypatch.setattr(jinxed, 'tigetstr', tigetstr_func)
 
     monkeypatch.setattr(blessed.keyboard, 'capability_names',
                         dict(((KEY_SMALL, CAP_SMALL,),
@@ -381,16 +323,15 @@ def test_get_keyboard_sequence(monkeypatch):
                         'DEFAULT_SEQUENCE_MIXIN', (
                             (SEQ_MIXIN.decode('latin1'), KEY_MIXIN),))
 
-    # patch for _alternative_left_right
     term = mock.Mock()
-    term._cuf1 = SEQ_ALT_CUF1.decode('latin1')
-    term._cub1 = SEQ_ALT_CUB1.decode('latin1')
+    term.does_styling = True
+    jinxed_mock = mock.Mock()
+    jinxed_mock.tigetstr = tigetstr_func
+    term._jinxed_term = jinxed_mock
     keymap = blessed.keyboard.get_keyboard_sequences(term)
 
     assert list(keymap.items()) == [
         (SEQ_LARGE.decode('latin1'), KEY_LARGE),
-        (SEQ_ALT_CUB1.decode('latin1'), curses.KEY_LEFT),
-        (SEQ_ALT_CUF1.decode('latin1'), curses.KEY_RIGHT),
         (SEQ_SMALL.decode('latin1'), KEY_SMALL),
         (SEQ_MIXIN.decode('latin1'), KEY_MIXIN)]
 
@@ -540,7 +481,6 @@ def test_keypad_mixins_and_aliases():
     # End     ^[[F    ^[OF    ^[[1;mF
     # Home    ^[[H    ^[OH    ^[[1;mH
     # pylint: disable=too-many-statements
-    @as_subprocess
     def child(kind):
         term = TestTerminal(kind=kind, force_styling=True)
 
@@ -655,32 +595,31 @@ def test_keypad_mixins_and_aliases():
 @pytest.mark.skipif(IS_WINDOWS, reason="not applicable")
 def test_kp_begin_center_key():
     """Test KP_BEGIN/center key (numpad 5) with modifiers and event types."""
-    @as_subprocess
     def child(kind):
         term = TestTerminal(kind=kind, force_styling=True)
 
         term.ungetch('\x1b[E')
         ks = term.inkey(timeout=0)
         assert ks and str(ks) == '\x1b[E'
-        assert ks.code == curses.KEY_B2
+        assert ks.code == jinxed.KEY_B2
         assert ks.name == 'KEY_CENTER'
 
         term.ungetch('\x1b[1;5E')
         ks = term.inkey(timeout=0)
         assert ks and str(ks) == '\x1b[1;5E'
-        assert ks.code == curses.KEY_B2
+        assert ks.code == jinxed.KEY_B2
         assert ks.name == 'KEY_CTRL_CENTER'
 
         term.ungetch('\x1b[1;3E')
         ks = term.inkey(timeout=0)
         assert ks and str(ks) == '\x1b[1;3E'
-        assert ks.code == curses.KEY_B2
+        assert ks.code == jinxed.KEY_B2
         assert ks.name == 'KEY_ALT_CENTER'
 
         term.ungetch('\x1b[1;7E')
         ks = term.inkey(timeout=0)
         assert ks and str(ks) == '\x1b[1;7E'
-        assert ks.code == curses.KEY_B2
+        assert ks.code == jinxed.KEY_B2
         assert ks.name == 'KEY_CTRL_ALT_CENTER'
 
     child('xterm')
@@ -731,7 +670,6 @@ def test_unsupported_high_byte_metasendsescape():
 
 def test_is_incomplete_keystroke():
     """Test _is_incomplete_keystroke private method."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
 
@@ -754,5 +692,4 @@ def test_is_incomplete_keystroke():
         assert not term._is_incomplete_keystroke('')
         assert not term._is_incomplete_keystroke('x')
         assert not term._is_incomplete_keystroke('xyz')
-
     child()

--- a/tests/test_kitty_protocol.py
+++ b/tests/test_kitty_protocol.py
@@ -13,7 +13,7 @@ from blessed.keyboard import (
     _match_kitty_key, KittyKeyEvent, Keystroke, KittyKeyboardProtocol, resolve_sequence,
     _match_legacy_csi_letter_form,
 )
-from tests.accessories import (as_subprocess, SEMAPHORE, TestTerminal,
+from tests.accessories import (SEMAPHORE, TestTerminal,
                                read_until_semaphore, pty_test)
 from tests.conftest import IS_WINDOWS, TEST_KEYBOARD
 
@@ -108,7 +108,6 @@ def test_kitty_sequence_properties():
 
 def test_terminal_inkey_kitty_protocol():
     """Test Terminal.inkey() with Kitty protocol sequences."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = Terminal(stream=stream, force_styling=True)
@@ -300,7 +299,6 @@ def test_enable_kitty_keyboard_pty_success():
 
 def test_kitty_state_0s_reply_via_ungetch():
     """0-second get_kitty_keyboard_state call with response via ungetch."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._is_a_tty = True  # Force TTY behavior for testing
@@ -321,7 +319,6 @@ def test_kitty_state_0s_reply_via_ungetch():
 
 def test_kitty_state_styling_indifferent():
     """Test get_kitty_keyboard_state with styling enabled and disabled."""
-    @as_subprocess
     def child():
         # Test with styling enabled
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
@@ -354,7 +351,6 @@ def test_kitty_state_styling_indifferent():
 
 def test_kitty_state_timeout_handling():
     """Test get_kitty_keyboard_state timeout and sticky failure behavior."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._is_a_tty = True  # Force TTY behavior for testing
@@ -379,7 +375,6 @@ def test_kitty_state_timeout_handling():
 
 def test_kitty_state_excludes_response_from_buffer():
     """Test get_kitty_keyboard_state buffer management."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._is_a_tty = True  # Force TTY behavior for testing
@@ -404,7 +399,6 @@ def test_kitty_state_excludes_response_from_buffer():
 ])
 def test_get_kitty_keyboard_state_no_tty_or_disabled(force_styling, expected_sticky_flag):
     """Test get_kitty_keyboard_state returns None when unsupported."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = Terminal(stream=stream, force_styling=force_styling)
@@ -443,7 +437,6 @@ def test_get_kitty_keyboard_state_no_tty_or_disabled(force_styling, expected_sti
 ])
 def test_enable_kitty_keyboard(force_styling, force, flags, mode, expected_output):
     """Test enable_kitty_keyboard with various flag combinations and conditions."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = Terminal(stream=stream, force_styling=force_styling)
@@ -456,7 +449,6 @@ def test_enable_kitty_keyboard(force_styling, force, flags, mode, expected_outpu
 
 def test_enable_kitty_keyboard_all_flag_operations():
     """Test all flag bit operations in enable_kitty_keyboard."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -481,7 +473,6 @@ def test_enable_kitty_keyboard_all_flag_operations():
 
 def test_enable_kitty_keyboard_sequence_emission():
     """Test sequence emission and flush in enable_kitty_keyboard."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -500,7 +491,6 @@ def test_enable_kitty_keyboard_sequence_emission():
 
 def test_enable_kitty_keyboard_restoration_with_previous_flags():
     """Test restoration logic when previous flags exist."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -518,7 +508,6 @@ def test_enable_kitty_keyboard_restoration_with_previous_flags():
 
 def test_enable_kitty_keyboard_sticky_failure():
     """Test enable_kitty_keyboard skips when first query failed."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -555,7 +544,6 @@ def test_kitty_keyboard_protocol_setters(flags, expected_value):
 
 def test_get_kitty_state_boundary_no_response():
     """Test CPR boundary approach when no response found."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -573,7 +561,6 @@ def test_get_kitty_state_boundary_no_response():
 
 def test_get_kitty_keyboard_state_boundary_approach():
     """Test CPR boundary approach for detecting Kitty keyboard support."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
 
@@ -736,7 +723,6 @@ def test_kitty_name_synthesis_custom_name():
 ])
 def test_kitty_letter_name_synthesis_integration(sequence, expected_name):
     """Test letter name synthesis with Terminal.inkey()."""
-    @as_subprocess
     def child():
         term = Terminal(force_styling=True)
         term.ungetch(sequence)
@@ -754,7 +740,6 @@ def test_kitty_letter_name_synthesis_integration(sequence, expected_name):
 ])
 def test_disambiguate_f1_f4_csi_sequences(sequence, expected_name):
     """Test F1-F4 recognition in disambiguate mode."""
-    @as_subprocess
     def child():
         term = Terminal(force_styling=True)
         mapper = term._keymap
@@ -777,7 +762,6 @@ def test_disambiguate_f1_f4_csi_sequences(sequence, expected_name):
 ])
 def test_disambiguate_f1_f4_via_inkey(sequence, expected_name):
     """Test F1-F4 disambiguate sequences with Terminal.inkey()."""
-    @as_subprocess
     def child():
         term = Terminal(stream=io.StringIO(), force_styling=True)
         term.ungetch(sequence)
@@ -790,7 +774,6 @@ def test_disambiguate_f1_f4_via_inkey(sequence, expected_name):
 
 def test_disambiguate_f1_f4_not_confused_with_alt():
     """Test F1-F4 not confused with ALT+[ sequences."""
-    @as_subprocess
     def child():
         term = Terminal(stream=io.StringIO(), force_styling=True)
 
@@ -1096,7 +1079,6 @@ def test_kitty_keypad_inkey_integration(
         # pylint: disable=too-many-positional-arguments
         sequence, expected_code, expected_name, ctrl, alt, released, repeated):
     """Test keypad integration with Terminal.inkey()."""
-    @as_subprocess
     def child():
         term = Terminal(stream=io.StringIO(), force_styling=True)
         term.ungetch(sequence)
@@ -1378,7 +1360,6 @@ def test_kitty_escape_key_integration(
         # pylint: disable=too-many-positional-arguments
         sequence, expected_name, expected_code, ctrl, alt, released, repeated):
     """Test ESC key sequences via Terminal.inkey() integration."""
-    @as_subprocess
     def child():
         term = Terminal(stream=io.StringIO(), force_styling=True)
         term.ungetch(sequence)
@@ -1405,7 +1386,6 @@ def test_kitty_escape_key_integration(
 ])
 def test_kitty_control_key_integration(sequence, expected_name, expected_code, expected_value, alt):
     """Test control key integration with Terminal.inkey()."""
-    @as_subprocess
     def child():
         term = Terminal(stream=io.StringIO(), force_styling=True)
         term.ungetch(sequence)
@@ -1420,7 +1400,6 @@ def test_kitty_control_key_integration(sequence, expected_name, expected_code, e
 @pytest.mark.skipif(not TEST_KEYBOARD, reason="TEST_KEYBOARD not specified")
 def test_kitty_negotiation_timing_cached_failure():
     """Test timing of cached failure returns immediately."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._is_a_tty = True
@@ -1445,7 +1424,6 @@ def test_kitty_negotiation_timing_cached_failure():
 @pytest.mark.skipif(not TEST_KEYBOARD, reason="TEST_KEYBOARD not specified")
 def test_kitty_negotiation_force_True_incurs_second_timeout():
     """Test timing of force=True incurs timeout again."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._is_a_tty = True
@@ -1542,7 +1520,6 @@ def test_kitty_keyboard_protocol_equality_with_other_types():
 ])
 def test_kitty_state_boundary_kitty_only_response(response, expected_flags):
     """Test boundary approach with kitty-only response (no DA1)."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._is_a_tty = True

--- a/tests/test_length_sequence.py
+++ b/tests/test_length_sequence.py
@@ -23,7 +23,6 @@ if platform.system() != 'Windows':
 
 def test_length_cjk():
     """Test length of East Asian characters"""
-    @as_subprocess
     def child():
         term = TestTerminal()
 
@@ -39,7 +38,6 @@ def test_length_cjk():
 
 def test_length_with_zwj():
     """Test that ZWJ sequences are measured correctly like wcswidth()."""
-    @as_subprocess
     def child():
         term = TestTerminal()
         # RGI_Emoji_ZWJ_Sequence  ; family: woman, woman, girl, boy
@@ -52,7 +50,6 @@ def test_length_with_zwj():
 
 def test_length_ansiart():
     """Test length of ANSI art"""
-    @as_subprocess
     def child(kind):
         term = TestTerminal(kind=kind)
         # this 'ansi' art contributed by xzip!impure for another project,
@@ -71,10 +68,9 @@ def test_length_ansiart():
     child(kind)
 
 
-def test_sequence_length(all_terms):
+def test_sequence_length(any_term):
     """Ensure T.length(string containing sequence) is correct."""
     # pylint: disable=too-complex,too-many-statements
-    @as_subprocess
     def child(kind):
         term = TestTerminal(kind=kind, force_styling=True)
 
@@ -319,12 +315,11 @@ def test_sequence_length(all_terms):
             *zip(plain_text, itertools.cycle(['\b_']))))
         assert term.length(text_wseqs) == len(plain_text)
 
-    child(all_terms)
+    child(any_term)
 
 
 def test_env_winsize():
     """Test height and width is appropriately queried in a pty."""
-    @as_subprocess
     def child():
         # set the pty's virtual window size
         os.environ['COLUMNS'] = '99'
@@ -370,9 +365,8 @@ def test_winsize(many_lines, many_columns):
     child(lines=many_lines, cols=many_columns)
 
 
-def test_Sequence_alignment_fixed_width(all_terms):
+def test_Sequence_alignment_fixed_width(any_term):
     """Test alignment methods with width provided"""
-    @as_subprocess
     def child(kind):
         term = TestTerminal(kind=kind)
         pony_msg = 'pony express, all aboard, choo, choo!'
@@ -391,11 +385,11 @@ def test_Sequence_alignment_fixed_width(all_terms):
         assert term.length(radjusted.strip()) == pony_len
         assert term.length(radjusted) == len(pony_msg.rjust(88))
 
-    child(kind=all_terms)
+    child(kind=any_term)
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="requires fcntl")
-def test_Sequence_alignment(all_terms):
+def test_Sequence_alignment(any_term):
     """Tests methods related to Sequence class, namely ljust, rjust, center."""
     @as_subprocess
     def child(kind, lines=25, cols=80):
@@ -421,12 +415,11 @@ def test_Sequence_alignment(all_terms):
         assert term.length(radjusted.strip()) == pony_len
         assert term.length(radjusted) == len(pony_msg.rjust(term.width))
 
-    child(kind=all_terms)
+    child(kind=any_term)
 
 
 def test_hyperlink_nostyling():
     """Test length our of hyperlink URL's."""
-    @as_subprocess
     def child():
         # given,
         term = TestTerminal(force_styling=None)
@@ -439,7 +432,6 @@ def test_hyperlink_nostyling():
 
 def test_basic_hyperlinks():
     """Test length our of hyperlink URL's."""
-    @as_subprocess
     def child():
         # given,
         term = TestTerminal()
@@ -462,7 +454,6 @@ def test_basic_hyperlinks():
 
 def test_hyperlink_with_id():
     """Test length our of hyperlink URL's with ID."""
-    @as_subprocess
     def child():
         # given,
         term = TestTerminal()
@@ -485,7 +476,6 @@ def test_hyperlink_with_id():
 
 def test_set_window_title_nostyling():
     """Test set_window_title returns empty when styling is disabled."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=None)
         result = term.set_window_title('hello')
@@ -496,7 +486,6 @@ def test_set_window_title_nostyling():
 
 def test_set_window_title_default():
     """Test set_window_title returns OSC 0 sequence."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         result = term.set_window_title('My Title')
@@ -512,7 +501,6 @@ def test_set_window_title_default():
 ])
 def test_set_window_title_modes(mode, expected_prefix):
     """Test set_window_title OSC mode parameter."""
-    @as_subprocess
     def child(mode=mode, expected_prefix=expected_prefix):
         term = TestTerminal(force_styling=True)
         result = term.set_window_title('test', mode=mode)
@@ -523,7 +511,6 @@ def test_set_window_title_modes(mode, expected_prefix):
 
 def test_set_window_title_sanitizes():
     """Test set_window_title strips ESC and BEL from title text."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         result = term.set_window_title('bad\x1b[31mtitle\x07end')
@@ -534,7 +521,6 @@ def test_set_window_title_sanitizes():
 
 def test_set_window_title_invalid_mode():
     """Test set_window_title rejects invalid mode values."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         try:
@@ -548,7 +534,6 @@ def test_set_window_title_invalid_mode():
 
 def test_window_title_context_manager():
     """Test title context manager writes push/pop sequences."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True, stream=StringIO())
         with term.window_title('My App'):
@@ -563,7 +548,6 @@ def test_window_title_context_manager():
 
 def test_window_title_context_manager_nostyling():
     """Test title context manager is a no-op without styling."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=None, stream=StringIO())
         with term.window_title('My App'):
@@ -574,9 +558,8 @@ def test_window_title_context_manager_nostyling():
     child()
 
 
-def test_sequence_is_movement_false(all_terms):
+def test_sequence_is_movement_false(any_term):
     """Test parser about sequences that do not move the cursor."""
-    @as_subprocess
     def child(kind):
         # local
         from blessed.sequences import measure_length
@@ -608,12 +591,11 @@ def test_sequence_is_movement_false(all_terms):
         assert (len(term.standout) == measure_length(term.standout, term)
                 ), (term.standout, term._wont_move)
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_termcap_will_move_false(all_terms):  # pylint: disable=too-complex
+def test_termcap_will_move_false(any_term):  # pylint: disable=too-complex
     """Test parser about sequences that do not move the cursor."""
-    @as_subprocess
     def child(kind):  # pylint: disable=too-many-branches
         # local
         from blessed.sequences import iter_parse
@@ -647,12 +629,11 @@ def test_termcap_will_move_false(all_terms):  # pylint: disable=too-complex
         if term.standout:
             assert not next(iter_parse(term, term.standout))[1].will_move
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_sequence_is_movement_true(all_terms):
+def test_sequence_is_movement_true(any_term):
     """Test parsers about sequences that move the cursor."""
-    @as_subprocess
     def child(kind):
         # local
         from blessed.sequences import measure_length
@@ -681,12 +662,11 @@ def test_sequence_is_movement_true(all_terms):
         assert not term.clear or (len(term.clear) ==
                                   measure_length(term.clear, term))
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_termcap_will_move_true(all_terms):
+def test_termcap_will_move_true(any_term):
     """Test parser about sequences that move the cursor."""
-    @as_subprocess
     def child(kind):
         # local
         from blessed.sequences import iter_parse
@@ -706,12 +686,11 @@ def test_termcap_will_move_true(all_terms):
         assert next(iter_parse(term, term.home))[1].will_move
         assert next(iter_parse(term, term.restore))[1].will_move
         assert next(iter_parse(term, term.clear))[1].will_move
-    child(all_terms)
+    child(any_term)
 
 
 def test_foreign_sequences():
     """Test parsers about sequences received from foreign sources."""
-    @as_subprocess
     def child(kind):
         # local
         from blessed.sequences import measure_length

--- a/tests/test_modifiers_keyboard.py
+++ b/tests/test_modifiers_keyboard.py
@@ -4,7 +4,7 @@ import platform
 
 import pytest
 
-from .accessories import (TestTerminal, as_subprocess, assert_modifiers,
+from .accessories import (TestTerminal, assert_modifiers,
                           assert_modifiers_value, assert_only_modifiers)
 from blessed.keyboard import Keystroke, LegacyCSIKeyEvent, ModifyOtherKeysEvent, resolve_sequence
 
@@ -82,7 +82,6 @@ def test_legacy_ctrl_alt_exact_matching():
 def test_keystroke_value_comprehensive(sequence, expected_value, needs_terminal):
     """Test keystroke.value property returns correct character for various sequences."""
     if needs_terminal:
-        @as_subprocess
         def child():
             term = TestTerminal(force_styling=True)
             term.ungetch(sequence)
@@ -203,7 +202,6 @@ def test_legacy_ctrl_alt_edge_cases(
 
 def test_terminal_inkey_legacy_ctrl_alt_integration():
     """Test terminal.inkey() correctly detects ctrl+alt modifier sequences."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
 
@@ -313,7 +311,6 @@ def test_keystroke_legacy_ctrl_alt_name_generation():
 def test_match_legacy_csi_modifiers_letter_form(
         sequence, final_char, expected_mod, expected_key_name):
     """Test legacy CSI modifier sequences with letter-form final characters."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         term.ungetch(sequence)
@@ -345,7 +342,6 @@ def test_match_legacy_csi_modifiers_letter_form(
 ])
 def test_match_legacy_csi_modifiers_tilde_form(sequence, key_num, expected_mod, expected_key_name):
     """Test legacy CSI modifier sequences with tilde-form final characters."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         term.ungetch(sequence)
@@ -367,7 +363,6 @@ def test_match_legacy_csi_modifiers_tilde_form(sequence, key_num, expected_mod, 
 
 def test_match_legacy_csi_modifiers_non_matching():
     """Test legacy CSI modifier sequences that don't match."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         resolve = functools.partial(resolve_sequence,
@@ -391,7 +386,6 @@ def test_match_legacy_csi_modifiers_non_matching():
 
 def test_legacy_csi_modifier_properties():
     """Test modifier properties set correctly for legacy CSI sequences."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
 
@@ -413,7 +407,6 @@ def test_legacy_csi_modifier_properties():
 
 def test_terminal_inkey_legacy_csi_modifiers():
     """Test terminal.inkey() correctly handles legacy CSI modifier sequences."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
 
@@ -446,7 +439,6 @@ def test_terminal_inkey_legacy_csi_modifiers():
 ])
 def test_match_modify_other_keys(sequence, expected_key, expected_modifiers):
     """Test ModifyOtherKeys protocol sequences are parsed correctly."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         term.ungetch(sequence)
@@ -464,7 +456,6 @@ def test_match_modify_other_keys(sequence, expected_key, expected_modifiers):
 
 def test_match_modify_other_keys_non_matching():
     """Test Modify OtherKeys sequences that don't match."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         resolve = functools.partial(resolve_sequence,
@@ -487,7 +478,6 @@ def test_match_modify_other_keys_non_matching():
 
 def test_terminal_inkey_modify_other_keys():
     """Test terminal.inkey() correctly handles ModifyOtherKeys sequences."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
 
@@ -590,7 +580,6 @@ def test_keystroke_properties_comprehensive(sequence, property_name, expected_va
 
 def test_keystroke_repr_with_name():
     """Test repr() shows name for sequences, string representation for text."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         term.ungetch('\x1b[A')
@@ -649,7 +638,6 @@ def test_alt_uppercase_sets_shift_modifier_and_name():
 
 def test_legacy_csi_modifiers_with_event_type_letter_form():
     """Test legacy CSI letter-form sequences with event type field."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
 
@@ -677,7 +665,6 @@ def test_legacy_csi_modifiers_with_event_type_letter_form():
 
 def test_legacy_csi_modifiers_with_event_type_tilde_form():
     """Test legacy CSI tilde-form sequences with event type field."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
 
@@ -705,7 +692,6 @@ def test_legacy_csi_modifiers_with_event_type_tilde_form():
 
 def test_terminal_inkey_legacy_csi_with_event_type():
     """Test terminal.inkey() parses event type from legacy CSI sequences."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
 
@@ -730,7 +716,6 @@ def test_terminal_inkey_legacy_csi_with_event_type():
 
 def test_legacy_csi_modifiers_event_type_edge_cases():
     """Test legacy CSI sequences with various event type values and invalid patterns."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
 
@@ -762,7 +747,6 @@ def test_legacy_csi_modifiers_event_type_edge_cases():
 
 def test_build_appkeys_predicate_with_char():
     """Test application key predicates with character argument."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         term.ungetch('\x1b[1;2A')
@@ -776,7 +760,6 @@ def test_build_appkeys_predicate_with_char():
 
 def test_build_appkeys_predicate_keycode_loop():
     """Test application key predicates with invalid key names raise AttributeError."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         term.ungetch('\x1b[1;2A')
@@ -795,7 +778,6 @@ def test_build_appkeys_predicate_keycode_loop():
 
 def test_match_legacy_csi_invalid_letter_final():
     """Test legacy CSI sequences with invalid letter final characters."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         resolve = functools.partial(resolve_sequence,
@@ -811,7 +793,6 @@ def test_match_legacy_csi_invalid_letter_final():
 
 def test_match_legacy_csi_invalid_tilde_number():
     """Test legacy CSI sequences with invalid tilde key numbers."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         resolve = functools.partial(resolve_sequence,
@@ -827,7 +808,6 @@ def test_match_legacy_csi_invalid_tilde_number():
 
 def test_match_ss3_fkey_modifier_zero():
     """Test SS3 F-key sequences with modifier zero are invalid."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         resolve = functools.partial(resolve_sequence,
@@ -843,7 +823,6 @@ def test_match_ss3_fkey_modifier_zero():
 
 def test_match_ss3_fkey_invalid_final():
     """Test SS3 F-key sequences with invalid final characters."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         resolve = functools.partial(resolve_sequence,
@@ -865,7 +844,6 @@ def test_match_ss3_fkey_invalid_final():
 ])
 def test_match_ss3_fkey_valid(sequence, expected_code, expected_mod):
     """Test SS3 F-key sequences with modifiers parse correctly."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         term.ungetch(sequence)
@@ -881,7 +859,6 @@ def test_match_ss3_fkey_valid(sequence, expected_code, expected_mod):
 
 def test_legacy_csi_e_center_key():
     """Test legacy CSI E (center/begin key) sequence with modifiers."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         term.ungetch('\x1b[1;5E')
@@ -910,7 +887,6 @@ def test_ctrl_code_symbols_all(sequence, expected_name):
 
 def test_match_legacy_csi_letter_keycode_none():
     """Test legacy CSI letter-form sequences that don't map to keycodes."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         resolve = functools.partial(resolve_sequence,
@@ -926,7 +902,6 @@ def test_match_legacy_csi_letter_keycode_none():
 
 def test_match_ss3_keycode_none():
     """Test SS3 sequences that don't map to keycodes."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         resolve = functools.partial(resolve_sequence,
@@ -942,7 +917,6 @@ def test_match_ss3_keycode_none():
 
 def test_legacy_csi_modifiers_keycode_none_both_forms():
     """Test legacy CSI sequences in both forms that don't map to keycodes."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         resolve = functools.partial(resolve_sequence,
@@ -962,7 +936,6 @@ def test_legacy_csi_modifiers_keycode_none_both_forms():
 
 def test_ss3_fkey_branches():
     """Test SS3 F-key sequence matching logic."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         resolve = functools.partial(resolve_sequence,
@@ -989,7 +962,6 @@ def test_alphanum_predicate_no_char_non_printable_return():
 
 def test_alphanum_predicate_no_char_application_key():
     """Test alphanumeric predicate without char argument for application keys."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
 
@@ -1065,7 +1037,6 @@ def test_pressed_property_default_return():
 
 def test_pressed_property_with_event_types():
     """Test pressed property returns correct value based on event_type."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
 
@@ -1097,7 +1068,6 @@ def test_getattr_property_getter():
 
 def test_get_modified_keycode_name_no_modifiers():
     """Test modified keycode name resolves for unmodified press events."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         term.ungetch('\x1b[1;1A')
@@ -1146,7 +1116,6 @@ def test_get_meta_escape_name_not_printable_edge_case():
 
 def test_build_appkeys_predicate_expected_code_none():
     """Test application key predicate when expected_code lookup fails."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         term.ungetch('\x1b[1;2A')
@@ -1159,7 +1128,6 @@ def test_build_appkeys_predicate_expected_code_none():
 
 def test_build_appkeys_predicate_code_mismatch():
     """Test application key predicate when keystroke code doesn't match expected."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         term.ungetch('\x1b[1;2A')
@@ -1179,7 +1147,6 @@ def test_alphanum_predicate_exact_matching_non_alpha():
 
 def test_alphanum_predicate_value_empty():
     """Test alphanumeric predicate when keystroke value is empty."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         term.ungetch('\x1b[A')
@@ -1198,7 +1165,6 @@ def test_alphanum_predicate_value_multi_char():
 
 def test_terminal_inkey_csi_sequence():
     """Test term.inkey() returns single CSI keystroke for unmatched sequences."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
 
@@ -1219,7 +1185,6 @@ def test_terminal_inkey_csi_sequence():
 
 def test_legacy_csi_modifiers_no_modifiers_integration():
     """Test legacy CSI sequence with modifier=1 (no actual modifiers)."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         term.ungetch('\x1b[1;1P')
@@ -1306,7 +1271,6 @@ def test_get_meta_escape_name_branch_coverage():
 
 def test_build_appkeys_predicate_modifier_validation():
     """Test application key predicate when modifiers don't match."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         term.ungetch('\x1b[1;2A')

--- a/tests/test_mouse.py
+++ b/tests/test_mouse.py
@@ -11,7 +11,7 @@ from blessed import Terminal
 from blessed.keyboard import Keystroke, _match_dec_event
 from blessed.mouse import MouseEvent, MouseSGREvent, MouseLegacyEvent
 from blessed.dec_modes import DecModeResponse
-from .accessories import TestTerminal, as_subprocess, make_enabled_dec_cache
+from .accessories import TestTerminal, make_enabled_dec_cache
 from .conftest import IS_WINDOWS
 
 
@@ -639,7 +639,6 @@ def test_mouse_legacy_encoding_systematic():
 ])
 def test_mouse_enabled_mode_selection(clicks, drag, motion, pixels, expected_modes):
     """Test mouse_enabled selects correct modes based on parameters."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -685,7 +684,6 @@ def test_mouse_enabled_no_styling():
 @pytest.mark.skipif(IS_WINDOWS, reason="Windows uses native console mouse API")
 def test_does_mouse_supported(clicks, drag, motion, pixels, expected_modes):
     """Test does_mouse returns True when all required modes are supported."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -708,7 +706,6 @@ def test_does_mouse_supported(clicks, drag, motion, pixels, expected_modes):
 @pytest.mark.skipif(IS_WINDOWS, reason="Windows uses native console mouse API")
 def test_does_mouse_unsupported():
     """Test does_mouse returns False when any mode is unsupported."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -741,7 +738,6 @@ def test_does_mouse_no_styling():
 @pytest.mark.skipif(IS_WINDOWS, reason="Windows uses native console mouse API")
 def test_does_mouse_default_parameters():
     """Test does_mouse with default parameters checks click tracking."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -761,7 +757,6 @@ def test_does_mouse_default_parameters():
 @pytest.mark.skipif(IS_WINDOWS, reason="Windows uses native console mouse API")
 def test_does_mouse_custom_timeout():
     """Test does_mouse respects custom timeout parameter."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -911,7 +906,6 @@ def test_mouse_sgr_pixels_precedence():
 ])
 def test_mouse_enabled_variations(kwargs, expected_modes):
     """Test mouse_enabled with various parameter combinations and precedence."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -933,7 +927,6 @@ def test_mouse_enabled_variations(kwargs, expected_modes):
 
 def test_does_mouse_default():
     """Test does_mouse with default parameters."""
-    @as_subprocess
     def child():
         stream = io.StringIO()
         term = TestTerminal(stream=stream, force_styling=True)
@@ -949,7 +942,6 @@ def test_does_mouse_default():
 
 def test_flushinp_with_unicode_followed_by_legacy_mouse():
     """Test flushinp() decodes legacy mouse sequences with high bytes after unicode text."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO())
         term._dec_mode_cache = make_enabled_dec_cache()
@@ -983,7 +975,6 @@ def test_flushinp_with_unicode_followed_by_legacy_mouse():
 
 def test_inkey_with_cjk_followed_by_legacy_mouse():
     """Test inkey() decodes legacy mouse sequences with high bytes after CJK characters."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO())
         term._dec_mode_cache = make_enabled_dec_cache()

--- a/tests/test_progress_bar.py
+++ b/tests/test_progress_bar.py
@@ -3,12 +3,11 @@
 import pytest
 
 # local
-from .accessories import TestTerminal, as_subprocess
+from .accessories import TestTerminal
 
 
 def test_progress_bar_normal():
     """Test progress_bar with state=1 returns OSC 9;4 set sequence."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         assert term.progress_bar(1, 42) == '\x1b]9;4;1;42\x07'
@@ -19,7 +18,6 @@ def test_progress_bar_normal():
 
 def test_progress_bar_states_no_value():
     """Test progress_bar for non-normal states returns correct sequence."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         assert term.progress_bar(0) == '\x1b]9;4;0;\x07'
@@ -35,7 +33,6 @@ def test_progress_bar_states_no_value():
 
 def test_progress_bar_nostyling():
     """Test progress_bar returns empty string when does_styling is False."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=None)
         assert term.progress_bar('normal', 50) == ''
@@ -46,7 +43,6 @@ def test_progress_bar_nostyling():
 @pytest.mark.parametrize("state", [5, 'unknown', -1])
 def test_progress_bar_invalid_state(state):
     """Test progress_bar raises ValueError for invalid state."""
-    @as_subprocess
     def child(state=state):
         term = TestTerminal(force_styling=True)
         with pytest.raises(ValueError):
@@ -64,7 +60,6 @@ def test_progress_bar_invalid_state(state):
 ])
 def test_progress_bar_invalid_value(state, value):
     """Test progress_bar raises ValueError for invalid or missing value."""
-    @as_subprocess
     def child(state=state, value=value):
         term = TestTerminal(force_styling=True)
         with pytest.raises(ValueError):

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -10,24 +10,16 @@ import pytest
 # local
 from .conftest import IS_WINDOWS
 from .accessories import (
-    MockTigetstr, TestTerminal, unicode_cap, unicode_parm, as_subprocess, pty_test)
-
-try:
-    # std imports
-    from unittest import mock
-except ImportError:
-    # 3rd party
-    import mock
+    TestTerminal, unicode_cap, unicode_parm, pty_test)
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="requires real tty")
 def test_capability():
     """Check that capability lookup works."""
-    @as_subprocess
     def child():
         # Also test that Terminal grabs a reasonable default stream.
-        t = TestTerminal()
-        sc = unicode_cap('sc')
+        t = TestTerminal(force_styling=True)
+        sc = unicode_cap('sc', t)
         assert t.save == sc
         assert t.save == sc  # Make sure caching doesn't screw it up.
 
@@ -36,7 +28,6 @@ def test_capability():
 
 def test_capability_without_tty():
     """Assert capability templates are '' when stream is not a tty."""
-    @as_subprocess
     def child():
         t = TestTerminal(stream=StringIO())
         assert t.save == ''
@@ -47,17 +38,15 @@ def test_capability_without_tty():
 
 def test_capability_with_forced_tty():
     """force styling should return sequences even for non-ttys."""
-    @as_subprocess
     def child():
         t = TestTerminal(stream=StringIO(), force_styling=True)
-        assert t.save == unicode_cap('sc')
+        assert t.save == unicode_cap('sc', t)
 
     child()
 
 
 def test_basic_url():
     """force styling should return sequences even for non-ttys."""
-    @as_subprocess
     def child():
         # given
         t = TestTerminal(stream=StringIO(), force_styling=True)
@@ -76,7 +65,6 @@ def test_basic_url():
 
 def test_url_with_id():
     """force styling should return sequences even for non-ttys."""
-    @as_subprocess
     def child():
         # given
         t = TestTerminal(stream=StringIO(), force_styling=True)
@@ -96,17 +84,15 @@ def test_url_with_id():
 
 def test_parametrization():
     """Test parameterizing a capability."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
-        assert term.cup(3, 4) == unicode_parm('cup', 3, 4)
+        assert term.cup(3, 4) == unicode_parm('cup', term, 3, 4)
 
     child()
 
 
 def test_height_and_width():
     """Assert that ``height_and_width()`` returns full integers."""
-    @as_subprocess
     def child():
         t = TestTerminal()  # kind shouldn't matter.
         assert isinstance(t.height, int)
@@ -117,33 +103,30 @@ def test_height_and_width():
 
 def test_stream_attr():
     """Make sure Terminal ``stream`` is stdout by default."""
-    @as_subprocess
     def child():
         assert TestTerminal().stream == sys.__stdout__
 
     child()
 
 
-def test_location_with_styling(all_terms):
+def test_location_with_styling(any_term):
     """Make sure ``location()`` works on all terminals."""
-    @as_subprocess
     def child_with_styling(kind):
         t = TestTerminal(kind=kind, stream=StringIO(), force_styling=True)
         with t.location(3, 4):
             t.stream.write('hi')
         expected_output = ''.join(
-            (unicode_cap('sc') or '\x1b[s',
-             unicode_parm('cup', 4, 3),
+            (unicode_cap('sc', t) or '\x1b[s',
+             unicode_parm('cup', t, 4, 3),
              'hi',
-             unicode_cap('rc') or '\x1b[u'))
+             unicode_cap('rc', t) or '\x1b[u'))
         assert t.stream.getvalue() == expected_output
 
-    child_with_styling(all_terms)
+    child_with_styling(any_term)
 
 
 def test_location_without_styling():
     """Make sure ``location()`` silently passes without styling."""
-    @as_subprocess
     def child_without_styling():
         """No side effect for location as a context manager without styling."""
         t = TestTerminal(stream=StringIO(), force_styling=None)
@@ -156,63 +139,60 @@ def test_location_without_styling():
     child_without_styling()
 
 
-def test_horizontal_location(all_terms):
+def test_horizontal_location(any_term):
     """Make sure we can move the cursor horizontally without changing rows."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(kind=kind, stream=StringIO(), force_styling=True)
         with t.location(x=5):
             pass
-        _hpa = unicode_parm('hpa', 5)
+        _hpa = unicode_parm('hpa', t, 5)
         if not _hpa and (kind.startswith('screen') or
                          kind.startswith('ansi')):
             _hpa = '\x1b[6G'
         expected_output = ''.join(
-            (unicode_cap('sc') or '\x1b[s',
+            (unicode_cap('sc', t) or '\x1b[s',
              _hpa,
-             unicode_cap('rc') or '\x1b[u'))
+             unicode_cap('rc', t) or '\x1b[u'))
         assert (t.stream.getvalue() == expected_output), (
             repr(t.stream.getvalue()), repr(expected_output))
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_vertical_location(all_terms):
+def test_vertical_location(any_term):
     """Make sure we can move the cursor vertically without changing columns."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(kind=kind, stream=StringIO(), force_styling=True)
         with t.location(y=5):
             pass
-        _vpa = unicode_parm('vpa', 5)
+        _vpa = unicode_parm('vpa', t, 5)
         if not _vpa and (kind.startswith('screen') or
                          kind.startswith('ansi')):
             _vpa = '\x1b[6d'
 
         expected_output = ''.join(
-            (unicode_cap('sc') or '\x1b[s',
+            (unicode_cap('sc', t) or '\x1b[s',
              _vpa,
-             unicode_cap('rc') or '\x1b[u'))
+             unicode_cap('rc', t) or '\x1b[u'))
         assert t.stream.getvalue() == expected_output
 
-    child(all_terms)
+    child(any_term)
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="requires multiprocess")
-def test_inject_move_x():
-    """Test injection of hpa attribute for screen/ansi (issue #55)."""
-    @as_subprocess
+def test_screen_ansi_hpa_from_jinxed():
+    """hpa for screen and ansi comes from jinxed terminfo directly."""
     def child(kind):
         t = TestTerminal(kind=kind, stream=StringIO(), force_styling=True)
         COL = 5
-        with mock.patch('curses.tigetstr', side_effect=MockTigetstr(hpa=None)):
-            with t.location(x=COL):
-                pass
-        expected_output = ''.join(
-            (unicode_cap('sc') or '\x1b[s', f'\x1b[{COL + 1}G', unicode_cap('rc') or '\x1b[u'),
-        )
+        with t.location(x=COL):
+            pass
+        expected_output = ''.join((
+            unicode_cap('sc', t) or '\x1b[s',
+            t.move_x(COL),
+            unicode_cap('rc', t) or '\x1b[u',
+        ))
         assert t.stream.getvalue() == expected_output
-        assert t.move_x(COL) == f'\x1b[{COL + 1}G'
 
     child('screen')
     child('screen-256color')
@@ -220,20 +200,19 @@ def test_inject_move_x():
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="requires multiprocess")
-def test_inject_move_y():
-    """Test injection of vpa attribute for screen/ansi (issue #55)."""
-    @as_subprocess
+def test_screen_ansi_vpa_from_jinxed():
+    """vpa for screen and ansi comes from jinxed terminfo directly."""
     def child(kind):
         t = TestTerminal(kind=kind, stream=StringIO(), force_styling=True)
         ROW = 5
-        with mock.patch('curses.tigetstr', side_effect=MockTigetstr(vpa=None)):
-            with t.location(y=ROW):
-                pass
-        expected_output = ''.join(
-            (unicode_cap('sc') or '\x1b[s', f'\x1b[{ROW + 1}d', unicode_cap('rc') or '\x1b[u')
-        )
+        with t.location(y=ROW):
+            pass
+        expected_output = ''.join((
+            unicode_cap('sc', t) or '\x1b[s',
+            t.move_y(ROW),
+            unicode_cap('rc', t) or '\x1b[u',
+        ))
         assert t.stream.getvalue() == expected_output
-        assert t.move_y(ROW) == f'\x1b[{ROW + 1}d'
 
     child('screen')
     child('screen-256color')
@@ -241,59 +220,61 @@ def test_inject_move_y():
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="requires multiprocess")
-def test_inject_civis_and_cnorm_for_ansi():
-    """Test injection of civis attribute for ansi."""
-    @as_subprocess
+def test_ansi_civis_cnorm_from_jinxed():
+    """civis and cnorm for ansi come from jinxed terminfo directly."""
     def child(kind):
         t = TestTerminal(kind=kind, stream=StringIO(), force_styling=True)
         with t.hidden_cursor():
             pass
-        expected_output = '\x1b[?25l\x1b[?25h'
+        expected_output = ''.join((
+            unicode_cap('civis', t),
+            unicode_cap('cnorm', t),
+        ))
         assert t.stream.getvalue() == expected_output
 
     child('ansi')
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="requires multiprocess")
-def test_inject_sc_and_rc_for_ansi():
-    """Test injection of sc and rc (save and restore cursor) for ansi."""
-    @as_subprocess
+def test_ansi_sc_rc_from_jinxed():
+    """sc and rc for ansi come from jinxed terminfo directly."""
     def child(kind):
         t = TestTerminal(kind=kind, stream=StringIO(), force_styling=True)
         with t.location():
             pass
-        expected_output = '\x1b[s\x1b[u'
+        expected_output = ''.join((
+            unicode_cap('sc', t),
+            unicode_cap('rc', t),
+        ))
         assert t.stream.getvalue() == expected_output
 
     child('ansi')
 
 
-def test_zero_location(all_terms):
+def test_zero_location(any_term):
     """Make sure ``location()`` pays attention to 0-valued args."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(kind=kind, stream=StringIO(), force_styling=True)
         with t.location(0, 0):
             pass
         expected_output = ''.join(
-            (unicode_cap('sc') or '\x1b[s',
-             unicode_parm('cup', 0, 0),
-             unicode_cap('rc') or '\x1b[u'))
+            (unicode_cap('sc', t) or '\x1b[s',
+             unicode_parm('cup', t, 0, 0),
+             unicode_cap('rc', t) or '\x1b[u'))
         assert t.stream.getvalue() == expected_output
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_mnemonic_colors(all_terms):
+def test_mnemonic_colors(any_term):
     """Make sure color shortcuts work."""
 
-    @as_subprocess
     def child(kind):
         def color(t, num):
-            return t.number_of_colors and unicode_parm('setaf', num) or ''
+            return t.number_of_colors and unicode_parm('setaf', t, num) or ''
 
         def on_color(t, num):
-            return t.number_of_colors and unicode_parm('setab', num) or ''
+            return t.number_of_colors and unicode_parm('setab', t, num) or ''
 
         # Avoid testing red, blue, yellow, and cyan, since they might someday
         # change depending on terminal type.
@@ -307,12 +288,11 @@ def test_mnemonic_colors(all_terms):
         assert t.on_bright_black == on_color(t, 8)
         assert t.on_bright_green == on_color(t, 10)
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_callable_numeric_colors(all_terms):
+def test_callable_numeric_colors(any_term):
     """``color(n)`` should return a formatting wrapper."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(kind=kind)
         if t.magenta:
@@ -340,33 +320,30 @@ def test_callable_numeric_colors(all_terms):
         else:
             assert t.on_color(6)('smoo') == 'smoo'
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_null_callable_numeric_colors(all_terms):
+def test_null_callable_numeric_colors(any_term):
     """``color(n)`` should be a no-op on null terminals."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(stream=StringIO(), kind=kind)
         assert t.color(5)('smoo') == 'smoo'
         assert t.on_color(6)('smoo') == 'smoo'
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_naked_color_cap(all_terms):
+def test_naked_color_cap(any_term):
     """``term.color`` should return a stringlike capability."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(kind=kind)
         assert f'{t.color}' == f'{t.setaf}'
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_formatting_functions(all_terms):
+def test_formatting_functions(any_term):
     """Test simple and compound formatting wrappers."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(kind=kind)
         # test simple sugar,
@@ -378,12 +355,11 @@ def test_formatting_functions(all_terms):
         expected_output = ''.join((t.underline, 'boö', t.normal)) if t.underline else 'boö'
         assert t.underline('boö') == expected_output
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_compound_formatting(all_terms):
+def test_compound_formatting(any_term):
     """Test simple and compound formatting wrappers."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(kind=kind)
         expected_output = (
@@ -398,12 +374,11 @@ def test_compound_formatting(all_terms):
         )
         assert t.on_bright_red_bold_bright_green_underline('meh') == expected_output
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_nested_formatting(all_terms):
+def test_nested_formatting(any_term):
     """Test complex nested compound formatting, wow!"""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(kind=kind)
 
@@ -427,10 +402,11 @@ def test_nested_formatting(all_terms):
             t.normal, t.green, ' off', t.normal))
         assert given == expected
 
+    child(any_term)
 
-def test_formatting_functions_without_tty(all_terms):
+
+def test_formatting_functions_without_tty(any_term):
     """Test crazy-ass formatting wrappers when there's no tty."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(kind=kind, stream=StringIO(), force_styling=False)
         assert t.bold('hi') == 'hi'
@@ -454,12 +430,11 @@ def test_formatting_functions_without_tty(all_terms):
         assert given == expected
         assert t.on_bright_red_bold_bright_green_underline('meh') == 'meh'
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_nice_formatting_errors(all_terms):
+def test_nice_formatting_errors(any_term):
     """Make sure you get nice hints if you misspell a formatting wrapper."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(kind=kind)
         try:
@@ -487,12 +462,11 @@ def test_nice_formatting_errors(all_terms):
             except TypeError as e:
                 assert 'Unknown terminal capability,' in e.args[0], e.args
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_null_callable_string(all_terms):
+def test_null_callable_string(any_term):
     """Make sure NullCallableString tolerates all kinds of args."""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(stream=StringIO(), kind=kind)
         assert t.clear == ''
@@ -502,17 +476,16 @@ def test_null_callable_string(all_terms):
         assert t.bold('', 'x', 'huh?') == 'xhuh?'
         assert t.clear('x') == 'x'
 
-    child(all_terms)
+    child(any_term)
 
 
 def test_padd():
     """Test Terminal.padd(seq)."""
-    @as_subprocess
     def child(kind):
         # local
-        from blessed import Terminal
+
         from blessed.sequences import Sequence
-        term = Terminal(kind)
+        term = TestTerminal(kind=kind)
         assert Sequence('xyz\b', term).padd() == 'xy'
         assert Sequence('xyz\b-', term).padd() == 'xy-'
         assert Sequence('xxxx\x1b[3Dzz', term).padd() == 'xzz'
@@ -522,13 +495,12 @@ def test_padd():
     child(kind)
 
 
-def test_split_seqs(all_terms):
+def test_split_seqs(any_term):
     """Test Terminal.split_seqs."""
-    @as_subprocess
     def child(kind):
         # local
-        from blessed import Terminal
-        term = Terminal(kind)
+
+        term = TestTerminal(kind=kind)
 
         if term.sc and term.rc:
             given_text = f'{term.sc}AB{term.rc}CD'
@@ -536,16 +508,15 @@ def test_split_seqs(all_terms):
             result = list(term.split_seqs(given_text))
             assert result == expected
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_split_seqs_maxsplit1(all_terms):
+def test_split_seqs_maxsplit1(any_term):
     """Test Terminal.split_seqs with maxsplit=1."""
-    @as_subprocess
     def child(kind):
         # local
-        from blessed import Terminal
-        term = Terminal(kind)
+
+        term = TestTerminal(kind=kind)
 
         if term.bold:
             given_text = f'{term.bold}bbq'
@@ -556,16 +527,15 @@ def test_split_seqs_maxsplit1(all_terms):
             # Another case where split matches exactly
             assert list(term.split_seqs(f'{term.bold}b', 1)) == [term.bold, 'b']
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_split_seqs_term_right(all_terms):
+def test_split_seqs_term_right(any_term):
     """Test Terminal.split_seqs with parameterized sequence"""
-    @as_subprocess
     def child(kind):
         # local
-        from blessed import Terminal
-        term = Terminal(kind)
+
+        term = TestTerminal(kind=kind)
 
         if term.move_up:
             given_text = f'XY{term.move_right}VK'
@@ -573,16 +543,15 @@ def test_split_seqs_term_right(all_terms):
             result = list(term.split_seqs(given_text))
             assert result == expected
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_split_seqs_maxsplit3_and_term_right(all_terms):
+def test_split_seqs_maxsplit3_and_term_right(any_term):
     """Test Terminal.split_seqs with parameterized sequence."""
-    @as_subprocess
     def child(kind):
         # local
-        from blessed import Terminal
-        term = Terminal(kind)
+
+        term = TestTerminal(kind=kind)
 
         if term.move_right(32):
             given_text = f'PQ{term.move_right(32)}RS'
@@ -596,24 +565,22 @@ def test_split_seqs_maxsplit3_and_term_right(all_terms):
             result = list(term.split_seqs(given_text))
             assert result == expected
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_invalid_params_for_horizontal_distance(all_terms):
+def test_invalid_params_for_horizontal_distance(any_term):
     """Raise error if text parametrized horizontal distance is invalid"""
-    @as_subprocess
     def child(kind):
         term = TestTerminal(stream=StringIO(), kind=kind, force_styling=True)
         with pytest.raises(ValueError) as e:
             term.caps['parm_left_cursor'].horizontal_distance('\x1b[C')
             assert e.value == "Invalid parameters for termccap parm_left_cursor: '\x1b[C'"
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_formatting_other_string(all_terms):
+def test_formatting_other_string(any_term):
     """FormattingOtherString output depends on how it's called"""
-    @as_subprocess
     def child(kind):
         t = TestTerminal(stream=StringIO(), kind=kind, force_styling=True)
 
@@ -633,16 +600,15 @@ def test_formatting_other_string(all_terms):
         assert t.move_down() == t.cud1
         assert t.move_down(2) == t.cud(2)
 
-    child(all_terms)
+    child(any_term)
 
 
 def test_termcap_match_optional():
     """When match_optional is given, numeric matches are optional"""
-    # local
-    from blessed.sequences import Termcap
-
-    @as_subprocess
     def child():
+        # local
+        from blessed.sequences import Termcap
+
         t = TestTerminal(force_styling=True)
         cap = Termcap.build('move_right', t.cuf, 'cuf', nparams=1,
                             match_grouped=True, match_optional=True)
@@ -662,13 +628,12 @@ def test_termcap_match_optional():
     child()
 
 
-def test_truncate(all_terms):
+def test_truncate(any_term):
     """Test terminal.truncate and make sure it agrees with terminal.length"""
-    @as_subprocess
     def child(kind):
         # local
-        from blessed import Terminal
-        term = Terminal(kind)
+
+        term = TestTerminal(kind=kind)
 
         test_string = (
             f'{term.red("Testing")} {term.yellow("makes")} {term.green("me")} '
@@ -685,31 +650,29 @@ def test_truncate(all_terms):
         assert term.length(trunc) == target_width
         assert term.strip_seqs(trunc) == "Testing makes me feel "
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_truncate_wide_end(all_terms):
+def test_truncate_wide_end(any_term):
     """Ensure that terminal.truncate has the correct behaviour for wide characters."""
-    @as_subprocess
     def child(kind):
         # local
-        from blessed import Terminal
-        term = Terminal(kind)
+
+        term = TestTerminal(kind=kind)
         # ABＣ where Ｃ is width 2 - truncating to 3 fills with space
         test_string = "AB\uff23"
         assert term.truncate(test_string, 3) == "AB "
         assert term.truncate(test_string, 4) == "AB\uff23"
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_truncate_wcwidth_clipping(all_terms):
+def test_truncate_wcwidth_clipping(any_term):
     """Ensure that terminal.truncate has the correct behaviour for control characters."""
-    @as_subprocess
     def child(kind):
         # local
-        from blessed import Terminal
-        term = Terminal(kind)
+
+        term = TestTerminal(kind=kind)
         assert term.truncate("", 4) == ""
         # Control character \x01 has zero width
         test_string = term.blue("one\x01two")
@@ -717,16 +680,15 @@ def test_truncate_wcwidth_clipping(all_terms):
         assert term.length(trunc) == 4
         assert term.strip_seqs(trunc) == "one\x01t"
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_truncate_padding(all_terms):
+def test_truncate_padding(any_term):
     """Ensure that terminal.truncate correctly handles cursor movement sequences."""
-    @as_subprocess
     def child(kind):
         # local
-        from blessed import Terminal
-        term = Terminal(kind)
+
+        term = TestTerminal(kind=kind)
 
         if term.move_right(5):
             test_right_string = term.blue(f"one{term.move_right(5)}two")
@@ -739,9 +701,9 @@ def test_truncate_padding(all_terms):
         assert term.length(trunc_bs) == 3
         assert term.strip_seqs(trunc_bs) == "two"
 
-    if all_terms != 'vtwin10':
+    if any_term != 'vtwin10':
         # padding doesn't work the same on windows !
-        child(all_terms)
+        child(any_term)
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="requires fcntl")
@@ -762,13 +724,12 @@ def test_truncate_default():
     pty_test(child, parent_func=None, test_name='test_truncate_default')
 
 
-def test_truncate_zwj_emoji(all_terms):
+def test_truncate_zwj_emoji(any_term):
     """Test truncate handles ZWJ emoji sequences."""
-    @as_subprocess
     def child(kind):
         # local
-        from blessed import Terminal
-        term = Terminal(kind)
+
+        term = TestTerminal(kind=kind)
 
         # Family emoji: 👨 + ZWJ + 👩 + ZWJ + 👧 (wcswidth=2)
         given_zwj = '\U0001F468\u200D\U0001F469\u200D\U0001F467'
@@ -783,16 +744,15 @@ def test_truncate_zwj_emoji(all_terms):
         # width 8: everything fits (2 + 6 = 8)
         assert term.truncate(given, 8) == given
 
-    child(all_terms)
+    child(any_term)
 
 
-def test_truncate_vs16_emoji(all_terms):
+def test_truncate_vs16_emoji(any_term):
     """Test truncate handles VS-16 emoji sequences."""
-    @as_subprocess
     def child(kind):
         # local
-        from blessed import Terminal
-        term = Terminal(kind)
+
+        term = TestTerminal(kind=kind)
 
         # Heart ❤ (U+2764) + VS-16 has width 2; truncating to 1 fills with space
         # since the grapheme cluster cannot be split
@@ -802,17 +762,15 @@ def test_truncate_vs16_emoji(all_terms):
         assert term.truncate('X\u2764\uFE0F', 2) == 'X '
         assert term.truncate('X\u2764\uFE0F', 3) == 'X\u2764\uFE0F'
 
-    child(all_terms)
+    child(any_term)
 
 
 @pytest.mark.skipif(sys.version_info[:2] < (3, 8), reason="Only supported on Python >= 3.8")
-def test_supports_index(all_terms):
+def test_supports_index(any_term):
     """Ensure sequence formatting methods support objects with __index__()"""
 
-    @as_subprocess
     def child(kind):
         # local
-        from blessed.terminal import Terminal
         from blessed.sequences import Sequence
 
         class Indexable:
@@ -821,7 +779,7 @@ def test_supports_index(all_terms):
             def __index__(self):
                 return 100
 
-        term = Terminal(kind)
+        term = TestTerminal(kind=kind)
         seq = Sequence('abcd', term)
         indexable = Indexable()
 
@@ -833,5 +791,10 @@ def test_supports_index(all_terms):
         seq = Sequence('abcd' * 30, term)
         assert seq.truncate(100) == seq.truncate(indexable)
 
-    kind = 'vtwin10' if IS_WINDOWS else 'xterm-256color'
-    child(kind)
+    child(any_term)
+
+
+def test_get_proxy_string_deprecated():
+    """get_proxy_string() returns None (deprecated, no warning emitted)."""
+    from blessed.formatters import get_proxy_string
+    assert get_proxy_string(None, 'any_cap') is None

--- a/tests/test_sixel.py
+++ b/tests/test_sixel.py
@@ -14,7 +14,6 @@ from .conftest import TEST_QUICK, IS_WINDOWS
 from .accessories import (
     SEMAPHORE,
     TestTerminal,
-    as_subprocess,
     read_until_semaphore,
     pty_test,
     PCT_MAXWAIT_KEYSTROKE,
@@ -76,7 +75,6 @@ def test_does_sixel_uses_cache():
 
 def test_does_sixel_not_a_tty():
     """Test does_sixel() returns False when not a TTY."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._is_a_tty = False
@@ -634,7 +632,6 @@ def test_window_cache_return_when_cell_query_fails():
 
 def test_preferred_size_cache_path():
     """Test get_sixel_height_and_width falls back to preferred_size_cache as last resort."""
-    @as_subprocess
     def child():
         from blessed.terminal import WINSZ
         term = TestTerminal()
@@ -775,7 +772,6 @@ def test_tiocswinsz_invalid_dimensions():
 
 def test_get_sixel_height_and_width_not_a_tty():
     """Test get_sixel_height_and_width returns (-1, -1) when not a TTY."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._is_a_tty = False

--- a/tests/test_software_version.py
+++ b/tests/test_software_version.py
@@ -27,7 +27,6 @@ from .conftest import TEST_KEYBOARD, IS_WINDOWS
 from .accessories import (
     TestTerminal,
     pty_test,
-    as_subprocess,
 )
 from blessed.keyboard import SoftwareVersion
 
@@ -204,7 +203,6 @@ def test_get_software_version_raw_stored():
 
 def test_get_software_version_not_a_tty():
     """Test get_software_version() returns None when not a TTY and no env vars."""
-    @as_subprocess
     def child():
         import io
         import os

--- a/tests/test_text_sizing.py
+++ b/tests/test_text_sizing.py
@@ -11,12 +11,12 @@ except ImportError:
     import mock
 
 # local
-from .accessories import TestTerminal, as_subprocess
+from .accessories import TestTerminal
 
 
 def test_string_vertical_align_top():
     """vertical_align='top' produces no v= key (default 0)."""
-    @as_subprocess
+
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         with mock.patch.object(term, 'does_text_sizing', return_value=True):
@@ -29,66 +29,67 @@ def test_string_vertical_align_top():
 
 def test_string_vertical_align_bottom():
     """vertical_align='bottom' produces v=1."""
-    @as_subprocess
+
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         with mock.patch.object(term, 'does_text_sizing', return_value=True):
-            result = term.text_sized('Hi', vertical_align='bottom')
+            result = term.text_sized('Hi', numerator=1, denominator=3, vertical_align='bottom')
             assert 'v=1' in result
     child()
 
 
 def test_string_vertical_align_center():
     """vertical_align='center' produces v=2."""
-    @as_subprocess
+
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         with mock.patch.object(term, 'does_text_sizing', return_value=True):
-            result = term.text_sized('Hi', vertical_align='center')
+            result = term.text_sized('Hi', numerator=1, denominator=3, vertical_align='center')
             assert 'v=2' in result
     child()
 
 
 def test_string_horizontal_align_left():
     """horizontal_align='left' produces no h= key (default 0)."""
-    @as_subprocess
+
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         with mock.patch.object(term, 'does_text_sizing', return_value=True):
-            result = term.text_sized('Hi', horizontal_align='left')
+            result = term.text_sized('Hi', numerator=1, denominator=3, horizontal_align='left')
             assert 'h=' not in result
     child()
 
 
 def test_string_horizontal_align_right():
     """horizontal_align='right' produces h=1."""
-    @as_subprocess
+
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         with mock.patch.object(term, 'does_text_sizing', return_value=True):
-            result = term.text_sized('Hi', horizontal_align='right')
+            result = term.text_sized('Hi', numerator=1, denominator=3, horizontal_align='right')
             assert 'h=1' in result
     child()
 
 
 def test_string_horizontal_align_center():
     """horizontal_align='center' produces h=2."""
-    @as_subprocess
+
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         with mock.patch.object(term, 'does_text_sizing', return_value=True):
-            result = term.text_sized('Hi', horizontal_align='center')
+            result = term.text_sized('Hi', numerator=1, denominator=3, horizontal_align='center')
             assert 'h=2' in result
     child()
 
 
 def test_int_align_still_works():
     """Integer alignment values still work as before."""
-    @as_subprocess
+
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         with mock.patch.object(term, 'does_text_sizing', return_value=True):
-            result = term.text_sized('Hi', vertical_align=2, horizontal_align=1)
+            result = term.text_sized('Hi', numerator=1, denominator=3,
+                                     vertical_align=2, horizontal_align=1)
             assert 'v=2' in result
             assert 'h=1' in result
     child()
@@ -96,7 +97,7 @@ def test_int_align_still_works():
 
 def test_string_vertical_align_default():
     """vertical_align='default' produces no v= key."""
-    @as_subprocess
+
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         with mock.patch.object(term, 'does_text_sizing', return_value=True):
@@ -107,13 +108,33 @@ def test_string_vertical_align_default():
 
 def test_string_horizontal_align_default():
     """horizontal_align='default' produces no h= key."""
-    @as_subprocess
+
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         with mock.patch.object(term, 'does_text_sizing', return_value=True):
             result = term.text_sized('Hi', horizontal_align='default')
             assert 'h=' not in result
     child()
+
+
+def test_alignment_clipped_without_fractional_scaling():
+    """Alignment parameters are excluded when no fractional scaling is active."""
+    term = TestTerminal(stream=io.StringIO(), force_styling=True)
+    with mock.patch.object(term, 'does_text_sizing', return_value=True):
+        # No fractional scaling: numerator=0
+        result = term.text_sized('Hi', numerator=0, denominator=3,
+                                 vertical_align=1, horizontal_align=2)
+        assert 'v=' not in result
+        assert 'h=' not in result
+        # n >= d: integer or upscale
+        result = term.text_sized('Hi', numerator=5, denominator=3,
+                                 vertical_align=1, horizontal_align=2)
+        assert 'v=' not in result
+        assert 'h=' not in result
+        # n=0, d=0: no fractional
+        result = term.text_sized('Hi', vertical_align=2, horizontal_align=1)
+        assert 'v=' not in result
+        assert 'h=' not in result
 
 
 @pytest.mark.parametrize('name,value', [
@@ -126,7 +147,7 @@ def test_string_horizontal_align_default():
 ])
 def test_invalid_string_align_raises_valueerror(name, value):
     """Invalid string alignment values raise ValueError."""
-    @as_subprocess
+
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         with mock.patch.object(term, 'does_text_sizing', return_value=True):
@@ -137,7 +158,7 @@ def test_invalid_string_align_raises_valueerror(name, value):
 
 def test_graceful_degradation_without_support():
     """text_sized returns plain text when does_text_sizing is False."""
-    @as_subprocess
+
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         with mock.patch.object(term, 'does_text_sizing', return_value=False):
@@ -148,7 +169,7 @@ def test_graceful_degradation_without_support():
 @pytest.mark.parametrize('value', [3, -1, 999])
 def test_vertical_align_int_out_of_range(value):
     """vertical_align int outside 0--2 raises ValueError."""
-    @as_subprocess
+
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         with mock.patch.object(term, 'does_text_sizing', return_value=True):
@@ -160,7 +181,7 @@ def test_vertical_align_int_out_of_range(value):
 @pytest.mark.parametrize('value', [3, -1, 999])
 def test_horizontal_align_int_out_of_range(value):
     """horizontal_align int outside 0--2 raises ValueError."""
-    @as_subprocess
+
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         with mock.patch.object(term, 'does_text_sizing', return_value=True):
@@ -171,7 +192,7 @@ def test_horizontal_align_int_out_of_range(value):
 
 def test_text_with_esc_raises_valueerror():
     """Text containing ESC raises ValueError."""
-    @as_subprocess
+
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         with mock.patch.object(term, 'does_text_sizing', return_value=True):
@@ -182,7 +203,7 @@ def test_text_with_esc_raises_valueerror():
 
 def test_text_exactly_4096_bytes():
     """Text at exactly 4096 UTF-8 bytes does not raise ValueError."""
-    @as_subprocess
+
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         with mock.patch.object(term, 'does_text_sizing', return_value=True):

--- a/tests/test_win_terminal.py
+++ b/tests/test_win_terminal.py
@@ -22,7 +22,7 @@ if IS_WINDOWS:
     )
     from blessed.dec_modes import DecPrivateMode
     from jinxed import win32
-    from .accessories import TestTerminal, as_subprocess
+    from .accessories import TestTerminal
 
 
 def _mock_mouse_event(x=0, y=0, button_state=0, event_flags=0,
@@ -152,7 +152,6 @@ def test_does_returns_false_without_styling(method):
 @pytest.mark.parametrize("method", ['does_mouse', 'does_inband_resize'])
 def test_does_returns_false_without_tty(method):
     """Test does_mouse/does_inband_resize return False without tty."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True,
                             is_a_tty=False)
@@ -163,7 +162,6 @@ def test_does_returns_false_without_tty(method):
 @pytest.mark.parametrize("method", ['does_mouse', 'does_inband_resize'])
 def test_does_returns_true_with_tty_and_styling(method):
     """Test does_mouse/does_inband_resize return True with tty and styling."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._is_a_tty = True
@@ -173,7 +171,6 @@ def test_does_returns_true_with_tty_and_styling(method):
 
 def test_getch_drains_event_buf():
     """Test getch returns buffered event characters first."""
-    @as_subprocess
     def child():
         seq = '\x1b[<0;1;1M'
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
@@ -184,7 +181,6 @@ def test_getch_drains_event_buf():
 
 def test_kbhit_returns_true_when_buf_has_data():
     """Test kbhit returns True when event buffer is populated."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._keyboard_fd = 0
@@ -195,7 +191,6 @@ def test_kbhit_returns_true_when_buf_has_data():
 
 def test_kbhit_returns_false_with_no_keyboard_fd():
     """Test kbhit returns False when keyboard fd is None."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._keyboard_fd = None
@@ -205,7 +200,6 @@ def test_kbhit_returns_false_with_no_keyboard_fd():
 
 def test_kbhit_timeout_zero_returns_false_on_empty():
     """Test kbhit returns False on empty buffer with zero timeout."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         with mock.patch.object(win32, 'ConsoleInput') as mock_ci:
@@ -219,7 +213,6 @@ def test_kbhit_timeout_zero_returns_false_on_empty():
 
 def test_drain_mouse_event_buffered():
     """Test drain converts mouse events to SGR sequences."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._native_mouse = True
@@ -236,7 +229,6 @@ def test_drain_mouse_event_buffered():
 
 def test_drain_resize_event_buffered():
     """Test drain converts resize events to DEC mode 2048 sequences."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._native_resize = True
@@ -254,7 +246,6 @@ def test_drain_resize_event_buffered():
 
 def test_drain_stops_at_key_down():
     """Test drain stops processing at key-down events."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._native_mouse = True
@@ -270,7 +261,6 @@ def test_drain_stops_at_key_down():
 
 def test_drain_consumes_non_key_down_events():
     """Test drain silently consumes key-up, focus, and menu events."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._native_mouse = True
@@ -289,7 +279,6 @@ def test_drain_consumes_non_key_down_events():
 
 def test_drain_multiple_mouse_events():
     """Test drain processes all pending mouse events eagerly."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._native_mouse = True
@@ -312,7 +301,6 @@ def test_drain_multiple_mouse_events():
 @pytest.mark.parametrize("flag", ['_native_mouse', '_native_resize'])
 def test_drain_ignores_events_when_flag_disabled(flag):
     """Test drain consumes but does not convert events when flag is off."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         setattr(term, flag, False)
@@ -330,7 +318,6 @@ def test_drain_ignores_events_when_flag_disabled(flag):
 
 def test_drain_tracks_button_state():
     """Test drain updates prev_button_state across consecutive events."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._native_mouse = True
@@ -364,7 +351,6 @@ _NATIVE_CTX_PARAMS = pytest.mark.parametrize(
 def test_native_fallback_sets_and_clears(
         ctx_method, probe_method, flag, dec_mode, enable_bit):
     """Test native fallback enables console mode and cleans up on exit."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._keyboard_fd = 0
@@ -394,7 +380,6 @@ def test_native_fallback_sets_and_clears(
 def test_native_fallback_no_keyboard_fd(
         ctx_method, probe_method, flag, dec_mode, enable_bit):
     """Test native fallback yields without action when keyboard fd is None."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._keyboard_fd = None
@@ -408,7 +393,6 @@ def test_native_fallback_no_keyboard_fd(
 
 def test_init_attributes():
     """Test Terminal.__init__ initializes native event attributes."""
-    @as_subprocess
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         assert isinstance(term._event_buf, collections.deque)

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -9,7 +9,7 @@ import pytest
 
 # local
 from .conftest import TEST_QUICK
-from .accessories import TestTerminal, as_subprocess
+from .accessories import TestTerminal
 
 TEXTWRAP_KEYWORD_COMBINATIONS = [
     {'break_long_words': False, 'drop_whitespace': False, 'subsequent_indent': ''},
@@ -39,7 +39,6 @@ def test_SequenceWrapper_invalid_width():
     """Test exception thrown from invalid width."""
     WIDTH = -3
 
-    @as_subprocess
     def child():
         term = TestTerminal()
         try:
@@ -56,7 +55,6 @@ def test_SequenceWrapper_invalid_width():
 @pytest.mark.parametrize("kwargs", TEXTWRAP_KEYWORD_COMBINATIONS)
 def test_SequenceWrapper(many_columns, kwargs):
     """Test that text wrapping matches internal extra options."""
-    @as_subprocess
     def child(width, pgraph, kwargs):
         # build a test paragraph, along with a very colorful version
         term = TestTerminal()
@@ -115,7 +113,6 @@ def test_SequenceWrapper(many_columns, kwargs):
 def test_multiline():
     """Test that text wrapping matches internal extra options."""
 
-    @as_subprocess
     def child():
         # build a test paragraph, along with a very colorful version
         term = TestTerminal()
@@ -138,7 +135,6 @@ def test_multiline():
 
 def test_east_asian_emojis_width_1():
     """Tests edge-case of east-asian and emoji characters split into single columns."""
-    @as_subprocess
     def child():
         term = TestTerminal()
         # by @grayjk from https://github.com/jquast/blessed/issues/273
@@ -169,7 +165,6 @@ def test_east_asian_emojis_width_1():
 
 def test_emojis_width_2_and_greater():
     """Tests emoji characters split into multiple columns."""
-    @as_subprocess
     def child():
         term = TestTerminal()
         given = '\U0001F469\U0001F467\U0001F466'  # woman, girl, boy
@@ -191,7 +186,6 @@ def test_emojis_width_2_and_greater():
 
 def test_greedy_join_with_cojoining():
     """Test that a word with trailing combining (café) wraps correctly."""
-    @as_subprocess
     def child():
         term = TestTerminal()
         given = 'cafe\u0301-latte'
@@ -211,7 +205,6 @@ def test_greedy_join_with_cojoining():
 def test_placeholder():
     """ENsure placeholder behavior matches stdlib"""
 
-    @as_subprocess
     def child():
         term = TestTerminal()
         text = 'The quick brown fox jumps over the lazy dog'
@@ -248,7 +241,6 @@ def test_placeholder():
 
 def test_break_on_hyphens_in_handle_long_word():
     """Test break_on_hyphens is respected in _handle_long_word()."""
-    @as_subprocess
     def child():
         term = TestTerminal()
 
@@ -268,7 +260,6 @@ def test_break_on_hyphens_in_handle_long_word():
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="break_on_hyphens behavior differs")
 def test_break_on_hyphens():
     """Test break_on_hyphens behavior matches stdlib for hyphenated words."""
-    @as_subprocess
     def child():
         term = TestTerminal()
         attributes = ('bright_red', 'on_bright_blue', 'underline')
@@ -320,7 +311,6 @@ def test_break_on_hyphens():
 
 def test_wrap_leading_sequence_preserved():
     """Leading escape sequence on first word should not be lost."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         # Color the first word - the leading sequence should be preserved
@@ -334,7 +324,6 @@ def test_wrap_leading_sequence_preserved():
 
 def test_wrap_color_preserved_across_boundary():
     """Regression test for #351: wrap drops color escape sequence."""
-    @as_subprocess
     def child():
         term = TestTerminal(force_styling=True)
         text = f"{term.blue('a' * 10)} {term.blue('b' * 10)}"
@@ -353,7 +342,6 @@ def test_wrap_color_preserved_across_boundary():
 ])
 def test_wrap_hyperlink_osc8(link):
     """Test wrap with OSC 8 hyperlinks using ST and BEL terminators."""
-    @as_subprocess
     def child(link):
         term = TestTerminal(force_styling=True)
         result = term.wrap(link, width=10)

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -9,7 +9,7 @@ import pytest
 from blessed._capabilities import Decrqss
 from blessed._capabilities import TermcapResponse, ITerm2Capabilities
 from .conftest import IS_WINDOWS
-from .accessories import TestTerminal, as_subprocess, pty_test
+from .accessories import TestTerminal, as_subprocess, pty_test, NO_XTGETTCAP_DATA
 
 
 class TestTermcapResponseParsing:
@@ -199,8 +199,7 @@ class TestGetXtgettcap:
             cached = TermcapResponse(supported=True,
                                      capabilities={'TN': 'old'})
             term._xtgettcap_cache = cached
-            term._xtgettcap_first_query_failed = True
-
+            term._is_a_tty = False
             result = term.get_xtgettcap(timeout=0.01, force=True)
             assert result is None
         child()
@@ -288,7 +287,7 @@ class TestStyledUnderlines:
             stream = io.StringIO()
             term = TestTerminal(stream=stream, force_styling=True)
             term._is_a_tty = True
-            term._xtgettcap_first_query_failed = True
+            term._xtgettcap_cache = TermcapResponse(supported=False)
             assert term.does_styled_underlines() is False
         child()
 
@@ -409,7 +408,8 @@ class TestKittyQuery:
             stream = io.StringIO()
             term = TestTerminal(stream=stream, force_styling=True)
             term._is_a_tty = True
-            term._kitty_query_supported = True
+            term._xtgettcap_cache = TermcapResponse(
+                supported=True, capabilities={'kitty-query-name': '1'})
             assert term.does_kitty_query() is True
         child()
 
@@ -420,7 +420,9 @@ class TestKittyQuery:
             stream = io.StringIO()
             term = TestTerminal(stream=stream, force_styling=True)
             term._is_a_tty = True
-            term._kitty_query_supported = True
+            term._xtgettcap_cache = TermcapResponse(
+                supported=True, capabilities={'kitty-query-name': '1'})
+            term._is_a_tty = False
             result = term.does_kitty_query(timeout=0.01, force=True)
             assert result is False
         child()
@@ -508,7 +510,8 @@ def test_get_xtgettcap_full_success():
         return b'OK'
 
     output = pty_test(child, parent_func=None,
-                      test_name='test_get_xtgettcap_full_success')
+                      test_name='test_get_xtgettcap_full_success',
+                      _xtgettcap_data=NO_XTGETTCAP_DATA)
     assert 'OK' in output
 
 
@@ -524,7 +527,8 @@ def test_get_xtgettcap_probe_failure():
         return b'OK'
 
     output = pty_test(child, parent_func=None,
-                      test_name='test_get_xtgettcap_probe_failure')
+                      test_name='test_get_xtgettcap_probe_failure',
+                      _xtgettcap_data=NO_XTGETTCAP_DATA)
     assert 'OK' in output
 
 
@@ -547,7 +551,8 @@ def test_get_xtgettcap_batch_with_remaining_input():
         return b'OK'
 
     output = pty_test(child, parent_func=None,
-                      test_name='test_get_xtgettcap_batch_with_remaining_input')
+                      test_name='test_get_xtgettcap_batch_with_remaining_input',
+                      _xtgettcap_data=NO_XTGETTCAP_DATA)
     assert 'OK' in output
 
 
@@ -566,7 +571,8 @@ def test_get_xtgettcap_batch_empty_flushinp():
         return b'OK'
 
     output = pty_test(child, parent_func=None,
-                      test_name='test_get_xtgettcap_batch_empty_flushinp')
+                      test_name='test_get_xtgettcap_batch_empty_flushinp',
+                      _xtgettcap_data=NO_XTGETTCAP_DATA)
     assert 'OK' in output
 
 
@@ -598,9 +604,10 @@ def test_does_osc52_clipboard_via_xtgettcap():
         # DA1 without extension 52, so DA1 path returns False
         da1_resp = '\x1b[?64;1;4c'
         da1_cpr = '\x1b[10;20R'
-        # XTGETTCAP probe + batch with Ms
+        # XTGETTCAP probe: "TN" capability
         probe_resp = f'\x1bP1+r{hex_tn}=787465726d\x1b\\'
         tcap_cpr = '\x1b[11;21R'
+        # batch query: "Ms" capability
         batch_resp = f'\x1bP1+r{hex_ms}={ms_val}\x1b\\'
         term.ungetch(da1_resp + da1_cpr + probe_resp + tcap_cpr + batch_resp)
         result = term.does_osc52_clipboard(timeout=1)
@@ -609,7 +616,8 @@ def test_does_osc52_clipboard_via_xtgettcap():
         return b'OK'
 
     output = pty_test(child, parent_func=None,
-                      test_name='test_does_osc52_clipboard_via_xtgettcap')
+                      test_name='test_does_osc52_clipboard_via_xtgettcap',
+                      _xtgettcap_data=NO_XTGETTCAP_DATA)
     assert 'OK' in output
 
 
@@ -782,21 +790,20 @@ def test_get_color_scheme_unsupported():
 
 @pytestmark_pty
 def test_does_kitty_query_supported():
-    """Kitty query extensions detected from DCS 1+r response."""
+    """Kitty query detected from DCS 1+r response."""
     def child(term):
         capname = 'kitty-query-name'
         hex_cap = TermcapResponse.hex_encode(capname)
-        hex_val = TermcapResponse.hex_encode('kitty')
-        resp = f'\x1bP1+r{hex_cap}={hex_val}\x1b\\'
+        resp = f'\x1bP1+r{hex_cap}=1\x1b\\'
         cpr = '\x1b[10;20R'
         term.ungetch(resp + cpr)
         result = term.does_kitty_query(timeout=1)
         assert result is True
-        assert term._kitty_query_supported is True
         return b'OK'
 
     output = pty_test(child, parent_func=None,
-                      test_name='test_does_kitty_query_supported')
+                      test_name='test_does_kitty_query_supported',
+                      _xtgettcap_data=NO_XTGETTCAP_DATA)
     assert 'OK' in output
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,10 +24,11 @@ passenv =
     TEST_QUICK
     TEST_KEYBOARD
     TEST_RAW
-# although we don't depend on any specific termcap, many tests casually call setupterm(),
-# so we must ensure the TERM *is* valid
 setenv =
-    TERM = xterm
+    TERM =
+    COLORTERM =
+    TERM_PROGRAM =
+    TERM_PROGRAM_VERSION =
     TEST_QUICK = {env:TEST_QUICK:1}
 deps =
     pytest
@@ -35,11 +36,12 @@ deps =
     pytest-xdist
     pytest-codspeed
 commands =
-    pytest {posargs:--strict-markers --verbose --durations=3} tests
+    pytest {posargs:tests --strict-markers --verbose --durations=50}
 
 [testenv:py314]
 setenv =
     TERM = xterm
+    COLORTERM =
     TEST_QUICK = {env:TEST_QUICK:0}
     TEST_KEYBOARD = {env:TEST_KEYBOARD:1}
 
@@ -139,15 +141,8 @@ disallow_untyped_defs = true
 enable_error_code = ignore-without-code
 disable_error_code = name-defined,operator,attr-defined,comparison-overlap,arg-type,no-any-return,has-type,return-value,call-overload,override
 
-[mypy-curses.has_key.*]
-ignore_missing_imports = True
-
 [mypy-jinxed.*]
 ignore_missing_imports = True
-
-[mypy-wcwidth.*]
-ignore_missing_imports = True
-
 
 [testenv:pydocstyle]
 deps =
@@ -170,7 +165,6 @@ commands =
 [testenv:pylint_tests]
 deps =
     {[testenv]deps}
-    jinxed
     pylint
 commands =
     # Disable test-specific checks here. Global disables are in pyproject.toml


### PR DESCRIPTION
Replace all 'curses' imports with jinxed throughout blessed.

- Remove _CUR_TERM singleton, add kind_fallback='xterm-256color'.
- Removes many 'as_subprocess' test guards, incree test time
- Refactor keyboard/formatters/win_terminal.
- Stub XTGETTCAP probe (completed in coming branch)
