### PR TITLE
Query XTGETTCAP on Terminal init

### DIFF
--- a/bin/scroller.py
+++ b/bin/scroller.py
@@ -67,18 +67,25 @@ _MESSAGE = (
 
 
 def _sized_char(ch, target, term, v_align=0, h_align=0):
-    """Return text-sizing sequence and display width for *ch* at *target* scale."""
+    """
+    Return text-sizing sequence and display width for *ch* at *target* scale.
+
+    Alignment parameters (*v_align*, *h_align*) are only applied when
+    fractional scaling is in effect (0 < n < d), per the Kitty text sizing
+    protocol: alignment describes how the fractionally-scaled render area
+    fits inside the full cell grid; it has no meaning for integer scaling.
+    """
     if not term.does_text_sizing().scale:
         return ch, wcswidth(ch)
     s, w, n, d = _scale_params(target)
     if s == 1 and n == 0:
         return ch, wcswidth(ch)
-    seq = term.text_sized(ch, scale=s, width=w,
-                          numerator=n, denominator=d,
-                          vertical_align=v_align,
-                          horizontal_align=h_align)
-    params = TextSizingParams(scale=s, width=w, numerator=n, denominator=d,
-                              vertical_align=v_align, horizontal_align=h_align)
+    is_fractional = n > 0 and n < d
+    params = TextSizingParams(
+        scale=s, width=w, numerator=n, denominator=d,
+        vertical_align=v_align if is_fractional else 0,
+        horizontal_align=h_align if is_fractional else 0)
+    seq = TextSizing(params, ch, '\x07').make_sequence()
     width = TextSizing(params, ch, '\x07').display_width()
     return seq, width
 

--- a/bin/text_sizing_protocol.py
+++ b/bin/text_sizing_protocol.py
@@ -39,20 +39,74 @@ def _params_for_target(target):
 
 def show_scale_range(term, lo, hi, steps):
     """Display a row of 'X' characters ranging from *lo* to *hi* in *steps*."""
-    label_top = []
-    label_bot = []
-    chars = []
+    targets_params = []
+    max_s = 1
     for i in range(steps + 1):
         target = lo + (hi - lo) * i / steps
         s, n, d = _params_for_target(target)
-        params = TextSizingParams(scale=s, numerator=n, denominator=d,
-                                  vertical_align=1)
+        if s > max_s:
+            max_s = s
+        targets_params.append((target, s, n, d))
+
+    chars = []
+    col_starts = []
+    col = 0
+    for i, (target, s, n, d) in enumerate(targets_params):
+        if i == 0 and n == 0 and d == 0 and s < max_s:
+            s = max_s
+            ratio = target / s
+            n, d = _nearest_fraction(round(ratio * 100), 100, FRACTIONS)
+            if n >= d:
+                n = d - 1
+            if n == 0:
+                n = 1
+        params = TextSizingParams(scale=s, numerator=n, denominator=d)
         chars.append(TextSizing(params, 'X', '\x07').make_sequence())
-        label_top.append(f'{target:.1f}'.center(s * 2))
-        label_bot.append(f's={s}'.center(s * 2))
-    print(''.join(chars))
-    print(''.join(label_top))
-    print(''.join(label_bot))
+        col_starts.append(col)
+        col += s
+
+    total_cols = col
+
+    pcts = {i: int(target * 100) for i, (target, _, _, _) in enumerate(targets_params)}
+    num_labels = 5
+    label_at = {}
+
+    for j in range(num_labels):
+        pct_target = lo * 100 + (hi - lo) * 100 * j / (num_labels - 1)
+        best = min(pcts, key=lambda i: abs(pcts[i] - pct_target))
+        label_text = f'{pcts[best]}%'
+        start_col = col_starts[best]
+        if j > 0:
+            overlaps = False
+            for prev_i, prev_text in label_at.items():
+                prev_start = col_starts[prev_i]
+                if prev_start + len(prev_text) > start_col:
+                    overlaps = True
+                    break
+            if overlaps:
+                continue
+        label_at[best] = label_text
+
+    lbl_top = [' '] * (total_cols + 5)
+    for i, text in sorted(label_at.items()):
+        start = col_starts[i]
+        for c, ch in enumerate(text):
+            pos = start + c
+            if pos < len(lbl_top) and lbl_top[pos] == ' ':
+                lbl_top[pos] = ch
+    lbl_bot = [' '] * (total_cols + 5)
+    for i, text in sorted(label_at.items()):
+        s_val = targets_params[i][1]
+        text_s = f's={s_val}'
+        start = col_starts[i]
+        for c, ch in enumerate(text_s):
+            pos = start + c
+            if pos < len(lbl_bot) and lbl_bot[pos] == ' ':
+                lbl_bot[pos] = ch
+
+    print(''.join(chars), end='\n' * max_s)
+    print(''.join(lbl_top).rstrip())
+    print(''.join(lbl_bot).rstrip())
     print()
 
 
@@ -108,30 +162,27 @@ def show_char_types(term):
     ]
     tl, tr, bl, br, hz, vt = '\u250c\u2510\u2514\u2518\u2500\u2502'
     gap = '    '
-    for _, _, width in types:
-        print(f'{tl}{hz * width}{tr}{gap}', end='')
-    print()
-    for _, ucs, width in types:
-        print(f'{vt}{term.text_sized(ucs, width=width)}{vt}{gap}', end='')
-    print()
-    for _, _, width in types:
-        print(f'{bl}{hz * width}{br}{gap}', end='')
-    print()
-    for label, _, width in types:
-        col_width = width + 2 + len(gap)
-        print(f'{label:<{col_width}}', end='')
+    widths = [w for _, _, w in types]
+    box_parts = [f'{tl}{hz * w}{tr}' for w in widths]
+    print(gap.join(box_parts))
+    mid_parts = [f'{vt}{term.text_sized(ucs, width=w)}{vt}' for _, ucs, w in types]
+    print(gap.join(mid_parts))
+    bot_parts = [f'{bl}{hz * w}{br}' for w in widths]
+    print(gap.join(bot_parts))
+    label_parts = [f'{label:<{w + 2}}' for label, _, w in types]
+    print(gap.join(label_parts))
     print()
 
 
 def show_fractional(term):
     fracs = sorted([(n, d) for d in range(2, 16) for n in range(1, d)
                     if n / d >= 0.25], key=lambda nd: nd[0] / nd[1])
-    budget = 43
+    budget = 42
     step = max(1, (len(fracs) + budget - 2) // (budget - 1))
     sampled = fracs[::step]
     sampled.append((0, 0))
     for n, d in sampled:
-        print(term.text_sized('X', width=1, numerator=n, denominator=d, vertical_align=1), end='')
+        print(term.text_sized('X', width=1, numerator=n, denominator=d, vertical_align=0), end='')
     print()
     pcts = {i: (int(n / d * 100) if d else 100) for i, (n, d) in enumerate(sampled)}
     label_at = {}
@@ -150,7 +201,7 @@ def show_fractional(term):
 def show_alignment(term):
     rows, cols, text = 3, 6, 'Hi'
     text_w = len(text)
-    gap = '  '
+    gap = '   '
     box_w = cols + 2
     gap_w = len(gap)
     common = dict(scale=rows, width=text_w, numerator=1, denominator=2)
@@ -162,9 +213,12 @@ def show_alignment(term):
          ['h=left', 'h=center', 'h=right'], 'v=top'),
     ]:
         boxes = [alignment_box(text, rows, cols, v, h) for v, h in params]
-        for line_parts in zip(*boxes):
-            print(gap.join(line_parts))
-        print(gap.join(f'{label:^{box_w}s}' for label in labels) + f'  ({fixed})')
+        for row_idx, line_parts in enumerate(zip(*boxes)):
+            line = gap.join(line_parts)
+            if row_idx == 3:
+                line += '    ' + fixed
+            print(line)
+        print(gap.join(f'{label:^{box_w}s}' for label in labels))
 
         end_y, _ = term.get_location()
         interior_y = end_y - rows - 3 + 1
@@ -208,10 +262,8 @@ def main():
     show_scale_factors(term)
     show_char_types(term)
     show_fractional(term)
-    print(term.bold('100% -- 200%:'))
-    show_scale_range(term, 1.0, 2.0, 10)
-    print(term.bold('200% -- 300%:'))
-    show_scale_range(term, 2.0, 3.0, 10)
+    show_scale_range(term, 1.0, 2.0, 20)
+    show_scale_range(term, 2.0, 3.0, 13)
     show_alignment(term)
     show_ljust_rjust_center(term, bool(result))
 

--- a/bin/xtgettcap_compare.py
+++ b/bin/xtgettcap_compare.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+"""Compare jinxed terminfo capabilities against XTGETTCAP responses."""
+import sys
+import os
+
+import jinxed
+from blessed import Terminal
+from blessed._capabilities import XTGETTCAP_CAPABILITIES
+
+FOCUS = frozenset({
+    # String caps
+    'sc', 'rc', 'cup', 'home', 'hpa', 'vpa',
+    'cub1', 'cuf1', 'cuu1', 'cud1', 'cub', 'cuf', 'cuu', 'cud',
+    'el', 'el1', 'ed', 'clear', 'smcup', 'rmcup', 'csr',
+    'civis', 'cnorm', 'cvvis',
+    'sgr0', 'bold', 'dim', 'blink', 'rev', 'smso', 'rmso',
+    'smul', 'rmul', 'sitm', 'ritm',
+    'setaf', 'setab', 'op', 'smkx', 'rmkx', 'smam', 'rmam',
+    'cr', 'bel', 'u6', 'u7', 'u8', 'u9',
+    # Numeric caps
+    'colors', 'cols', 'lines', 'it', 'pairs', 'RGB',
+    # Boolean caps
+    'am', 'bce', 'bw', 'ccc', 'da', 'db', 'eslok', 'hs',
+    'km', 'mir', 'msgr', 'npc', 'ul', 'xenl', 'xt',
+    # Extended (XTGETTCAP-only, no jinxed equivalent)
+    'Ms', 'Smulx', 'Setulc',
+})
+
+# Classify caps using jinxed's built-in type lists.
+# RGB is not a standard terminfo cap so jinxed doesn't know about it.
+_JINXED_BOOL = frozenset(jinxed.terminfo.BOOL_CAPS)
+_JINXED_NUM = frozenset(jinxed.terminfo.NUM_CAPS) | {'RGB'}
+
+
+def decode_cap(value: str) -> str:
+    """Display-formatted capability value with visible control characters."""
+    result = []
+    for ch in value:
+        if ch == '\x1b':
+            result.append('\\E')
+        elif ch == '\r':
+            result.append('\\r')
+        elif ch == '\n':
+            result.append('\\n')
+        elif ch == '\t':
+            result.append('\\t')
+        elif '\x00' <= ch < ' ':
+            result.append(f'^{chr(ord(ch) + 64)}')
+        elif ch == '\x7f':
+            result.append('^?')
+        else:
+            result.append(ch)
+    return ''.join(result)
+
+
+def parse_numeric(value):
+    """Parse a numeric capability, handling r/g/b format."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return int(value.split('/')[0])
+    except (ValueError, IndexError):
+        pass
+    return None
+
+
+def main():
+    """Compare jinxed terminfo against XTGETTCAP."""
+    print("=== XTGETTCAP Probe ===")
+    term = Terminal(force_styling=True)
+    result = term.get_xtgettcap(timeout=2)
+
+    if result is None:
+        print("XTGETTCAP query returned None")
+        sys.exit(1)
+
+    print(f"Supported: {result.supported}")
+    print(f"Capabilities reported: {len(result.capabilities)}")
+
+    tn = result.capabilities.get('TN', '')
+    term_kind = tn if tn else os.environ.get('TERM', '')
+    print(
+        f"Terminal kind: {term_kind!r}"
+        + (" (from TN)" if tn else " (from $TERM)")
+    )
+
+    try:
+        jterm = jinxed.Terminal(term_kind)
+    except jinxed.error:
+        fallback = 'xterm-256color'
+        print(f"jinxed.Terminal({term_kind!r}) failed, using {fallback!r}")
+        jterm = jinxed.Terminal(fallback)
+        term_kind = fallback
+
+    print(f"jinxed terminal: {term_kind}")
+
+    caps_desc = dict(XTGETTCAP_CAPABILITIES)
+    show_all = '--all' in sys.argv
+
+    str_caps = [c for c in FOCUS if c not in _JINXED_BOOL and c not in _JINXED_NUM]
+    num_caps = [c for c in FOCUS if c in _JINXED_NUM]
+    bool_caps = [c for c in FOCUS if c in _JINXED_BOOL]
+
+    mismatches = 0
+    matches = 0
+
+    def print_section(title, capnames, compare_fn):
+        nonlocal mismatches, matches
+        print(f"\n=== {title} ===")
+        hdr = (
+            f"{'Cap':>6s}  {'XTGETTCAP':<30s}  {'jinxed':<30s}  "
+            f"{'Status':<15s}  Description"
+        )
+        print(hdr)
+        print("-" * len(hdr))
+        for capname in capnames:
+            xt_disp, jn_disp, status = compare_fn(capname)
+            if status == 'MISMATCH':
+                mismatches += 1
+            elif status == 'MATCH':
+                matches += 1
+            desc = caps_desc.get(capname, '')
+            if show_all or status != 'MATCH':
+                print(
+                    f"{capname:>6s}  {xt_disp:<30s}  {jn_disp:<30s}  "
+                    f"{status:<15s}  {desc}"
+                )
+
+    def compare_str(capname):
+        xt_raw = result.capabilities.get(capname)
+        xt_val = decode_cap(xt_raw) if xt_raw else None
+        jn_bytes = jterm.tigetstr(capname)
+        jn_val = decode_cap(jn_bytes.decode('latin-1')) if jn_bytes else None
+        if xt_val == jn_val:
+            status = 'MATCH'
+        elif jn_val is None and xt_val is not None:
+            status = 'XTGETTCAP ONLY'
+        else:
+            status = 'MISMATCH'
+        return (
+            repr(xt_val) if xt_val else '-',
+            repr(jn_val) if jn_val else '-',
+            status,
+        )
+
+    def compare_num(capname):
+        xt_val = parse_numeric(result.capabilities.get(capname))
+        jn_val = jterm.tigetnum(capname)
+        jn_val = jn_val if jn_val >= 0 else None
+        if str(xt_val) == str(jn_val):
+            status = 'MATCH'
+        elif jn_val is None and xt_val is not None:
+            status = 'XTGETTCAP ONLY'
+        else:
+            status = 'MISMATCH'
+        return (
+            str(xt_val) if xt_val is not None else '-',
+            str(jn_val) if jn_val is not None else '-',
+            status,
+        )
+
+    def compare_bool(capname):
+        xt_val = capname in result.capabilities
+        jn_val = jterm.tigetflag(capname) == 1
+        status = 'MATCH' if xt_val == jn_val else 'MISMATCH'
+        return str(xt_val), str(jn_val), status
+
+    print_section('String Capabilities', str_caps, compare_str)
+    print_section('Numeric Capabilities', num_caps, compare_num)
+    print_section('Boolean Capabilities', bool_caps, compare_bool)
+
+    print(f"\n=== Summary: {mismatches} mismatches, {matches} matches ===")
+
+
+if __name__ == '__main__':
+    main()

--- a/blessed/_capabilities.py
+++ b/blessed/_capabilities.py
@@ -2,8 +2,11 @@
 # std imports
 import re
 import typing
-from typing import Dict, Optional
+from typing import Set, Dict, Optional
 from collections import OrderedDict
+
+# 3rd party
+import jinxed.terminfo
 
 __all__ = (
     'CAPABILITY_DATABASE',
@@ -551,6 +554,19 @@ class TermcapResponse:
         <https://invisible-island.net/xterm/ctlseqs/ctlseqs.html>`_
     """
 
+    _TERMINFO_ESCAPE: typing.ClassVar[typing.Dict[str, str]] = {
+        'E': '\x1b', 'e': '\x1b',
+        'n': '\n', 't': '\t', 'r': '\r',
+        'b': '\b', 'f': '\f',
+        '\\': '\\', '^': '^', ':': ':',
+    }
+
+    # XTGETTCAP DCS response: DCS <valid>+r<hex-name>[=<hex-value>] ST
+    #   valid=1: terminal supports this capability, value follows
+    #   valid=0: terminal does not support this capability (negative acknowledgement)
+    _RE_XTGETTCAP_RESPONSE: typing.ClassVar[typing.Pattern[str]] = re.compile(
+        r'\x1bP([01])\+r([0-9a-fA-F]+)(?:=([0-9a-fA-F]*))?\x1b\\')
+
     def __init__(self, supported: bool = False,
                  capabilities: Optional[Dict[str, str]] = None) -> None:
         """Initialize TermcapResponse with support status and capabilities."""
@@ -578,7 +594,7 @@ class TermcapResponse:
         """
         Terminal name from ``TN`` capability, or ``None``.
 
-        .. deprecated:: This alias is not very useful or used by blessed.
+        .. deprecated:: This alias is not useful or used by blessed.
         """
         return self.capabilities.get('TN')
 
@@ -587,7 +603,7 @@ class TermcapResponse:
         """
         Number of colors from ``colors`` capability, or ``None``.
 
-        .. deprecated:: This value is not very useful or used by blessed.
+        .. deprecated:: This value is not useful or used by blessed.
         """
         val = self.capabilities.get('colors')
         if val is not None:
@@ -614,6 +630,99 @@ class TermcapResponse:
             return bytes.fromhex(hex_str).decode('ascii', errors='strict')
         except ValueError:
             return ''
+
+    @staticmethod
+    def unescape_terminfo(
+        value: str,
+    ) -> str:
+        r"""
+        Unescape terminfo source-level escape sequences.
+
+        Terminfo source format uses ``\E``, ``\n``, ``\t``, ``\r``, ``\b``, ``\f``, ``\\``, ``\^``,
+        ``\:``, ``\NNN`` octal, and ``^X`` control-character notation.  XTGETTCAP responses from
+        some terminals (e.g. ghostty, kitty, foot, rio) report values in this source format rather
+        than as raw binary.  Convert these to their actual byte values.
+        """
+        result = []
+        idx = 0
+        while idx < len(value):
+            cur = value[idx]
+            if cur == '\\' and idx + 1 < len(value):
+                nxt = value[idx + 1]
+                esc = TermcapResponse._TERMINFO_ESCAPE.get(nxt)
+                if esc is not None:
+                    result.append(esc)
+                    idx += 2
+                    continue
+                if nxt in '01234567':
+                    end = idx + 1
+                    while end < len(value) and value[end] in '01234567':
+                        end += 1
+                    result.append(chr(int(value[idx + 1:end], 8)))
+                    idx = end
+                    continue
+            elif cur == '^' and idx + 1 < len(value):
+                nxt = value[idx + 1]
+                if 'A' <= nxt <= '_':
+                    result.append(chr(ord(nxt) - ord('A') + 1))
+                    idx += 2
+                    continue
+                if nxt == '?':
+                    result.append('\x7f')
+                    idx += 2
+                    continue
+            result.append(cur)
+            idx += 1
+        return ''.join(result)
+
+    @classmethod
+    def from_match(cls, match: 're.Match[str]') -> 'tuple[str, str]':
+        """Parse a single XTGETTCAP DCS +r regex match into (name, value)."""
+        cap_name = cls.hex_decode(match.group(2))
+        value = (
+            cls.unescape_terminfo(cls.hex_decode(val_hex))
+            if (val_hex := match.group(3)) is not None
+            else ''
+        )
+        return cap_name, value
+
+    @classmethod
+    def parse_capabilities(cls, raw: str) -> 'Dict[str, str]':
+        """Parse all successful DCS +r responses from raw text."""
+        capabilities: Dict[str, str] = {}
+        for match in cls._RE_XTGETTCAP_RESPONSE.finditer(raw):
+            if match.group(1) == '1':
+                name, value = cls.from_match(match)
+                capabilities[name] = value
+        return capabilities
+
+    def make_jinxed_capabilities(self) -> 'Dict[str, Dict[str, str] | Dict[str, int] | Set[str]]':
+        """
+        Classify discovered capabilities for injection into a jinxed Terminal.
+
+        :returns: dict with keys ``str_caps``, ``num_caps``, ``bool_caps``, matching
+            the keyword arguments accepted by jinxed Terminal method, ``apply_capabilities()``
+        """
+        str_caps: Dict[str, str] = {}
+        num_caps: Dict[str, int] = {}
+        bool_caps: Set[str] = set()
+
+        for capname, value in self.capabilities.items():
+            if capname == 'RGB':
+                # 'RGB' is not a terminfo(5) capability, as noted by foot, "RGB - number of bits per
+                # color channel (different semantics from the RGB capability in file-based terminfo
+                # definitions!)." https://codeberg.org/dnkl/foot#xtgettcap
+                continue
+            if not value:
+                if capname in jinxed.terminfo.BOOL_CAPS:
+                    bool_caps.add(capname)
+            elif capname in jinxed.terminfo.NUM_CAPS:
+                if value.isdigit():
+                    num_caps[capname] = int(value)
+            else:
+                str_caps[capname] = value
+
+        return {'str_caps': str_caps, 'num_caps': num_caps, 'bool_caps': bool_caps}
 
 
 class ITerm2Capabilities:

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -1293,7 +1293,8 @@ def get_keyboard_codes() -> Dict[int, str]:
     return dict(zip(keycodes.values(), keycodes.keys()))
 
 
-def get_keyboard_sequences(term: 'Terminal') -> typing.OrderedDict[str, int]:
+def get_keyboard_sequences(  # pylint: disable=protected-access
+        term: 'Terminal') -> typing.OrderedDict[str, int]:
     r"""
     Return mapping of keyboard sequences paired by keycodes.
 
@@ -1312,7 +1313,6 @@ def get_keyboard_sequences(term: 'Terminal') -> typing.OrderedDict[str, int]:
     The return value is an OrderedDict instance, with their keys
     sorted longest-first.
     """
-    # pylint: disable=protected-access
     # A small gem from curses.has_key that makes this all possible,
     # _capability_names: a lookup table of terminal capability names for
     # keyboard sequences (fe. kcub1, key_left), keyed by the values of

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -979,7 +979,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             # CPR always reports 1-based coordinates (row 1, column 1).  All terminals published by
             # jinxed use %i in their u6 string (the standard behavior), so we unconditionally
             # convert to 0-based.  A pedantic impl would check for %i in the u6 capability, but no
-            # terminal supoprted by blessed/jinxed uses 0-index, it was an ANSI standard, afterall.
+            # terminal supoprted by blessed/jinxed uses 0-index, it was an ANSI standard, after all.
             return (max(0, int(val) - 1) for val in match.groups())
 
         # Return an illegal value (-1) rather than a custom exception, developers should

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -16,7 +16,18 @@ import platform
 import warnings
 import contextlib
 import collections
-from typing import IO, Dict, List, Match, Tuple, Union, Callable, Optional, Generator, SupportsIndex
+from typing import (IO,
+                    Set,
+                    Dict,
+                    List,
+                    Match,
+                    Tuple,
+                    Union,
+                    Callable,
+                    Iterable,
+                    Optional,
+                    Generator,
+                    SupportsIndex)
 
 # 3rd party
 import jinxed
@@ -61,11 +72,14 @@ from ._capabilities import (CAPABILITY_DATABASE,
                             CAPABILITIES_ADDITIVES,
                             CAPABILITIES_RAW_MIXIN,
                             XTGETTCAP_CAPABILITIES,
+                            XTGETTCAP_INIT_CAPABILITIES,
                             CAPABILITIES_HORIZONTAL_DISTANCE,
                             Decrqss,
                             TermcapResponse,
                             TextSizingResult,
                             ITerm2Capabilities)
+
+_ALL_XTGETTCAP_CAPS = frozenset({c[0] for c in XTGETTCAP_CAPABILITIES})
 
 HAS_TTY = True  # pylint: disable=invalid-name
 IS_WINDOWS = platform.system() == 'Windows'
@@ -116,9 +130,6 @@ _RE_OSC52_RESPONSE = re.compile(r'\x1b\]52;[a-z]*;([^\x07\x1b]*)(?:\x07|\x1b\\)'
 _RE_COLOR_SCHEME_MODE_RESPONSE = re.compile(r'\x1b\[\?997;([12])n')
 # DECRQSS: DCS Ps $ r Pt ST (Ps=1 means valid)
 _RE_DECRQSS_RESPONSE = re.compile(r'\x1bP([01])\$r([^\x1b]*)\x1b\\')
-# XTGETTCAP: DCS Ps + r Pt ST (Ps=1 means valid, Pt=hex-encoded capname=value)
-_RE_XTGETTCAP_RESPONSE = re.compile(
-    r'\x1bP([01])\+r([0-9a-fA-F]+)(?:=([0-9a-fA-F]*))?\x1b\\')
 
 
 class Terminal():  # pylint: disable=attribute-defined-outside-init
@@ -256,8 +267,6 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             self.__init__keyboard_state()
 
             # Step 1: XTGETTCAP capability negotiation
-            self._xtgettcap_cache: Optional[TermcapResponse] = None
-            self._xtgettcap_first_query_failed = False
             self._xtgettcap_cache = (
                 _xtgettcap_data if _xtgettcap_data is not None
                 else self.__init__xtgettcap())
@@ -265,7 +274,12 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             # Step 2: Initialize using jinxed for its terminfo(5) database.
             self.__init_termcap_kind(kind_preferred=kind, kind_fallback=kind_fallback)
 
-        # Step 3: Initialize keyboard infrastructure
+            # Step 3: Inject XTGETTCAP overrides into jinxed
+            if self._xtgettcap_cache.supported and self.does_styling:
+                self._jinxed_term.overlay_capabilities(
+                    **self._xtgettcap_cache.make_jinxed_capabilities())
+
+        # Step 4: Initialize keyboard infrastructure
         self.__init__keycodes()
 
         # Step 5: Finalize capabilities using best available data
@@ -287,8 +301,19 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         self._keymap_prefixes: set[str] = set()
 
     def __init__xtgettcap(self) -> TermcapResponse:
-        """XTGETTCAP probing happens lazily on first call to get_xtgettcap()."""
-        return None
+        """Probe for core XTGETTCAP capabilities."""
+        _xtgettcap_cache = TermcapResponse(supported=False)
+        if (self.is_a_tty and self._keyboard_fd is not None):
+            try:
+                _xtgettcap_cache = self._xtgettcap_batch(
+                    caps=XTGETTCAP_INIT_CAPABILITIES,
+                    timeout=TERMINAL_QUERY_TIMEOUT_SECONDS)
+            except OSError as exc:
+                self.errors.append(f'XTGETTCAP probe failed, OSError: {exc}')
+            else:
+                if not _xtgettcap_cache.supported:
+                    self.errors.append('XTGETTCAP probe: no support')
+        return _xtgettcap_cache
 
     def __init_termcap_kind(self, kind_preferred: Optional[str], kind_fallback: str) -> None:
         """Determine terminal 'kind' jinxed.setupterm() capability database."""
@@ -298,8 +323,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         #
         # I believe now xterm-256 sequences are safe as unknown fallback for the year 2026. If dumb
         # *is*, use NO_COLOR or force_styling=False which has the same general result.
-        tn_kind = (self._xtgettcap_cache.capabilities.get('TN')
-                   if self._xtgettcap_cache is not None else None)
+        tn_kind = self._xtgettcap_cache.capabilities.get('TN')
         term_kind = (jinxed.get_term(self._init_descriptor)
                      if IS_WINDOWS and self._init_descriptor is not None
                      else os.environ.get('TERM'))
@@ -417,7 +441,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         # Keyboard valid as stdin only when output stream is stdout or stderr and is a tty.
         if self._stream in (sys.__stdout__, sys.__stderr__):
             try:
-                self._keyboard_fd = sys.__stdin__.fileno()  # type: ignore[union-attr,assignment]
+                self._keyboard_fd = sys.__stdin__.fileno()  # type: ignore[union-attr]
             except (AttributeError, ValueError) as err:
                 self.errors.append(f'Unable to determine input stream file descriptor: {err}')
             else:
@@ -432,11 +456,11 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             self.errors.append('Output stream is not a default stream')
 
         # The descriptor to direct terminal initialization sequences to.
-        self._init_descriptor = stream_fd  # type: ignore[assignment]
+        self._init_descriptor = stream_fd
         if stream_fd is None:
             try:
                 self._init_descriptor = \
-                    sys.__stdout__.fileno()  # type: ignore[union-attr,assignment]
+                    sys.__stdout__.fileno()  # type: ignore[union-attr]
             except ValueError as err:
                 self.errors.append(
                     f'sys.__stdout__.fileno() failed, stdout may be detached or closed: {err}')
@@ -461,6 +485,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         """Initialize color distance algorithm and determine Terminal.number_of_colors."""
         # Resolution order:
         # - COLORTERM environment value
+        # - XTGETTCAP 'RGB' (24-bit), then 'colors'
         # - termcap 'colors' (jinxed)
         # - Windows native console (vtwin10) gets 24-bit boost
         self._color_distance_algorithm = 'cie2000'
@@ -468,9 +493,21 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             return 0
         if os.environ.get('COLORTERM') in {'truecolor', '24bit'}:
             return 1 << 24
+        if (rgb_val := self._xtgettcap_cache.capabilities.get('RGB')):
+            try:
+                if int(rgb_val.split('/', 1)[0]) == 8:
+                    return 1 << 24
+            except ValueError:
+                pass
+        if (xt_colors := self._xtgettcap_cache.capabilities.get('colors')) and xt_colors.isdigit():
+            return int(xt_colors)
         _win_build = tuple(int(n) for n in platform.version().split('.')
                            if n.isdigit()) if IS_WINDOWS else 0
         if IS_WINDOWS and self._kind == 'vtwin10' and _win_build >= (10, 0, 14931):
+            # Windows 10 build 14931+ (2016) supports 24-bit color natively, but they do not set
+            # COLORTERM. Older Windows releases and versions of ConHost.exe lack truecolor and fall
+            # through to jinxed terminfo (8 or 16 colors).
+            # https://devblogs.microsoft.com/commandline/24-bit-color-in-the-windows-console/
             return 1 << 24
         return max(0, self._jinxed_term.tigetnum('colors'))
 
@@ -820,8 +857,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
                 data = data[:match.start()] + data[match.end():]
 
             # Check if the feature response arrived before the CPR
-            feature_match = feature_re.search(data)
-            if feature_match:
+            if (feature_match := feature_re.search(data)):
                 data = data[:feature_match.start()] + data[feature_match.end():]
 
             # Re-buffer any remaining keyboard input
@@ -1617,103 +1653,133 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         return self.get_dec_mode(_DecPrivateMode.FOCUS_IN_OUT_EVENTS, timeout=timeout).supported
 
     def get_xtgettcap(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
-                      force: bool = False) -> Optional[TermcapResponse]:
-        # pylint: disable=too-complex
+                      force: bool = False,
+                      caps: Optional[Iterable[str]] = None) -> Optional[TermcapResponse]:
         """
         Query terminal capabilities via XTGETTCAP (DCS +q).
 
-        Sends XTGETTCAP queries to discover the terminal's built-in
-        terminfo capabilities, bypassing the local terminfo database.
-        Supported by xterm, foot, kitty, WezTerm, ghostty, and others.
+        When *caps* is specified, only those capabilities are returned. When unspecified, all known
+        XTGETTCAP capabilities are queried and returned.  All results from XTGETTCAP are memoized
+        permanently, unlike DECRQSS :meth:`get_decrqss` which may change. Using ``force=True`` to
+        re-retrieve any request.
 
-        Uses a probe-first strategy: sends a single capability query
-        first, then queries remaining capabilities only if the probe
-        succeeds.  This avoids visible garbage on terminals that do
-        not support XTGETTCAP.
-
-        When :attr:`is_a_tty` is False, returns ``None``.
-
-        Responses are cached unless *force* is True.
-
-        :arg float timeout: Timeout in seconds per query round.
-        :arg bool force: Bypass cache and re-query the terminal.
-        :rtype: TermcapResponse or None
+        :arg float timeout: Timeout in seconds.
+        :arg bool force: Always re-query for latest values.
+        :arg caps: Capability names to query.  When specified, only these additional capabilities
+            may queried (incremental on cache).  when unspecified, it as though `all=True` was used.
+        :rtype: TermcapResponse
         """
-        if not self.is_a_tty:
+        if not self.is_a_tty or (
+                not self._xtgettcap_cache.supported
+                and not force):
+            # sticky failure when not a tty, or XTGETTCAP not supported
             return None
 
-        if self._xtgettcap_first_query_failed and not force:
+        timeout = timeout if timeout is not None else TERMINAL_QUERY_TIMEOUT_SECONDS
+
+        caps = set(_ALL_XTGETTCAP_CAPS) if caps is None else set(caps)
+
+        # force=True: single batch
+        if force:
+            result = self._xtgettcap_batch(list(caps), timeout=timeout)
+            return self._maybe_none(self._filter_xtgettcap_response(
+                self._update_xtgettcap_cache(result), caps))
+
+        # cache hit: check if all requested caps are already known
+        cached_names = set(self._xtgettcap_cache.capabilities.keys())
+        missing = caps - cached_names
+        if not missing:
+            return self._maybe_none(self._filter_xtgettcap_response(
+                self._xtgettcap_cache, caps))
+
+        # Incremental: query only missing caps, merge into cache
+        result = self._xtgettcap_batch(list(missing), timeout=timeout)
+        return self._maybe_none(self._filter_xtgettcap_response(
+            self._update_xtgettcap_cache(result), caps))
+
+    def _update_xtgettcap_cache(self, result: TermcapResponse) -> TermcapResponse:
+        """Merge *result* into ``_xtgettcap_cache``, clearing cached attributes."""
+        base_caps = self._xtgettcap_cache.capabilities if self._xtgettcap_cache is not None else {}
+        next_caps = dict(base_caps)
+        next_caps.update(result.capabilities)
+        merged = TermcapResponse(
+            supported=self._xtgettcap_cache.supported or result.supported,
+            capabilities=next_caps)
+        self._xtgettcap_cache = merged
+        return merged
+
+    @staticmethod
+    def _filter_xtgettcap_response(
+            tc: TermcapResponse,
+            requested: Optional[Set[str]] = None,
+    ) -> TermcapResponse:
+        """
+        Return *tc* with ``None``-valued capabilities filtered out.
+
+        When *requested* is given, the result is further filtered to only contain those capability
+        names.
+        """
+        filtered = {k: v for k, v in tc.capabilities.items() if v is not None}
+        if requested is not None:
+            filtered = {k: v for k, v in filtered.items() if k in requested}
+        return TermcapResponse(supported=tc.supported, capabilities=filtered)
+
+    @staticmethod
+    def _maybe_none(tc: TermcapResponse) -> Optional[TermcapResponse]:
+        """Return *tc* or None if unsupported."""
+        return tc if tc.supported else None
+
+    def _xtgettcap_batch(
+            self,
+            caps: List[str],
+            timeout: float,
+    ) -> TermcapResponse:
+        """
+        Spray *caps* + CPR fence, read responses.
+
+        Returns a ``TermcapResponse`` for the requested capabilities.  Caps
+        that are not answered are recorded as ``None`` so they are not
+        re-queried on future calls.
+        """
+        if not caps:
             return None
 
-        if self._xtgettcap_cache is not None and not force:
-            if self._xtgettcap_cache.supported:
-                return self._xtgettcap_cache
-            return None
-
-        # Phase 1: Probe with single capability via _query_with_boundary,
-        # which safely preserves any concurrent keyboard input and uses
-        # CPR boundary guard for fast negative detection.
-        probe_cap = XTGETTCAP_CAPABILITIES[0][0]
-        probe_query = f'\x1bP+q{TermcapResponse.hex_encode(probe_cap)}\x1b\\'
-        match = self._query_with_boundary(
-            probe_query, _RE_XTGETTCAP_RESPONSE, timeout)
-
-        if match is None:
-            self._xtgettcap_first_query_failed = True
-            # Erase any visible garbage from unsupported terminals
-            if hasattr(self, '_jinxed_term'):
-                self.stream.write(f'\r{self.clear_eol}')
-                self.stream.flush()
-            return None
-
-        capabilities: Dict[str, str] = {}
-        self._parse_single_xtgettcap(match, capabilities)
-
-        # Phase 2: Batch-query remaining capabilities.  We use
-        # flushinp() here because multiple DCS responses arrive, then
-        # re-buffer any non-DCS keyboard data via ungetch().
         ctx = None
         try:
             if self._line_buffered:
                 ctx = self.cbreak()
                 ctx.__enter__()
-
-            for capname, _desc in XTGETTCAP_CAPABILITIES[1:]:
+            for capname in caps:
                 self.stream.write(
                     f'\x1bP+q{TermcapResponse.hex_encode(capname)}\x1b\\')
+            self.stream.write('\x1b[6n')  # CPR fence
             self.stream.flush()
-
-            raw = self.flushinp(timeout=timeout)
-            if raw:
-                self._parse_xtgettcap_responses(raw, capabilities)
-                # Re-buffer any keyboard input that arrived alongside
-                remaining = _RE_XTGETTCAP_RESPONSE.sub('', raw)
-                if remaining:
-                    self.ungetch(remaining)
-
+            match, data = _read_until(self, _RE_CPR_BOUNDARY.pattern, timeout)
         finally:
             if ctx is not None:
                 ctx.__exit__(None, None, None)
 
-        result = TermcapResponse(supported=True, capabilities=capabilities)
-        self._xtgettcap_cache = result
-        return result
+        if match is None:
+            return TermcapResponse()
 
-    @staticmethod
-    def _parse_single_xtgettcap(match: Match[str], capabilities: Dict[str, str]) -> None:
-        """Parse a single XTGETTCAP DCS +r regex match into *capabilities*."""
-        success = match.group(1) == '1'
-        if success:
-            cap_name = TermcapResponse.hex_decode(match.group(2))
-            val_hex = match.group(3)
-            capabilities[cap_name] = (
-                TermcapResponse.hex_decode(val_hex) if val_hex is not None else '')
+        # Strip the CPR itself from the response data
+        data = data[:match.start()] + data[match.end():]
 
-    @staticmethod
-    def _parse_xtgettcap_responses(raw: str, capabilities: Dict[str, str]) -> None:
-        """Parse DCS +r responses from XTGETTCAP into *capabilities* dict."""
-        for match in _RE_XTGETTCAP_RESPONSE.finditer(raw):
-            Terminal._parse_single_xtgettcap(match, capabilities)
+        capabilities: Dict[str, str] = {}
+        if data:
+            capabilities.update(TermcapResponse.parse_capabilities(data))
+            # pylint: disable=protected-access
+            remaining = TermcapResponse._RE_XTGETTCAP_RESPONSE.sub('', data)
+            if remaining:
+                self.ungetch(remaining)
+
+        # Record None sentinel for any requested cap that wasn't answered.
+        for capname in caps:
+            if capname not in capabilities:
+                capabilities[capname] = None  # type: ignore[assignment]
+
+        supported = any(value is not None for value in capabilities.values())
+        return TermcapResponse(supported=supported, capabilities=capabilities)
 
     def does_xtgettcap(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                        force: bool = False) -> bool:
@@ -1929,7 +1995,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             return True
 
         # Strategy 2: XTGETTCAP Ms capability
-        tcap = self.get_xtgettcap(timeout=timeout, force=force)
+        tcap = self.get_xtgettcap(timeout=timeout, force=force, caps=['Ms'])
         if tcap is not None and 'Ms' in tcap.capabilities:
             self._osc52_clipboard_supported = True
             return True
@@ -2057,7 +2123,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         :arg bool force: Bypass cached result.
         :rtype: bool
         """
-        result = self.get_xtgettcap(timeout=timeout, force=force)
+        result = self.get_xtgettcap(
+            timeout=timeout, force=force, caps=['kitty-query-name'])
         return result is not None and 'kitty-query-name' in result.capabilities
 
     def get_decrqss(self, setting_id: str = Decrqss.SGR,
@@ -2135,7 +2202,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         :arg bool force: Bypass cached result.
         :rtype: bool
         """
-        tc = self.get_xtgettcap(timeout=timeout, force=force)
+        tc = self.get_xtgettcap(timeout=timeout, force=force, caps=['Smulx'])
         return tc is not None and 'Smulx' in tc
 
     def does_colored_underlines(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
@@ -2149,7 +2216,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         :arg bool force: Bypass cached result.
         :rtype: bool
         """
-        tc = self.get_xtgettcap(timeout=timeout, force=force)
+        tc = self.get_xtgettcap(timeout=timeout, force=force, caps=['Setulc'])
         return tc is not None and 'Setulc' in tc
 
     def does_text_sizing(self, timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS,
@@ -3121,7 +3188,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         """
         if self._normal:
             return self._normal
-        self._normal = resolve_capability(self, 'normal')  # type: ignore[assignment]
+        self._normal = resolve_capability(self, 'normal')
         return self._normal
 
     def link(self, url: str, text: str, url_id: str = '') -> str:
@@ -3404,6 +3471,18 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             The result is permanently cached and all further calls to these methods return
             immediately without this side effect.
         """
+        def _validate(value: Union[int, str], name: str,
+                      mapping: Dict[str, int]) -> int:
+            """Validate alignment value, raise ValueError on invalid input."""
+            if isinstance(value, int):
+                if not 0 <= value <= 2:
+                    raise ValueError(f"'{name}' out of range (0-2), got {value}")
+                return value
+            if value not in mapping:
+                raise ValueError(f"'{name}' invalid, expected: {', '.join(mapping)}, "
+                                 f"got {value}")
+            return mapping[value]
+
         # validation,
         utf8_len = len(text.encode('utf-8'))
         if utf8_len > 4096:
@@ -3414,29 +3493,17 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             raise ValueError("'text' must not contain control codes or terminal sequences, "
                              f"got ESC (\\x1b) at index {pos_esc}")
 
-        def _validate(name: str, value: Union[int, str],
-                      string_values: Dict[str, int]) -> int:
-            if isinstance(value, int):
-                if not 0 <= value <= 2:
-                    raise ValueError(f"'{name}' out of range (0-2), got {value}")
-                return value
-            if value not in string_values:
-                expected = ', '.join(string_values)
-                raise ValueError(f"'{name}' invalid, expected: {expected}, got {value}")
-            return string_values[value]
-
-        _vert_map = {'top': 0, 'bottom': 1, 'center': 2, 'default': 0}
-        _horz_map = {'left': 0, 'right': 1, 'center': 2, 'default': 0}
-        vertical_align = _validate('vertical_align', vertical_align, _vert_map)
-        horizontal_align = _validate('horizontal_align', horizontal_align, _horz_map)
+        vertical_align = _validate(vertical_align, 'vertical_align',
+                                   {'top': 0, 'bottom': 1, 'center': 2, 'default': 0})
+        horizontal_align = _validate(horizontal_align, 'horizontal_align',
+                                     {'left': 0, 'right': 1, 'center': 2, 'default': 0})
 
         # Kitty text sizing protocol: alignment only applies when fractional
         # scaling is in effect (0 < numerator < denominator).  When there is
         # no fractional scaling, alignment describes how the scaled render area
         # fits inside the cell grid — which has no meaning and can cause
         # flickering/artifacts if passed unconditionally.
-        is_fractional = 0 < numerator < denominator
-        if not is_fractional:
+        if not 0 < numerator < denominator:
             vertical_align = 0
             horizontal_align = 0
 

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -975,18 +975,12 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
         if match:
             # return matching sequence response, the cursor location.
-            row, col = (int(val) for val in match.groups())
-
-            # Per https://invisible-island.net/ncurses/terminfo.src.html The cursor position report
-            # (<u6>) string must contain two scanf(3)-style %d format elements.  The first of these
-            # must correspond to the Y coordinate and the second to the %d.  If the string contains
-            # the sequence %i, it is taken as an instruction to decrement each value after reading
-            # it (this is the inverse sense from the cup string).
-            response_str = getattr(self, self.caps['cursor_report'].attribute) or '\x1b[%i%d;%dR'
-            if '%i' in response_str:
-                row -= 1
-                col -= 1
-            return row, col
+            #
+            # CPR always reports 1-based coordinates (row 1, column 1).  All terminals published by
+            # jinxed use %i in their u6 string (the standard behavior), so we unconditionally
+            # convert to 0-based.  A pedantic impl would check for %i in the u6 capability, but no
+            # terminal supoprted by blessed/jinxed uses 0-index, it was an ANSI standard, afterall.
+            return (max(0, int(val) - 1) for val in match.groups())
 
         # Return an illegal value (-1) rather than a custom exception, developers should
         # check or filters, such as if (x, y) != (-1, -1) or max(0, y).

--- a/blessed/win_terminal.py
+++ b/blessed/win_terminal.py
@@ -124,6 +124,9 @@ class Terminal(_Terminal):
         self._prev_button_state: int = 0
         self._native_mouse: bool = False
         self._native_resize: bool = False
+        # As of May 2026, the latest Windows Terminal.exe is without XTGETTCAP support,
+        # and so on it is not checked or negotiated for as a side-effect of the class initializer
+        # like the base class, does.
 
     def getch(self, decode_latin1: bool = False) -> str:
         r"""

--- a/blessed/win_terminal.py
+++ b/blessed/win_terminal.py
@@ -117,16 +117,15 @@ class Terminal(_Terminal):
                  _xtgettcap_data: Optional[TermcapResponse] = None
                  ) -> None:
         """Initialize Windows terminal instance."""
+        # Initialize instance attributes needed by kbhit() during
+        # XTGETTCAP probing in the base class __init__.
+        self._event_buf: collections.deque[str] = collections.deque()
+        self._native_mouse: bool = False
+        self._native_resize: bool = False
         super().__init__(kind=kind, stream=stream, force_styling=force_styling,
                          kind_fallback=kind_fallback,
                          _xtgettcap_data=_xtgettcap_data)
-        self._event_buf: collections.deque[str] = collections.deque()
         self._prev_button_state: int = 0
-        self._native_mouse: bool = False
-        self._native_resize: bool = False
-        # As of May 2026, the latest Windows Terminal.exe is without XTGETTCAP support,
-        # and so on it is not checked or negotiated for as a side-effect of the class initializer
-        # like the base class, does.
 
     def getch(self, decode_latin1: bool = False) -> str:
         r"""

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -10,6 +10,13 @@ Version History
     terminal `capability database
     <https://jinxed.readthedocs.io/en/stable/capabilities.html#database>` of 45 terminals and their
     common aliases.
+  * improved: Class initialization of :class:`~.Terminal()` now uses `XTGETTCAP`_ to determine
+    preferred terminal name ``TN``, 24-bit color support ``RGB``, number of colors ``Co``, `italic`,
+    and `blink` capabilities.
+
+    This improves detection of ``TERM`` over protocols like serial that cannot forward any
+    environment variables, to determine 24-bit value for :attr:`~.Terminal.number_of_colors` when
+    using protocols like ssh that do not forward ``COLORTERM``.
   * introduced: A :exc:`UserWarning` is emitted when :meth:`~.Terminal.__getattr__` resolves an
     unknown terminal capability name, helping developers catch typos like ``term.bld``
     (missing ``bold``).  The warning can be suppressed by setting the environment variable

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -821,28 +821,14 @@ def test_get_color_scheme_force_bypasses_sticky_failure():
     assert result == 'dark'
 
 
-def test_get_location_percent_i_flag():
-    """get_location applies %i decrement when cursor_report contains %i."""
+def test_get_location_always_decrements():
+    """get_location always converts CPR 1-based coordinates to 0-based."""
     term = TestTerminal(stream=StringIO(), force_styling=True)
     term._is_a_tty = True
     term.ungetch('\x1b[2;6R')
-    term.caps['cursor_report'].attribute = '_mock_never_exists'
-    setattr(term, '_mock_never_exists', '\x1b[%i%d;%dR')
     row, col = term.get_location(timeout=0.01)
     assert row == 1
     assert col == 5
-
-
-def test_get_location_no_percent_i():
-    """get_location does not decrement when cursor_report lacks %i."""
-    term = TestTerminal(stream=StringIO(), force_styling=True)
-    term._is_a_tty = True
-    term.ungetch('\x1b[2;6R')
-    term.caps['cursor_report'].attribute = '_mock_no_i'
-    setattr(term, '_mock_no_i', '\x1b[%d;%dR')
-    row, col = term.get_location(timeout=0.01)
-    assert row == 2
-    assert col == 6
 
 
 def test_split_seqs_maxsplit_with_xterm():

--- a/tests/test_full_keyboard.py
+++ b/tests/test_full_keyboard.py
@@ -497,25 +497,6 @@ def test_get_location_0s_reply_via_ungetch():
     child()
 
 
-def test_get_location_0s_nonstandard_u6():
-    """u6 without %i should not be decremented."""
-    # local
-    from blessed.formatters import ParameterizingString
-
-    def child():
-        term = TestTerminal(stream=StringIO(), force_styling=True, is_a_tty=True)
-        stime = time.time()
-        # monkey patch in an invalid response !
-        term.ungetch('\x1b[10;10R')
-
-        with mock.patch.object(term, 'u6') as mock_u6:
-            mock_u6.return_value = ParameterizingString('\x1b[%d;%dR', term.normal, 'u6')
-            y, x = term.get_location(timeout=0.01)
-        assert math.floor(time.time() - stime) == 0.0
-        assert (y, x) == (10, 10)
-    child()
-
-
 def test_get_location_styling_indifferent():
     """Ensure get_location() behavior is the same regardless of styling"""
     def child():

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -1,490 +1,665 @@
 """Tests for XTGETTCAP (DCS +q) terminal capability queries."""
 # std imports
 import io
+import os
+import select
+import sys
+import time
 
 # 3rd party
 import pytest
+from unittest import mock
 
 # local
-from blessed._capabilities import Decrqss
 from blessed._capabilities import TermcapResponse, ITerm2Capabilities
+from blessed.terminal import Terminal
 from .conftest import IS_WINDOWS
-from .accessories import TestTerminal, as_subprocess, pty_test, NO_XTGETTCAP_DATA
-
-
-class TestTermcapResponseParsing:
-    """TermcapResponse hex encoding/decoding and construction."""
-
-    def test_hex_encode(self):
-        """Hex-encode ASCII strings."""
-        assert TermcapResponse.hex_encode('TN') == '544e'
-        assert TermcapResponse.hex_encode('colors') == '636f6c6f7273'
-
-    def test_hex_decode(self):
-        """Hex-decode valid hex strings."""
-        assert TermcapResponse.hex_decode('544e') == 'TN'
-        assert TermcapResponse.hex_decode('636f6c6f7273') == 'colors'
-
-    def test_hex_decode_invalid(self):
-        """Hex-decode returns empty string on invalid hex."""
-        assert TermcapResponse.hex_decode('zzzz') == ''
-
-    def test_hex_decode_non_ascii(self):
-        """Hex-decode returns empty string on non-ASCII bytes."""
-        assert TermcapResponse.hex_decode('c0c1') == ''
-
-    def test_supported_with_capabilities(self):
-        """Supported response exposes capabilities via dict-like API."""
-        caps = {'TN': 'xterm-256color', 'colors': '256'}
-        resp = TermcapResponse(supported=True, capabilities=caps)
-        assert resp.supported is True
-        assert resp.terminal_name == 'xterm-256color'
-        assert resp.num_colors == 256
-        assert len(resp) == 2
-        assert 'TN' in resp
-        assert resp['TN'] == 'xterm-256color'
-        assert resp.get('missing') is None
-        assert resp.get('missing', 'default') == 'default'
-
-    def test_unsupported(self):
-        """Unsupported response returns None for all properties."""
-        resp = TermcapResponse(supported=False)
-        assert resp.supported is False
-        assert resp.terminal_name is None
-        assert resp.num_colors is None
-        assert len(resp) == 0
-
-    def test_num_colors_non_integer(self):
-        """Non-integer colors value returns None."""
-        resp = TermcapResponse(supported=True, capabilities={'colors': 'abc'})
-        assert resp.num_colors is None
-
-    def test_repr(self):
-        """String representation includes key attributes."""
-        resp = TermcapResponse(supported=True, capabilities={'TN': 'xterm'})
-        assert 'supported=True' in repr(resp)
-        assert 'TN' in repr(resp)
-
-    def test_getitem_keyerror(self):
-        """Missing key raises KeyError."""
-        resp = TermcapResponse(supported=True, capabilities={})
-        with pytest.raises(KeyError):
-            _ = resp['nonexistent']
-
-    def test_defaults_empty_capabilities(self):
-        """Default capabilities is empty dict."""
-        resp = TermcapResponse(supported=True)
-        assert resp.capabilities == {}
-        assert len(resp) == 0
-
-
-class TestITerm2Capabilities:
-    """ITerm2Capabilities parsing and construction."""
-
-    @pytest.mark.parametrize('feature_str,expected', [
-        ('T2CwBF', {
-            'truecolor': 2,
-            'clipboard_writable': True,
-            'bracketed_paste': True,
-            'focus_reporting': True,
-        }),
-        ('', {}),
-        ('ZZZ', {}),
-        ('Sc', {'decscusr': 0}),
-        ('Sc3', {'decscusr': 3}),
-        ('MSxNo', {
-            'mouse': True,
-            'sixel': True,
-            'notifications': True,
-        }),
-        ('UAwUw6', {
-            'unicode_basic': True,
-            'ambiguous_wide': True,
-            'unicode_widths': 6,
-        }),
-        ('LrGsGoSyH', {
-            'decslrm': True,
-            'strikethrough': True,
-            'overline': True,
-            'sync': True,
-            'hyperlinks': True,
-        }),
-        ('Ts2', {'titles': 2}),
-    ])
-    def test_parse_feature_string(self, feature_str, expected):
-        """Parse iTerm2 feature string into dict."""
-        result = ITerm2Capabilities.parse_feature_string(feature_str)
-        assert result == expected
-
-    def test_supported_capabilities_response(self):
-        """Supported response with features."""
-        features = {'truecolor': 2, 'sixel': True}
-        caps = ITerm2Capabilities(supported=True, features=features)
-        assert caps.supported is True
-        assert caps.features == features
-
-    def test_unsupported(self):
-        """Unsupported response has empty features."""
-        caps = ITerm2Capabilities(supported=False)
-        assert caps.supported is False
-        assert caps.features == {}
-
-    def test_repr(self):
-        """String representation includes key attributes."""
-        caps = ITerm2Capabilities(
-            supported=True, features={'truecolor': 2})
-        r = repr(caps)
-        assert 'supported=True' in r
-        assert 'truecolor' in r
-
-
-class TestGetXtgettcap:
-    """Terminal.get_xtgettcap() method."""
-
-    def test_not_a_tty_returns_none(self):
-        """Returns None when not a TTY."""
-        @as_subprocess
-        def child():
-            term = TestTerminal(stream=io.StringIO(), force_styling=True,
-                                is_a_tty=False)
-            assert term.get_xtgettcap(timeout=0.01) is None
-        child()
-
-    def test_does_xtgettcap_not_a_tty(self):
-        """does_xtgettcap returns False when not a TTY."""
-        @as_subprocess
-        def child():
-            term = TestTerminal(stream=io.StringIO(), force_styling=True,
-                                is_a_tty=False)
-            assert term.does_xtgettcap(timeout=0.01) is False
-        child()
-
-    def test_cached_result(self):
-        """Returns cached result without re-querying."""
-        @as_subprocess
-        def child():
-            stream = io.StringIO()
-            term = TestTerminal(stream=stream, force_styling=True)
-            term._is_a_tty = True
-
-            cached = TermcapResponse(supported=True,
-                                     capabilities={'TN': 'test'})
-            term._xtgettcap_cache = cached
-
-            result = term.get_xtgettcap()
-            assert result is cached
-        child()
-
-    def test_sticky_failure(self):
-        """Returns None after first query failure."""
-        @as_subprocess
-        def child():
-            stream = io.StringIO()
-            term = TestTerminal(stream=stream, force_styling=True)
-            term._is_a_tty = True
-            term._xtgettcap_first_query_failed = True
-
-            result = term.get_xtgettcap()
-            assert result is None
-        child()
-
-    def test_force_bypasses_cache(self):
-        """force=True bypasses both cache and sticky failure."""
-        @as_subprocess
-        def child():
-            stream = io.StringIO()
-            term = TestTerminal(stream=stream, force_styling=True)
-            term._is_a_tty = True
-
-            cached = TermcapResponse(supported=True,
-                                     capabilities={'TN': 'old'})
-            term._xtgettcap_cache = cached
-            term._is_a_tty = False
-            result = term.get_xtgettcap(timeout=0.01, force=True)
-            assert result is None
-        child()
-
-    def test_parse_xtgettcap_responses(self):
-        """Parse multiple DCS +r responses."""
-        from blessed.terminal import Terminal
-        raw = (
-            '\x1bP1+r544e=787465726d\x1b\\'
-            '\x1bP1+r636f6c6f7273=323536\x1b\\'
-            '\x1bP0+r626365\x1b\\'
-        )
-        capabilities: dict = {}
-        Terminal._parse_xtgettcap_responses(raw, capabilities)
-        assert capabilities['TN'] == 'xterm'
-        assert capabilities['colors'] == '256'
-        assert 'bce' not in capabilities
-
-    def test_parse_xtgettcap_boolean_capability(self):
-        """Parse DCS +r boolean capability (no value)."""
-        from blessed.terminal import Terminal
-        raw = '\x1bP1+r626365\x1b\\'
-        capabilities: dict = {}
-        Terminal._parse_xtgettcap_responses(raw, capabilities)
-        assert capabilities['bce'] == ''
-
-    def test_does_xtgettcap_with_cached(self):
-        """does_xtgettcap returns True with cached supported result."""
-        @as_subprocess
-        def child():
-            stream = io.StringIO()
-            term = TestTerminal(stream=stream, force_styling=True)
-            term._is_a_tty = True
-            term._xtgettcap_cache = TermcapResponse(
-                supported=True, capabilities={'TN': 'test'})
-
-            assert term.does_xtgettcap() is True
-        child()
-
-    def test_does_xtgettcap_unsupported(self):
-        """does_xtgettcap returns False after probe failure."""
-        @as_subprocess
-        def child():
-            stream = io.StringIO()
-            term = TestTerminal(stream=stream, force_styling=True)
-            term._is_a_tty = True
-            term._xtgettcap_first_query_failed = True
-
-            assert term.does_xtgettcap() is False
-        child()
-
-
-class TestStyledUnderlines:
-    """Terminal.does_styled_underlines() and does_colored_underlines()."""
-
-    def test_styled_underlines_supported(self):
-        """Returns True when Smulx is in XTGETTCAP capabilities."""
-        @as_subprocess
-        def child():
-            stream = io.StringIO()
-            term = TestTerminal(stream=stream, force_styling=True)
-            term._is_a_tty = True
-            term._xtgettcap_cache = TermcapResponse(
-                supported=True,
-                capabilities={'TN': 'xterm', 'Smulx': '\x1b[4:%p1%dm'})
-            assert term.does_styled_underlines() is True
-        child()
-
-    def test_styled_underlines_unsupported(self):
-        """Returns False when Smulx is not in capabilities."""
-        @as_subprocess
-        def child():
-            stream = io.StringIO()
-            term = TestTerminal(stream=stream, force_styling=True)
-            term._is_a_tty = True
-            term._xtgettcap_cache = TermcapResponse(
-                supported=True, capabilities={'TN': 'xterm'})
-            assert term.does_styled_underlines() is False
-        child()
-
-    def test_styled_underlines_no_xtgettcap(self):
-        """Returns False when XTGETTCAP is not supported."""
-        @as_subprocess
-        def child():
-            stream = io.StringIO()
-            term = TestTerminal(stream=stream, force_styling=True)
-            term._is_a_tty = True
-            term._xtgettcap_cache = TermcapResponse(supported=False)
-            assert term.does_styled_underlines() is False
-        child()
-
-    def test_colored_underlines_supported(self):
-        """Returns True when Setulc is in XTGETTCAP capabilities."""
-        @as_subprocess
-        def child():
-            stream = io.StringIO()
-            term = TestTerminal(stream=stream, force_styling=True)
-            term._is_a_tty = True
-            term._xtgettcap_cache = TermcapResponse(
-                supported=True,
-                capabilities={'Setulc': '\x1b[58;2;%p1%d;%p2%d;%p3%dm'})
-            assert term.does_colored_underlines() is True
-        child()
-
-    def test_colored_underlines_unsupported(self):
-        """Returns False when Setulc is not in capabilities."""
-        @as_subprocess
-        def child():
-            stream = io.StringIO()
-            term = TestTerminal(stream=stream, force_styling=True)
-            term._is_a_tty = True
-            term._xtgettcap_cache = TermcapResponse(
-                supported=True, capabilities={'TN': 'xterm'})
-            assert term.does_colored_underlines() is False
-        child()
-
-
-class TestOsc52Clipboard:
-    """Terminal.does_osc52_clipboard() detection."""
-
-    def test_not_a_tty(self):
-        """Returns False when not a TTY."""
-        @as_subprocess
-        def child():
-            term = TestTerminal(stream=io.StringIO(), force_styling=True,
-                                is_a_tty=False)
-            assert term.does_osc52_clipboard(timeout=0.01) is False
-        child()
-
-    def test_cached_result(self):
-        """Returns cached result without re-querying."""
-        @as_subprocess
-        def child():
-            stream = io.StringIO()
-            term = TestTerminal(stream=stream, force_styling=True)
-            term._is_a_tty = True
-            term._osc52_clipboard_supported = True
-            assert term.does_osc52_clipboard() is True
-        child()
-
-    def test_force_bypasses_cache(self):
-        """force=True bypasses cached result."""
-        @as_subprocess
-        def child():
-            stream = io.StringIO()
-            term = TestTerminal(stream=stream, force_styling=True)
-            term._is_a_tty = True
-            term._osc52_clipboard_supported = True
-            result = term.does_osc52_clipboard(timeout=0.01, force=True)
-            assert result is False
-        child()
-
-
-class TestColorScheme:
-    """Terminal.get_color_scheme() detection."""
-
-    def test_not_a_tty(self):
-        """Returns None when not a TTY."""
-        @as_subprocess
-        def child():
-            term = TestTerminal(stream=io.StringIO(), force_styling=True,
-                                is_a_tty=False)
-            assert term.get_color_scheme(timeout=0.01) is None
-        child()
-
-    def test_negative_cache(self):
-        """Returns None immediately when previously unsupported."""
-        @as_subprocess
-        def child():
-            stream = io.StringIO()
-            term = TestTerminal(stream=stream, force_styling=True)
-            term._is_a_tty = True
-            term._color_scheme_supported = False
-            assert term.get_color_scheme() is None
-        child()
-
-    def test_force_bypasses_negative_cache(self):
-        """force=True bypasses negative cache."""
-        @as_subprocess
-        def child():
-            stream = io.StringIO()
-            term = TestTerminal(stream=stream, force_styling=True)
-            term._is_a_tty = True
-            term._color_scheme_supported = False
-            result = term.get_color_scheme(timeout=0.01, force=True)
-            assert result is None
-        child()
-
-
-class TestKittyQuery:
-    """Terminal.does_kitty_query() detection."""
-
-    def test_not_a_tty(self):
-        """Returns False when not a TTY."""
-        @as_subprocess
-        def child():
-            term = TestTerminal(stream=io.StringIO(), force_styling=True,
-                                is_a_tty=False)
-            assert term.does_kitty_query(timeout=0.01) is False
-        child()
-
-    def test_cached_result(self):
-        """Returns cached result without re-querying."""
-        @as_subprocess
-        def child():
-            stream = io.StringIO()
-            term = TestTerminal(stream=stream, force_styling=True)
-            term._is_a_tty = True
-            term._xtgettcap_cache = TermcapResponse(
-                supported=True, capabilities={'kitty-query-name': '1'})
-            assert term.does_kitty_query() is True
-        child()
-
-    def test_force_bypasses_cache(self):
-        """force=True bypasses cached result."""
-        @as_subprocess
-        def child():
-            stream = io.StringIO()
-            term = TestTerminal(stream=stream, force_styling=True)
-            term._is_a_tty = True
-            term._xtgettcap_cache = TermcapResponse(
-                supported=True, capabilities={'kitty-query-name': '1'})
-            term._is_a_tty = False
-            result = term.does_kitty_query(timeout=0.01, force=True)
-            assert result is False
-        child()
-
-
-class TestDecrqss:
-    """Terminal.does_decrqss() detection."""
-
-    def test_not_a_tty(self):
-        """Returns False when not a TTY."""
-        @as_subprocess
-        def child():
-            term = TestTerminal(stream=io.StringIO(), force_styling=True,
-                                is_a_tty=False)
-            assert term.does_decrqss(timeout=0.01) is False
-        child()
-
-    def test_cached_result(self):
-        """Returns cached result without re-querying."""
-        @as_subprocess
-        def child():
-            stream = io.StringIO()
-            term = TestTerminal(stream=stream, force_styling=True)
-            term._is_a_tty = True
-            term._decrqss_supported = True
-            assert term.does_decrqss() is True
-        child()
-
-    def test_force_bypasses_cache(self):
-        """force=True bypasses cached result."""
-        @as_subprocess
-        def child():
-            stream = io.StringIO()
-            term = TestTerminal(stream=stream, force_styling=True)
-            term._is_a_tty = True
-            term._decrqss_supported = True
-            result = term.does_decrqss(timeout=0.01, force=True)
-            assert result is False
-        child()
-
-
-class TestGetDecrqss:
-    """Terminal.get_decrqss() state queries."""
-
-    def test_not_a_tty(self):
-        """Returns None when not a TTY."""
-        @as_subprocess
-        def child():
-            term = TestTerminal(stream=io.StringIO(), force_styling=True,
-                                is_a_tty=False)
-            assert term.get_decrqss(timeout=0.01) is None
-        child()
-
-    def test_default_setting_is_sgr(self):
-        """Default setting_id is SGR ('m')."""
-        @as_subprocess
-        def child():
-            term = TestTerminal(stream=io.StringIO(), force_styling=True,
-                                is_a_tty=False)
-            assert Decrqss.SGR == 'm'
-            assert term.get_decrqss() is None
-        child()
+from .accessories import TestTerminal, pty_test, NO_XTGETTCAP_DATA
+
+
+def test_hex_encode():
+    """Hex-encode ASCII strings."""
+    assert TermcapResponse.hex_encode('TN') == '544e'
+    assert TermcapResponse.hex_encode('colors') == '636f6c6f7273'
+
+
+def test_hex_decode():
+    """Hex-decode valid hex strings."""
+    assert TermcapResponse.hex_decode('544e') == 'TN'
+    assert TermcapResponse.hex_decode('636f6c6f7273') == 'colors'
+
+
+def test_hex_decode_invalid():
+    """Hex-decode returns empty string on invalid hex."""
+    assert TermcapResponse.hex_decode('zzzz') == ''
+
+
+def test_hex_decode_non_ascii():
+    """Hex-decode returns empty string on non-ASCII bytes."""
+    assert TermcapResponse.hex_decode('c0c1') == ''
+
+
+def test_supported_with_capabilities():
+    """Supported response exposes capabilities via dict-like API."""
+    caps = {'TN': 'xterm-256color', 'colors': '256'}
+    resp = TermcapResponse(supported=True, capabilities=caps)
+    assert resp.supported is True
+    assert resp.terminal_name == 'xterm-256color'
+    assert resp.num_colors == 256
+    assert len(resp) == 2
+    assert 'TN' in resp
+    assert resp['TN'] == 'xterm-256color'
+    assert resp.get('missing') is None
+    assert resp.get('missing', 'default') == 'default'
+
+
+def test_unsupported():
+    """Unsupported response returns None for all properties."""
+    resp = TermcapResponse(supported=False)
+    assert resp.supported is False
+    assert resp.terminal_name is None
+    assert resp.num_colors is None
+    assert len(resp) == 0
+
+
+def test_num_colors_non_integer():
+    """Non-integer colors value returns None."""
+    resp = TermcapResponse(supported=True, capabilities={'colors': 'abc'})
+    assert resp.num_colors is None
+
+
+def test_repr():
+    """String representation includes key attributes."""
+    resp = TermcapResponse(supported=True, capabilities={'TN': 'xterm'})
+    assert 'supported=True' in repr(resp)
+    assert 'TN' in repr(resp)
+
+
+def test_getitem_keyerror():
+    """Missing key raises KeyError."""
+    resp = TermcapResponse(supported=True, capabilities={})
+    with pytest.raises(KeyError):
+        _ = resp['nonexistent']
+
+
+def test_defaults_empty_capabilities():
+    """Default capabilities is empty dict."""
+    resp = TermcapResponse(supported=True)
+    assert resp.capabilities == {}
+    assert len(resp) == 0
+
+
+def test_make_jinxed_capabilities_classifies_by_type():
+    """Bool, num, and str caps are routed to correct output dicts."""
+    resp = TermcapResponse(supported=True, capabilities={
+        'am': '',          # empty value + in BOOL_CAPS -> bool_caps
+        'colors': '256',   # digit value + in NUM_CAPS -> num_caps
+        'TN': 'xterm',     # non-empty + not in NUM_CAPS -> str_caps
+    })
+    result = resp.make_jinxed_capabilities()
+    assert 'am' in result['bool_caps']
+    assert result['num_caps'] == {'colors': 256}
+    assert result['str_caps'] == {'TN': 'xterm'}
+
+
+def test_make_jinxed_capabilities_non_digit_num_value():
+    """Non-digit NUM_CAPS value is skipped."""
+    resp = TermcapResponse(supported=True, capabilities={
+        'colors': 'not_a_number',
+    })
+    result = resp.make_jinxed_capabilities()
+    assert 'colors' not in result['num_caps']
+
+
+def test_make_jinxed_capabilities_skips_rgb():
+    """RGB capability is excluded from num_caps."""
+    resp = TermcapResponse(supported=True, capabilities={
+        'RGB': '8',
+    })
+    result = resp.make_jinxed_capabilities()
+    assert 'RGB' not in result['num_caps']
+
+
+def test_xtgettcap_probe_oserror():
+    """XTGETTCAP probe OSError is recorded in errors list."""
+    with mock.patch('os.isatty', return_value=True), \
+        mock.patch.object(Terminal, '_xtgettcap_batch',
+                          side_effect=OSError('broken pipe')):
+        t = Terminal(stream=sys.__stdout__, force_styling=True)
+        assert any('OSError' in err for err in t.errors)
+
+
+def test_init_descriptor_stdout_valueerror():
+    """ValueError from sys.__stdout__.fileno() is recorded in errors."""
+    mock_term = mock.MagicMock()
+    mock_term.tigetnum.return_value = 0
+    with mock.patch.object(sys.__stdout__, 'fileno',
+                           side_effect=ValueError('detached stdout')), \
+            mock.patch('blessed.terminal.jinxed.Terminal', return_value=mock_term):
+        t = Terminal(stream=io.StringIO(), force_styling=True)
+        assert any('stdout may be detached or closed' in err for err in t.errors)
+        assert t.number_of_colors == 0
+
+
+@pytest.mark.parametrize('value,expected', [
+    (r'\E', '\x1b'),
+    (r'\n', '\n'),
+    (r'\t', '\t'),
+    (r'\r', '\r'),
+    (r'\b', '\b'),
+    (r'\f', '\f'),
+    (r'\\', '\\'),
+    (r'\^', '^'),
+    (r'\:', ':'),
+])
+def test_unescape_terminfo_backslash_escapes(value, expected):
+    r"""Backslash escapes are unescaped."""
+    assert TermcapResponse.unescape_terminfo(value) == expected
+
+
+@pytest.mark.parametrize('value,expected', [
+    (r'\033', '\x1b'),
+    (r'\101\102', 'AB'),
+    (r'\000', '\x00'),
+    (r'\141', 'a'),
+])
+def test_unescape_terminfo_octal_escapes(value, expected):
+    r"""Octal \NNN escapes are decoded."""
+    assert TermcapResponse.unescape_terminfo(value) == expected
+
+
+@pytest.mark.parametrize('value,expected', [
+    ('^A', '\x01'),
+    ('^Z', '\x1a'),
+    ('^?', '\x7f'),
+    ('^_', '\x1f'),
+])
+def test_unescape_terminfo_control_notation(value, expected):
+    """^X control-character and ^? DEL notation."""
+    assert TermcapResponse.unescape_terminfo(value) == expected
+
+
+def test_unescape_terminfo_mixed():
+    """Mixed escape sequences."""
+    result = TermcapResponse.unescape_terminfo(r'\E[5m\E[m')
+    assert result == '\x1b[5m\x1b[m'
+
+
+def test_unescape_terminfo_no_escapes():
+    """String without escapes is unchanged."""
+    assert TermcapResponse.unescape_terminfo('hello') == 'hello'
+
+
+@pytest.mark.parametrize('value,expected', [
+    (r'\9', r'\9'),
+    ('^0', '^0'),
+])
+def test_unescape_terminfo_pass_through(value, expected):
+    """Escape-like sequences that are not valid escapes pass through unchanged."""
+    assert TermcapResponse.unescape_terminfo(value) == expected
+
+
+@pytest.mark.parametrize('feature_str,expected', [
+    ('T2CwBF', {
+        'truecolor': 2,
+        'clipboard_writable': True,
+        'bracketed_paste': True,
+        'focus_reporting': True,
+    }),
+    ('', {}),
+    ('ZZZ', {}),
+    ('Sc', {'decscusr': 0}),
+    ('Sc3', {'decscusr': 3}),
+    ('MSxNo', {
+        'mouse': True,
+        'sixel': True,
+        'notifications': True,
+    }),
+    ('UAwUw6', {
+        'unicode_basic': True,
+        'ambiguous_wide': True,
+        'unicode_widths': 6,
+    }),
+    ('LrGsGoSyH', {
+        'decslrm': True,
+        'strikethrough': True,
+        'overline': True,
+        'sync': True,
+        'hyperlinks': True,
+    }),
+    ('Ts2', {'titles': 2}),
+])
+def test_parse_feature_string(feature_str, expected):
+    """Parse iTerm2 feature string into dict."""
+    result = ITerm2Capabilities.parse_feature_string(feature_str)
+    assert result == expected
+
+
+def test_iterm2_supported_capabilities_response():
+    """Supported response with features."""
+    features = {'truecolor': 2, 'sixel': True}
+    caps = ITerm2Capabilities(supported=True, features=features)
+    assert caps.supported is True
+    assert caps.features == features
+
+
+def test_iterm2_unsupported():
+    """Unsupported response has empty features."""
+    caps = ITerm2Capabilities(supported=False)
+    assert caps.supported is False
+    assert caps.features == {}
+
+
+def test_iterm2_repr():
+    """String representation includes key attributes."""
+    caps = ITerm2Capabilities(
+        supported=True, features={'truecolor': 2})
+    r = repr(caps)
+    assert 'supported=True' in r
+    assert 'truecolor' in r
+
+
+def test_get_xtgettcap_not_a_tty():
+    """Returns None when not a TTY."""
+    term = TestTerminal(stream=io.StringIO(), force_styling=True,
+                        is_a_tty=False)
+    assert term.get_xtgettcap(timeout=0.01) is None
+
+
+def test_does_xtgettcap_not_a_tty():
+    """does_xtgettcap returns False when not a TTY."""
+    term = TestTerminal(stream=io.StringIO(), force_styling=True,
+                        is_a_tty=False)
+    assert term.does_xtgettcap(timeout=0.01) is False
+
+
+def test_get_xtgettcap_cached_result():
+    """Returns cached result without re-querying."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+
+    cached = TermcapResponse(supported=True,
+                             capabilities={'TN': 'test'})
+    term._xtgettcap_cache = cached
+
+    result = term.get_xtgettcap(caps=['TN'])
+    assert result is not cached
+    assert result.supported is True
+    assert result['TN'] == 'test'
+
+
+def test_get_xtgettcap_sticky_failure():
+    """Returns None after first query failure."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._xtgettcap_cache = TermcapResponse(supported=False)
+
+    result = term.get_xtgettcap()
+    assert result is None
+
+
+def test_get_xtgettcap_force_bypasses_cache():
+    """force=True bypasses both cache and sticky failure."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+
+    cached = TermcapResponse(supported=True,
+                             capabilities={'TN': 'old'})
+    term._xtgettcap_cache = cached
+
+    result = term.get_xtgettcap(timeout=0.01, force=True)
+    assert result is not None
+    assert result.supported
+
+
+def test_parse_xtgettcap_responses():
+    """Parse multiple DCS +r responses."""
+    raw = (
+        '\x1bP1+r544e=787465726d\x1b\\'
+        '\x1bP1+r636f6c6f7273=323536\x1b\\'
+        '\x1bP0+r626365\x1b\\'
+    )
+    capabilities = TermcapResponse.parse_capabilities(raw)
+    assert capabilities['TN'] == 'xterm'
+    assert capabilities['colors'] == '256'
+    assert 'bce' not in capabilities
+
+
+def test_parse_xtgettcap_boolean_capability():
+    """Parse DCS +r boolean capability."""
+    raw = '\x1bP1+r626365\x1b\\'
+    capabilities = TermcapResponse.parse_capabilities(raw)
+    assert capabilities['bce'] == ''
+
+
+def test_does_xtgettcap_with_cached():
+    """does_xtgettcap returns True with cached supported result."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._xtgettcap_cache = TermcapResponse(
+        supported=True, capabilities={'TN': 'test'})
+
+    assert term.does_xtgettcap(timeout=0.1) is True
+
+
+def test_does_xtgettcap_unsupported():
+    """does_xtgettcap returns False after probe failure."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._xtgettcap_cache = TermcapResponse(supported=False)
+
+    assert term.does_xtgettcap() is False
+
+
+def test_get_xtgettcap_caps_all_in_cache():
+    """caps= with all names already in cache returns filtered copy."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    cached = TermcapResponse(supported=True,
+                             capabilities={'TN': 'xterm', 'FAKE_CAP': 'FAKE_VAL'})
+    term._xtgettcap_cache = cached
+    result = term.get_xtgettcap(caps=['FAKE_CAP'])
+    assert result is not cached
+    assert result['FAKE_CAP'] == 'FAKE_VAL'
+
+
+def test_get_xtgettcap_caps_incremental_queries_missing():
+    """caps= with names absent from cache queries only missing ones."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._xtgettcap_cache = TermcapResponse(
+        supported=True, capabilities={'TN': 'xterm'})
+    hex_fake = TermcapResponse.hex_encode('FAKE_CAP')
+    term.ungetch(
+        f'\x1bP1+r{hex_fake}=46414b455f56414c\x1b\\'
+        '\x1b[10;20R')
+    result = term.get_xtgettcap(caps=['FAKE_CAP'], timeout=0.1)
+    assert result['FAKE_CAP'] == 'FAKE_VAL'
+    assert 'TN' not in result.capabilities
+    assert 'FAKE_CAP' in term._xtgettcap_cache.capabilities
+    assert term._xtgettcap_cache.capabilities['TN'] == 'xterm'
+
+
+def test_get_xtgettcap_caps_force_queries_all():
+    """force=True with caps= queries only the specified caps."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._xtgettcap_cache = TermcapResponse(
+        supported=True, capabilities={'TN': 'old'})
+    hex_fake = TermcapResponse.hex_encode('FAKE_CAP')
+    term.ungetch(
+        f'\x1bP1+r{hex_fake}=46414b455f56414c\x1b\\'
+        '\x1b[10;20R')
+    result = term.get_xtgettcap(timeout=0.1, force=True, caps=['FAKE_CAP'])
+    assert result['FAKE_CAP'] == 'FAKE_VAL'
+
+
+def test_get_xtgettcap_caps_ignores_sticky_failure():
+    """caps= with sticky failure still attempts query."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    hex_fake = TermcapResponse.hex_encode('FAKE_CAP')
+    term.ungetch(
+        f'\x1bP1+r{hex_fake}=46414b455f56414c\x1b\\'
+        '\x1b[10;20R')
+    result = term.get_xtgettcap(timeout=0.1, caps=['FAKE_CAP'])
+    assert result is not None
+
+
+def test_get_xtgettcap_batch_non_line_buffered():
+    """_xtgettcap_batch with _line_buffered=False skips cbreak context manager."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._line_buffered = False
+    hex_fake = TermcapResponse.hex_encode('FAKE_CAP')
+    term.ungetch(
+        f'\x1bP1+r{hex_fake}=46414b455f56414c\x1b\\'
+        '\x1b[10;20R')
+    result = term.get_xtgettcap(timeout=0.1, force=True, caps=['FAKE_CAP'])
+    assert result is not None
+    assert result['FAKE_CAP'] == 'FAKE_VAL'
+
+
+def test_xtgettcap_batch_empty_caps():
+    """_xtgettcap_batch returns None when caps list is empty."""
+    term = TestTerminal(stream=io.StringIO(), force_styling=True)
+    result = term._xtgettcap_batch([], timeout=0.01)
+    assert result is None
+
+
+def test_get_xtgettcap_all_parameter():
+    """No caps specified queries all standard XTGETTCAP capabilities."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    hex_tn = TermcapResponse.hex_encode('TN')
+    hex_co = TermcapResponse.hex_encode('colors')
+    term.ungetch(
+        f'\x1bP1+r{hex_tn}=787465726d\x1b\\'
+        f'\x1bP1+r{hex_co}=323536\x1b\\'
+        '\x1b[10;20R'
+        '\x1b[11;21R')
+    result = term.get_xtgettcap(timeout=0.1)
+    assert result is not None
+    assert result['TN'] == 'xterm'
+    assert result['colors'] == '256'
+
+
+def test_get_xtgettcap_none_sentinel_not_in_returned_response():
+    """None-valued caps in cache are filtered from returned response."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._xtgettcap_cache = TermcapResponse(
+        supported=True,
+        capabilities={'TN': 'xterm', 'FAKE_CAP': None})
+    result = term.get_xtgettcap(caps=['TN', 'FAKE_CAP'])
+    assert 'TN' in result.capabilities
+    assert 'FAKE_CAP' not in result.capabilities
+
+
+def test_get_xtgettcap_none_sentinel_internal_cache_retains_none():
+    """Internal cache retains None sentinel for absent caps."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._xtgettcap_cache = TermcapResponse(
+        supported=True,
+        capabilities={'TN': 'xterm'})
+    hex_fake = TermcapResponse.hex_encode('FAKE_CAP')
+    term.ungetch(
+        f'\x1bP1+r{hex_fake}=\x1b\\'
+        '\x1b[10;20R')
+    result = term.get_xtgettcap(caps=['FAKE_CAP'], timeout=0.1)
+    assert 'FAKE_CAP' in result.capabilities
+
+
+def test_get_xtgettcap_absent_cap_not_requeried():
+    """Absent caps are not re-queried on subsequent calls."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._xtgettcap_cache = TermcapResponse(
+        supported=True,
+        capabilities={'TN': 'xterm', 'Ms': None})
+    result = term.get_xtgettcap(caps=['Ms'], timeout=0.01)
+    assert result is not None
+    assert result.supported
+    assert 'Ms' not in result.capabilities
+    assert term._xtgettcap_cache.capabilities['Ms'] is None
+
+
+def test_get_xtgettcap_no_args():
+    """get_xtgettcap() with no caps queries all standard caps."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    hex_tn = TermcapResponse.hex_encode('TN')
+    hex_co = TermcapResponse.hex_encode('colors')
+    term.ungetch(
+        f'\x1bP1+r{hex_tn}=787465726d\x1b\\'
+        f'\x1bP1+r{hex_co}=323536\x1b\\'
+        '\x1b[10;20R'
+        '\x1b[11;21R')
+    result = term.get_xtgettcap(timeout=0.1)
+    assert result is not None
+    assert result['TN'] == 'xterm'
+    assert result['colors'] == '256'
+
+
+def test_filter_xtgettcap_response_removes_none_values():
+    """_filter_xtgettcap_response removes None-valued caps."""
+    tc = TermcapResponse(
+        supported=True,
+        capabilities={'TN': 'xterm', 'RGB': None, 'colors': '256'})
+    result = Terminal._filter_xtgettcap_response(tc)
+    assert 'TN' in result.capabilities
+    assert 'colors' in result.capabilities
+    assert 'RGB' not in result.capabilities
+    assert result.supported is True
+
+
+def test_styled_underlines_supported():
+    """Returns True when Smulx is in XTGETTCAP capabilities."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._xtgettcap_cache = TermcapResponse(
+        supported=True,
+        capabilities={'TN': 'xterm', 'Smulx': '\x1b[4:%p1%dm'})
+    assert term.does_styled_underlines() is True
+
+
+def test_styled_underlines_unsupported():
+    """Returns False when Smulx is not in capabilities."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._xtgettcap_cache = TermcapResponse(
+        supported=True, capabilities={'TN': 'xterm'})
+    assert term.does_styled_underlines(timeout=0.1) is False
+
+
+def test_styled_underlines_no_xtgettcap():
+    """Returns False when XTGETTCAP is not supported."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._xtgettcap_cache = TermcapResponse(supported=False)
+    assert term.does_styled_underlines(timeout=0.1) is False
+
+
+def test_colored_underlines_supported():
+    """Returns True when Setulc is in XTGETTCAP capabilities."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._xtgettcap_cache = TermcapResponse(
+        supported=True,
+        capabilities={'Setulc': '\x1b[58;2;%p1%d;%p2%d;%p3%dm'})
+    assert term.does_colored_underlines() is True
+
+
+def test_colored_underlines_unsupported():
+    """Returns False when Setulc is not in capabilities."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._xtgettcap_cache = TermcapResponse(
+        supported=True, capabilities={'TN': 'xterm'})
+    assert term.does_colored_underlines(timeout=0.1) is False
+
+
+def test_osc52_clipboard_not_a_tty():
+    """Returns False when not a TTY."""
+    term = TestTerminal(stream=io.StringIO(), force_styling=True,
+                        is_a_tty=False)
+    assert term.does_osc52_clipboard(timeout=0.01) is False
+
+
+def test_osc52_clipboard_cached_result():
+    """Returns cached result without re-querying."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._osc52_clipboard_supported = True
+    assert term.does_osc52_clipboard() is True
+
+
+def test_osc52_clipboard_force_bypasses_cache():
+    """force=True bypasses cached result."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._osc52_clipboard_supported = True
+    result = term.does_osc52_clipboard(timeout=0.01, force=True)
+    assert result is False
+
+
+def test_color_scheme_not_a_tty():
+    """Returns None when not a TTY."""
+    term = TestTerminal(stream=io.StringIO(), force_styling=True,
+                        is_a_tty=False)
+    assert term.get_color_scheme(timeout=0.01) is None
+
+
+def test_color_scheme_negative_cache():
+    """Returns None immediately when previously unsupported."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._color_scheme_supported = False
+    assert term.get_color_scheme() is None
+
+
+def test_color_scheme_force_bypasses_negative_cache():
+    """force=True bypasses negative cache."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._color_scheme_supported = False
+    result = term.get_color_scheme(timeout=0.01, force=True)
+    assert result is None
+
+
+def test_kitty_query_not_a_tty():
+    """Returns False when not a TTY."""
+    term = TestTerminal(stream=io.StringIO(), force_styling=True,
+                        is_a_tty=False)
+    assert term.does_kitty_query(timeout=0.01) is False
+
+
+def test_kitty_query_cached_result():
+    """Returns cached result without re-querying."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._xtgettcap_cache = TermcapResponse(
+        capabilities={'kitty-query-name': 'kitty'},
+        supported=True)
+    assert term.does_kitty_query() is True
+
+
+def test_kitty_query_force_bypasses_cache():
+    """force=True bypasses cached result."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, force_styling=True)
+    term._is_a_tty = True
+    term._xtgettcap_cache = TermcapResponse(
+        capabilities={'kitty-query-name': 'kitty'},
+        supported=True)
+    result = term.does_kitty_query(timeout=0.01, force=True)
+    assert result is True
 
 
 pytestmark_pty = pytest.mark.skipif(
@@ -495,40 +670,35 @@ pytestmark_pty = pytest.mark.skipif(
 def test_get_xtgettcap_full_success():
     """Phase 1 probe + Phase 2 batch query returns parsed capabilities."""
     def child(term):
-        # Phase 1: DCS +r response for probe cap "TN" + CPR boundary
-        # Phase 2: DCS +r response for "Co" (colors=256), read by flushinp
         probe_resp = '\x1bP1+r544e=787465726d\x1b\\'
         cpr = '\x1b[10;20R'
-        batch_resp = '\x1bP1+r436f=323536\x1b\\'
+        batch_resp = '\x1bP1+r636f6c6f7273=323536\x1b\\'
         term.ungetch(probe_resp + cpr + batch_resp)
-        result = term.get_xtgettcap(timeout=1)
+        result = term.get_xtgettcap(timeout=0.1, force=True)
         assert result is not None
         assert result.supported is True
         assert result['TN'] == 'xterm'
-        assert result['Co'] == '256'
-        assert term._xtgettcap_cache is result
+        assert result['colors'] == '256'
+        assert term._xtgettcap_cache is not None
         return b'OK'
 
     output = pty_test(child, parent_func=None,
-                      test_name='test_get_xtgettcap_full_success',
-                      _xtgettcap_data=NO_XTGETTCAP_DATA)
+                      test_name='test_get_xtgettcap_full_success')
     assert 'OK' in output
 
 
 @pytestmark_pty
-def test_get_xtgettcap_probe_failure():
-    """Phase 1 probe failure sets sticky flag and writes clear_eol."""
+def test_get_xtgettcap_batch_empty():
+    """Batch with CPR-only response returns supported=False."""
     def child(term):
-        # Only CPR, no DCS response -- probe fails
+        term._xtgettcap_cache = TermcapResponse(supported=False)
         term.ungetch('\x1b[10;20R')
-        result = term.get_xtgettcap(timeout=1)
+        result = term.get_xtgettcap(timeout=0.1)
         assert result is None
-        assert term._xtgettcap_first_query_failed is True
         return b'OK'
 
     output = pty_test(child, parent_func=None,
-                      test_name='test_get_xtgettcap_probe_failure',
-                      _xtgettcap_data=NO_XTGETTCAP_DATA)
+                      test_name='test_get_xtgettcap_batch_empty')
     assert 'OK' in output
 
 
@@ -538,32 +708,31 @@ def test_get_xtgettcap_batch_with_remaining_input():
     def child(term):
         probe_resp = '\x1bP1+r544e=787465726d\x1b\\'
         cpr = '\x1b[10;20R'
-        batch_resp = '\x1bP1+r436f=323536\x1b\\'
+        batch_resp = '\x1bP1+r636f6c6f7273=323536\x1b\\'
         keyboard_data = 'x'
         term.ungetch(probe_resp + cpr + batch_resp + keyboard_data)
-        result = term.get_xtgettcap(timeout=1)
+        result = term.get_xtgettcap(timeout=0.1, force=True)
         assert result is not None
         assert result['TN'] == 'xterm'
-        assert result['Co'] == '256'
+        assert result['colors'] == '256'
         with term.cbreak():
             inp = term.inkey(timeout=0)
             assert inp == 'x'
         return b'OK'
 
     output = pty_test(child, parent_func=None,
-                      test_name='test_get_xtgettcap_batch_with_remaining_input',
-                      _xtgettcap_data=NO_XTGETTCAP_DATA)
+                      test_name='test_get_xtgettcap_batch_with_remaining_input')
     assert 'OK' in output
 
 
 @pytestmark_pty
 def test_get_xtgettcap_batch_empty_flushinp():
-    """Phase 2 flushinp returns empty -- result has only probe capability."""
+    """Phase 2 flushinp returns empty."""
     def child(term):
         probe_resp = '\x1bP1+r544e=787465726d\x1b\\'
         cpr = '\x1b[10;20R'
         term.ungetch(probe_resp + cpr)
-        result = term.get_xtgettcap(timeout=0.01)
+        result = term.get_xtgettcap(timeout=0.01, force=True)
         assert result is not None
         assert result.supported is True
         assert result['TN'] == 'xterm'
@@ -571,8 +740,7 @@ def test_get_xtgettcap_batch_empty_flushinp():
         return b'OK'
 
     output = pty_test(child, parent_func=None,
-                      test_name='test_get_xtgettcap_batch_empty_flushinp',
-                      _xtgettcap_data=NO_XTGETTCAP_DATA)
+                      test_name='test_get_xtgettcap_batch_empty_flushinp')
     assert 'OK' in output
 
 
@@ -580,11 +748,10 @@ def test_get_xtgettcap_batch_empty_flushinp():
 def test_does_osc52_clipboard_via_da1():
     """OSC 52 detected via DA1 extension 52."""
     def child(term):
-        # DA1 with extension 52 (OSC 52 support)
         da1_resp = '\x1b[?64;1;4;52c'
         cpr = '\x1b[10;20R'
         term.ungetch(da1_resp + cpr)
-        result = term.does_osc52_clipboard(timeout=1)
+        result = term.does_osc52_clipboard(timeout=0.1)
         assert result is True
         assert term._osc52_clipboard_supported is True
         return b'OK'
@@ -601,23 +768,19 @@ def test_does_osc52_clipboard_via_xtgettcap():
         hex_tn = TermcapResponse.hex_encode('TN')
         hex_ms = TermcapResponse.hex_encode('Ms')
         ms_val = TermcapResponse.hex_encode(r'\e]52;%p1%s;%p2%s\007')
-        # DA1 without extension 52, so DA1 path returns False
         da1_resp = '\x1b[?64;1;4c'
         da1_cpr = '\x1b[10;20R'
-        # XTGETTCAP probe: "TN" capability
         probe_resp = f'\x1bP1+r{hex_tn}=787465726d\x1b\\'
         tcap_cpr = '\x1b[11;21R'
-        # batch query: "Ms" capability
         batch_resp = f'\x1bP1+r{hex_ms}={ms_val}\x1b\\'
         term.ungetch(da1_resp + da1_cpr + probe_resp + tcap_cpr + batch_resp)
-        result = term.does_osc52_clipboard(timeout=1)
+        result = term.does_osc52_clipboard(timeout=0.1, force=True)
         assert result is True
         assert term._osc52_clipboard_supported is True
         return b'OK'
 
     output = pty_test(child, parent_func=None,
-                      test_name='test_does_osc52_clipboard_via_xtgettcap',
-                      _xtgettcap_data=NO_XTGETTCAP_DATA)
+                      test_name='test_does_osc52_clipboard_via_xtgettcap')
     assert 'OK' in output
 
 
@@ -625,13 +788,11 @@ def test_does_osc52_clipboard_via_xtgettcap():
 def test_does_osc52_clipboard_unsupported():
     """OSC 52 not detected when neither DA1 nor XTGETTCAP report it."""
     def child(term):
-        # DA1 without extension 52
         da1_resp = '\x1b[?64;1;4c'
         da1_cpr = '\x1b[10;20R'
-        # XTGETTCAP probe fails (no DCS response)
         tcap_cpr = '\x1b[11;21R'
         term.ungetch(da1_resp + da1_cpr + tcap_cpr)
-        result = term.does_osc52_clipboard(timeout=1)
+        result = term.does_osc52_clipboard(timeout=0.1)
         assert result is False
         assert term._osc52_clipboard_supported is False
         return b'OK'
@@ -685,7 +846,7 @@ def test_clipboard_paste_success(terminator):
     def child(term):
         osc52_resp = '\x1b]52;c;SGVsbG8=' + terminator
         term.ungetch(osc52_resp)
-        result = term.clipboard_paste(timeout=1)
+        result = term.clipboard_paste(timeout=0.1)
         assert result == 'Hello'
         return b'OK'
 
@@ -701,7 +862,7 @@ def test_clipboard_paste_empty(terminator):
     def child(term):
         osc52_resp = '\x1b]52;c;' + terminator
         term.ungetch(osc52_resp)
-        result = term.clipboard_paste(timeout=1)
+        result = term.clipboard_paste(timeout=0.1)
         assert result == ''
         return b'OK'
 
@@ -730,7 +891,7 @@ def test_clipboard_paste_invalid_base64(terminator):
     def child(term):
         osc52_resp = '\x1b]52;c;!!!not-base64!!!' + terminator
         term.ungetch(osc52_resp)
-        result = term.clipboard_paste(timeout=1)
+        result = term.clipboard_paste(timeout=0.1)
         assert result is None
         return b'OK'
 
@@ -746,7 +907,7 @@ def test_get_color_scheme_dark():
         resp = '\x1b[?997;1n'
         cpr = '\x1b[10;20R'
         term.ungetch(resp + cpr)
-        result = term.get_color_scheme(timeout=1)
+        result = term.get_color_scheme(timeout=0.1)
         assert result == 'dark'
         assert term._color_scheme_supported is True
         return b'OK'
@@ -763,7 +924,7 @@ def test_get_color_scheme_light():
         resp = '\x1b[?997;2n'
         cpr = '\x1b[10;20R'
         term.ungetch(resp + cpr)
-        result = term.get_color_scheme(timeout=1)
+        result = term.get_color_scheme(timeout=0.1)
         assert result == 'light'
         assert term._color_scheme_supported is True
         return b'OK'
@@ -779,7 +940,7 @@ def test_get_color_scheme_unsupported():
     def child(term):
         cpr = '\x1b[10;20R'
         term.ungetch(cpr)
-        result = term.get_color_scheme(timeout=1)
+        result = term.get_color_scheme(timeout=0.1)
         assert result is None
         return b'OK'
 
@@ -790,20 +951,24 @@ def test_get_color_scheme_unsupported():
 
 @pytestmark_pty
 def test_does_kitty_query_supported():
-    """Kitty query detected from DCS 1+r response."""
+    """Kitty query extensions detected from DCS 1+r response."""
     def child(term):
         capname = 'kitty-query-name'
         hex_cap = TermcapResponse.hex_encode(capname)
-        resp = f'\x1bP1+r{hex_cap}=1\x1b\\'
+        hex_val = TermcapResponse.hex_encode('kitty')
+        resp = f'\x1bP1+r{hex_cap}={hex_val}\x1b\\'
         cpr = '\x1b[10;20R'
         term.ungetch(resp + cpr)
-        result = term.does_kitty_query(timeout=1)
-        assert result is True
+        result = term.does_kitty_query(timeout=0.1)
+        assert result is True, (term._xtgettcap_cache, term.does_styling)
+        assert term._xtgettcap_cache is not None
+        assert term._xtgettcap_cache.capabilities.get('kitty-query-name') == 'kitty'
         return b'OK'
 
     output = pty_test(child, parent_func=None,
                       test_name='test_does_kitty_query_supported',
-                      _xtgettcap_data=NO_XTGETTCAP_DATA)
+                      _xtgettcap_data=TermcapResponse(supported=True),
+                      )
     assert 'OK' in output
 
 
@@ -813,7 +978,7 @@ def test_does_kitty_query_unsupported():
     def child(term):
         cpr = '\x1b[10;20R'
         term.ungetch(cpr)
-        result = term.does_kitty_query(timeout=1)
+        result = term.does_kitty_query(timeout=0.1)
         assert result is False
         return b'OK'
 
@@ -824,14 +989,14 @@ def test_does_kitty_query_unsupported():
 
 @pytestmark_pty
 def test_does_kitty_query_rejected():
-    """Kitty query returns False on DCS 0+r (not recognized)."""
+    """Kitty query returns False on DCS 0+r."""
     def child(term):
         capname = 'kitty-query-name'
         hex_cap = TermcapResponse.hex_encode(capname)
         resp = f'\x1bP0+r{hex_cap}\x1b\\'
         cpr = '\x1b[10;20R'
         term.ungetch(resp + cpr)
-        result = term.does_kitty_query(timeout=1)
+        result = term.does_kitty_query(timeout=0.1)
         assert result is False
         return b'OK'
 
@@ -841,143 +1006,161 @@ def test_does_kitty_query_rejected():
 
 
 @pytestmark_pty
-def test_does_decrqss_supported():
-    """DECRQSS detected from DCS 1 $ r response."""
+def test_terminal_init_xtgettcap_success():
+    """Terminal() init with real XTGETTCAP probe and batch succeeds."""
+    def parent(master_fd):
+        # Wait for child to emit queries (indicates it's past
+        # read_until_semaphore).  No need to drain stdout -- child's
+        # _read_until reads from stdin (what we write to master_fd),
+        # not stdout (what we read from master_fd).
+        stime = time.time()
+        while time.time() - stime < 0.5:
+            ready, _, _ = select.select([master_fd], [], [], 0.05)
+            if ready:
+                break
+        os.write(master_fd, b'\x1bP1+r636f6c6f7273=323536\x1b\\')
+        os.write(master_fd, b'\x1bP1+r524742=38\x1b\\')
+        os.write(master_fd, b'\x1bP1+r544e=787465726d\x1b\\')
+        os.write(master_fd, b'\x1b[10;20R')
+
     def child(term):
-        resp = '\x1bP1$r0m\x1b\\'
-        cpr = '\x1b[10;20R'
-        term.ungetch(resp + cpr)
-        result = term.does_decrqss(timeout=1)
-        assert result is True
-        assert term._decrqss_supported is True
+        assert term._xtgettcap_cache is not None
+        assert term._xtgettcap_cache.supported is True
+        assert term._xtgettcap_cache['TN'] == 'xterm'
+        assert term._xtgettcap_cache['colors'] == '256'
+        assert term._xtgettcap_cache['RGB'] == '8'
+        with term.cbreak():
+            leaked = term.inkey(timeout=0)
+            assert not leaked
         return b'OK'
 
-    output = pty_test(child, parent_func=None,
-                      test_name='test_does_decrqss_supported')
+    output = pty_test(child, parent,
+                      test_name='test_terminal_init_xtgettcap_success',
+                      _xtgettcap_data=NO_XTGETTCAP_DATA)
     assert 'OK' in output
 
 
 @pytestmark_pty
-def test_does_decrqss_unsupported():
-    """DECRQSS not detected when only CPR arrives."""
+def test_terminal_init_xtgettcap_timeout():
+    """Terminal() init with XTGETTCAP probe that times out."""
+
     def child(term):
-        cpr = '\x1b[10;20R'
-        term.ungetch(cpr)
-        result = term.does_decrqss(timeout=1)
-        assert result is False
+        assert term._xtgettcap_cache is not None
+        assert term._xtgettcap_cache.supported is False
         return b'OK'
 
     output = pty_test(child, parent_func=None,
-                      test_name='test_does_decrqss_unsupported')
+                      test_name='test_terminal_init_xtgettcap_timeout',
+                      _xtgettcap_data=NO_XTGETTCAP_DATA,
+                      _xtgettcap_timeout=0.01)
     assert 'OK' in output
 
 
 @pytestmark_pty
-def test_does_decrqss_invalid():
-    """DECRQSS returns False on DCS 0 $ r (invalid request)."""
+def test_terminal_init_xtgettcap_unsupported():
+    """Terminal() init with XTGETTCAP probe that gets CPR-only response."""
+    def parent(master_fd):
+        data = b''
+        stime = time.time()
+        while b'\x1b[6n' not in data:
+            remaining = 2.0 - (time.time() - stime)
+            if remaining <= 0:
+                break
+            ready, _, _ = select.select([master_fd], [], [], remaining)
+            if ready:
+                data += os.read(master_fd, 4096)
+        # Send only CPR, no XTGETTCAP responses -- terminal does not support it.
+        os.write(master_fd, b'\x1b[10;20R')
+
     def child(term):
-        resp = '\x1bP0$r\x1b\\'
-        cpr = '\x1b[10;20R'
-        term.ungetch(resp + cpr)
-        result = term.does_decrqss(timeout=1)
-        assert result is False
+        assert term._xtgettcap_cache is not None
+        assert term._xtgettcap_cache.supported is False
         return b'OK'
 
-    output = pty_test(child, parent_func=None,
-                      test_name='test_does_decrqss_invalid')
+    output = pty_test(child, parent,
+                      test_name='test_terminal_init_xtgettcap_unsupported',
+                      _xtgettcap_data=NO_XTGETTCAP_DATA)
     assert 'OK' in output
 
 
-@pytestmark_pty
-def test_get_decrqss_sgr():
-    """get_decrqss returns SGR parameter value with setting_id stripped."""
-    def child(term):
-        resp = '\x1bP1$r0m\x1b\\'
-        cpr = '\x1b[10;20R'
-        term.ungetch(resp + cpr)
-        result = term.get_decrqss(Decrqss.SGR, timeout=1)
-        assert result == '0'
-        return b'OK'
-
-    output = pty_test(child, parent_func=None,
-                      test_name='test_get_decrqss_sgr')
-    assert 'OK' in output
+def test_init_cache_populated_from_xtgettcap_data():
+    """Injected XTGETTCAP data populates _xtgettcap_cache."""
+    xt_data = TermcapResponse(
+        supported=True, capabilities={'TN': 'xterm', 'colors': '256'})
+    term = TestTerminal(stream=io.StringIO(), force_styling=True,
+                        kind=None, _xtgettcap_data=xt_data)
+    assert term._xtgettcap_cache is not None
+    assert term._xtgettcap_cache.capabilities['colors'] == '256'
 
 
-@pytestmark_pty
-def test_get_decrqss_sgr_with_attrs():
-    """get_decrqss returns compound SGR values."""
-    def child(term):
-        resp = '\x1bP1$r1;4;38;5;12m\x1b\\'
-        cpr = '\x1b[10;20R'
-        term.ungetch(resp + cpr)
-        result = term.get_decrqss(Decrqss.SGR, timeout=1)
-        assert result == '1;4;38;5;12'
-        return b'OK'
-
-    output = pty_test(child, parent_func=None,
-                      test_name='test_get_decrqss_sgr_with_attrs')
-    assert 'OK' in output
+def test_init_kind_set_from_xtgettcap_tn():
+    """XTGETTCAP TN capability updates terminal kind."""
+    xt_data = TermcapResponse(
+        supported=True, capabilities={'TN': 'foot'})
+    term = TestTerminal(stream=io.StringIO(), force_styling=True,
+                        kind=None, _xtgettcap_data=xt_data)
+    assert term.kind == 'foot'
 
 
-@pytestmark_pty
-def test_get_decrqss_cursor_style():
-    """get_decrqss returns cursor style value for DECSCUSR."""
-    def child(term):
-        resp = '\x1bP1$r2 q\x1b\\'
-        cpr = '\x1b[10;20R'
-        term.ungetch(resp + cpr)
-        result = term.get_decrqss(Decrqss.DECSCUSR, timeout=1)
-        assert result == '2'
-        return b'OK'
-
-    output = pty_test(child, parent_func=None,
-                      test_name='test_get_decrqss_cursor_style')
-    assert 'OK' in output
+def test_init_cache_unsupported_from_data():
+    """Injected unsupported TermcapResponse stored in cache."""
+    xt_data = TermcapResponse(supported=False)
+    term = TestTerminal(stream=io.StringIO(), force_styling=True,
+                        kind=None, _xtgettcap_data=xt_data)
+    assert term._xtgettcap_cache is not None
+    assert term._xtgettcap_cache.supported is False
 
 
-@pytestmark_pty
-def test_get_decrqss_scroll_region():
-    """get_decrqss returns top/bottom margins for DECSTBM."""
-    def child(term):
-        resp = '\x1bP1$r1;24r\x1b\\'
-        cpr = '\x1b[10;20R'
-        term.ungetch(resp + cpr)
-        result = term.get_decrqss(Decrqss.DECSTBM, timeout=1)
-        assert result == '1;24'
-        return b'OK'
-
-    output = pty_test(child, parent_func=None,
-                      test_name='test_get_decrqss_scroll_region')
-    assert 'OK' in output
+def test_init_cache_unsupported_from_probe_timeout():
+    """XTGETTCAP probe timeout sets supported=False in cache."""
+    term = TestTerminal(stream=io.StringIO(), force_styling=True,
+                        kind=None, _xtgettcap_data=None, is_a_tty=True)
+    assert term._xtgettcap_cache is not None
+    assert term._xtgettcap_cache.supported is False
 
 
-@pytestmark_pty
-def test_get_decrqss_unsupported():
-    """get_decrqss returns None when terminal does not respond."""
-    def child(term):
-        cpr = '\x1b[10;20R'
-        term.ungetch(cpr)
-        result = term.get_decrqss(Decrqss.SGR, timeout=1)
-        assert result is None
-        return b'OK'
+@pytest.mark.parametrize('method,capabilities', [
+    ('does_styled_underlines', {'Smulx': '\x1b[4:%p1%dm'}),
+    ('does_colored_underlines', {'Setulc': '\x1b[58;2;%p1%d;%p2%d;%p3%dm'}),
+    ('does_xtgettcap', {'TN': 'xterm'}),
+])
+def test_force_bypasses_cache(method, capabilities):
+    """force=True causes re-query even with populated cache, returns False."""
+    term = TestTerminal(stream=io.StringIO(), force_styling=True)
+    term._is_a_tty = True
+    term._xtgettcap_cache = TermcapResponse(
+        supported=True, capabilities=capabilities)
+    result = getattr(term, method)(timeout=0.01, force=True)
+    assert result is True
 
-    output = pty_test(child, parent_func=None,
-                      test_name='test_get_decrqss_unsupported')
-    assert 'OK' in output
+
+@pytest.mark.parametrize('capabilities,expected_colors', [
+    ({'RGB': '8'}, 1 << 24),
+    ({'RGB': '8/8/8'}, 1 << 24),
+    ({}, 256),
+    ({'RGB': '4'}, 256),
+])
+def test_rgb_truecolor_detection(capabilities, expected_colors):
+    """XTGETTCAP RGB=8 sets number_of_colors to 1<<24."""
+    xt_data = TermcapResponse(supported=True, capabilities=capabilities)
+    with mock.patch.dict(os.environ, {}, clear=True):
+        term = Terminal(
+            kind='xterm-256color', force_styling=True,
+            _xtgettcap_data=xt_data)
+        assert term.number_of_colors == expected_colors
 
 
-@pytestmark_pty
-def test_get_decrqss_invalid():
-    """get_decrqss returns None on DCS 0 $ r (invalid request)."""
-    def child(term):
-        resp = '\x1bP0$r\x1b\\'
-        cpr = '\x1b[10;20R'
-        term.ungetch(resp + cpr)
-        result = term.get_decrqss(Decrqss.SGR, timeout=1)
-        assert result is None
-        return b'OK'
+def test_get_xtgettcap_applies_overlay_to_jinxed():
+    """get_xtgettcap() applies discovered caps to jinxed for property access."""
+    stream = io.StringIO()
+    term = TestTerminal(stream=stream, kind='vt220', force_styling=True)
+    term._is_a_tty = True
+    assert term.dim == ''
 
-    output = pty_test(child, parent_func=None,
-                      test_name='test_get_decrqss_invalid')
-    assert 'OK' in output
+    hex_dim = TermcapResponse.hex_encode('dim')
+    term.ungetch(
+        '\x1bP1+r' + hex_dim + '=1b5b326d\x1b\\'
+        '\x1b[10;20R')
+    result = term.get_xtgettcap(timeout=0.1, force=True, caps=['dim'])
+    assert result is not None
+    assert result['dim'] == '\x1b[2m'


### PR DESCRIPTION
Implement terminal capability discovery via XTGETTCAP (DCS +q).

- Add TermcapResponse.parse_capabilities(), make_jinxed_capabilities(),
  unescape_terminfo() for ghostty/kitty/foot terminfo-source values.
- Probe during __init__ for TN, RGB, colors, blink, sitm, ritm, cvvis,
  Smulx, Setulc, Ms.  Overlay discovered capabilities onto jinxed.
- Add get_xtgettcap(caps=...) for selective/incremental capability queries.
- Detect 24-bit color via COLORTERM and XTGETTCAP RGB/colors.
- Add number_of_colors XTGETTCAP resolution layers.
