### PR TITLE
24-bit color fix for 'ms-terminal' (vs. vtwin10)

### DIFF
--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -487,7 +487,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         # - COLORTERM environment value
         # - XTGETTCAP 'RGB' (24-bit), then 'colors'
         # - termcap 'colors' (jinxed)
-        # - Windows native console (vtwin10) gets 24-bit boost
+        # - Windows native console (vtwin10) and Microsoft Terminal (ms-terminal) get
+        #   24-bit boost
         self._color_distance_algorithm = 'cie2000'
         if not self.does_styling:
             return 0
@@ -503,7 +504,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             return int(xt_colors)
         _win_build = tuple(int(n) for n in platform.version().split('.')
                            if n.isdigit()) if IS_WINDOWS else 0
-        if IS_WINDOWS and self._kind == 'vtwin10' and _win_build >= (10, 0, 14931):
+        if IS_WINDOWS and self._kind in {'vtwin10', 'ms-terminal'} \
+                and _win_build >= (10, 0, 14931):
             # Windows 10 build 14931+ (2016) supports 24-bit color natively, but they do not set
             # COLORTERM. Older Windows releases and versions of ConHost.exe lack truecolor and fall
             # through to jinxed terminfo (8 or 16 colors).

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -14,9 +14,8 @@ Version History
     preferred terminal name ``TN``, 24-bit color support ``RGB``, number of colors ``Co``, `italic`,
     and `blink` capabilities.
 
-    This improves detection of ``TERM`` over protocols like serial that cannot forward any
-    environment variables, to determine 24-bit value for :attr:`~.Terminal.number_of_colors` when
-    using protocols like ssh that do not forward ``COLORTERM``.
+    This improves detection of Terminal `kind` and `number_of_colors` over protocols like serial
+    that cannot forward any environment variables or ssh that do not forward ``COLORTERM``.
   * introduced: A :exc:`UserWarning` is emitted when :meth:`~.Terminal.__getattr__` resolves an
     unknown terminal capability name, helping developers catch typos like ``term.bld``
     (missing ``bold``).  The warning can be suppressed by setting the environment variable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
 ]
 dependencies = [
     'wcwidth>=0.7',
-    'jinxed>=1.5',
+    'jinxed>=2.0,<3',
 ]
 dynamic = ['version']
 license = 'MIT'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1078,3 +1078,17 @@ def test_windows_vtwin10_truecolor():
             assert term.number_of_colors == 1 << 24
     finally:
         bt.IS_WINDOWS = original_is_windows
+
+
+def test_windows_ms_terminal_truecolor():
+    """__init__color_capabilities returns 1<<24 for ms-terminal on modern Windows."""
+    import blessed.terminal as bt
+    original_is_windows = bt.IS_WINDOWS
+    try:
+        bt.IS_WINDOWS = True
+        with mock.patch('platform.version', return_value='10.0.19041'), \
+                mock.patch('platform.system', return_value='Windows'):
+            term = TestTerminal(stream=StringIO(), kind='ms-terminal', force_styling=True)
+            assert term.number_of_colors == 1 << 24
+    finally:
+        bt.IS_WINDOWS = original_is_windows


### PR DESCRIPTION
Add 24-bit color support for kind='ms-terminal' 

Only 'vtwin10' was given the 24-bit color check, though it's not entirely clear when 'ms-terminal'
became an identity, I don't think it existed in 2016? Anyway we're long past for 24-bit colors.

https://devblogs.microsoft.com/commandline/24-bit-color-in-the-windows-console/
