### PR TITLE
bugfix get_location() return type in 1.40 release

### DIFF
--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -15,4 +15,4 @@ else:
 from blessed.line_editor import LineEditor, LineHistory
 
 __all__ = ('Terminal', 'LineEditor', 'LineHistory')
-__version__ = "1.40.0"
+__version__ = "1.41.0"

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -982,7 +982,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             # jinxed use %i in their u6 string (the standard behavior), so we unconditionally
             # convert to 0-based.  A pedantic impl would check for %i in the u6 capability, but no
             # terminal supoprted by blessed/jinxed uses 0-index, it was an ANSI standard, after all.
-            return (max(0, int(val) - 1) for val in match.groups())
+            return tuple(max(0, int(val) - 1) for val in match.groups())
 
         # Return an illegal value (-1) rather than a custom exception, developers should
         # check or filters, such as if (x, y) != (-1, -1) or max(0, y).

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,6 +2,9 @@
 
 Version History
 ===============
+1.41
+  * bugfix: :meth:`~.Terminal.get_location` broken in 1.40, returned a generator instead of a tuple.
+    :ghissue:`378`.
 
 1.40
   * improved: jinxed_ is **now required on all platforms**, providing a curses-free and

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -831,6 +831,17 @@ def test_get_location_always_decrements():
     assert col == 5
 
 
+def test_get_location_returns_tuple():
+    """get_location returns a tuple so callers can subscript it."""
+    term = TestTerminal(stream=StringIO(), force_styling=True)
+    term._is_a_tty = True
+    term.ungetch('\x1b[2;6R')
+    result = term.get_location(timeout=0.01)
+    assert isinstance(result, tuple)
+    assert result[0] == 1
+    assert result[1] == 5
+
+
 def test_split_seqs_maxsplit_with_xterm():
     """split_seqs maxsplit truncates remaining text."""
     term = TestTerminal(kind='xterm-256color', stream=StringIO(), force_styling=True)


### PR DESCRIPTION
bugfix get_location return type, as described in #378
