### PR TITLE
1.40 regression: do not ignore SIGTTOU

### DIFF
--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -15,4 +15,4 @@ else:
 from blessed.line_editor import LineEditor, LineHistory
 
 __all__ = ('Terminal', 'LineEditor', 'LineHistory')
-__version__ = "1.41.0"
+__version__ = "1.42.0"

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -3777,22 +3777,18 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
     @contextlib.contextmanager
     def _enter_termios_mode(self, setter: Callable[[int, int], None]
                             ) -> Generator[None, None, None]:
-        """Put the keyboard terminal into mode using 'setter', guarding against SIGTTOU."""
-        old_sigttou = signal.signal(signal.SIGTTOU, signal.SIG_IGN)
+        """Put the keyboard terminal into mode using 'setter'."""
+        save_mode = termios.tcgetattr(self._keyboard_fd)
+        save_line_buffered = self._line_buffered
+        setter(self._keyboard_fd, termios.TCSANOW)
         try:
-            save_mode = termios.tcgetattr(self._keyboard_fd)
-            save_line_buffered = self._line_buffered
-            setter(self._keyboard_fd, termios.TCSANOW)
-            try:
-                self._line_buffered = False
-                yield
-            finally:
-                termios.tcsetattr(self._keyboard_fd,
-                                  termios.TCSADRAIN,
-                                  save_mode)
-                self._line_buffered = save_line_buffered
+            self._line_buffered = False
+            yield
         finally:
-            signal.signal(signal.SIGTTOU, old_sigttou)
+            termios.tcsetattr(self._keyboard_fd,
+                              termios.TCSADRAIN,
+                              save_mode)
+            self._line_buffered = save_line_buffered
 
     @contextlib.contextmanager
     def raw(self) -> Generator[None, None, None]:

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -9,7 +9,6 @@ import base64
 import codecs
 import locale
 import select
-import signal
 import struct
 import asyncio
 import platform

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,6 +2,10 @@
 
 Version History
 ===============
+1.42
+  * bugfix: regression in :meth:`~.Terminal.cbreak` and :meth:`~.Terminal.raw` were not thread-safe
+    broken in versions 1.40 and 1.41, remove signal ignore of SIGTTOU :ghissue:`380`.
+
 1.41
   * bugfix: :meth:`~.Terminal.get_location` broken in 1.40, returned a generator instead of a tuple.
     :ghissue:`378`.

--- a/tests/test_full_keyboard.py
+++ b/tests/test_full_keyboard.py
@@ -725,32 +725,6 @@ def test_cbreak_with_has_tty():
     assert 'CBREAK_OK' in output or 'RESTORED' in output
 
 
-@pytest.mark.skipif(not TEST_KEYBOARD or IS_WINDOWS, reason="Requires TTY")
-@pytest.mark.parametrize("mode", ['cbreak', 'raw'])
-def test_termios_mode_ignores_sigttou(mode):
-    """cbreak() and raw() set SIGTTOU to SIG_IGN while termios mode is active.
-
-    When a process in a background process group calls tcgetattr() or
-    tcsetattr() on its controlling terminal, the kernel sends SIGTTOU,
-    whose default action is to stop the process.  _enter_termios_mode
-    guards against this by temporarily ignoring SIGTTOU.
-    """
-    def child(term):
-        ctx = getattr(term, mode)()
-        before = signal.getsignal(signal.SIGTTOU)
-        with ctx:
-            inside = signal.getsignal(signal.SIGTTOU)
-            assert inside == signal.SIG_IGN, (
-                f'SIGTTOU not ignored inside {mode}: {inside}')
-        after = signal.getsignal(signal.SIGTTOU)
-        assert after == before, (
-            f'SIGTTOU not restored after {mode}: before={before} after={after}')
-        return b'SIGTTOU_OK'
-
-    output = pty_test(child, test_name=f'test_{mode}_ignores_sigttou')
-    assert 'SIGTTOU_OK' in output
-
-
 def test_inkey_with_csi_sequence_triggers_latin1_decoding():
     """Test that CSI sequences trigger Latin1 decoding path in inkey()"""
     def child(term):


### PR DESCRIPTION
1.40 regression: don't try to ignore SIGTTOU, cbreak() wasn't "thread-safe"

https://github.com/jquast/blessed/issues/380
