### PR TITLE
bugfix leaked XTGETTCAP responses into inkey()

### DIFF
--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -15,4 +15,4 @@ else:
 from blessed.line_editor import LineEditor, LineHistory
 
 __all__ = ('Terminal', 'LineEditor', 'LineHistory')
-__version__ = "1.42.0"
+__version__ = "1.43.0"

--- a/blessed/_capabilities.py
+++ b/blessed/_capabilities.py
@@ -563,9 +563,12 @@ class TermcapResponse:
 
     # XTGETTCAP DCS response: DCS <valid>+r<hex-name>[=<hex-value>] ST
     #   valid=1: terminal supports this capability, value follows
-    #   valid=0: terminal does not support this capability (negative acknowledgement)
+    # valid=0: terminal does not support this capability (negative acknowledgement)
+    # The capability name is hex-encoded; VTE-based terminals (GNOME Terminal, et al.) send
+    # malformed ``\\x1bP0+r\\x1b\\\\`` (empty name) for unsupported capabilities, so we accept
+    # zero-or-more hex digits rather than requiring at least one.
     _RE_XTGETTCAP_RESPONSE: typing.ClassVar[typing.Pattern[str]] = re.compile(
-        r'\x1bP([01])\+r([0-9a-fA-F]+)(?:=([0-9a-fA-F]*))?\x1b\\')
+        r'\x1bP([01])\+r([0-9a-fA-F]*)(?:=([0-9a-fA-F]*))?\x1b\\')
 
     def __init__(self, supported: bool = False,
                  capabilities: Optional[Dict[str, str]] = None) -> None:

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,6 +2,10 @@
 
 Version History
 ===============
+1.43
+  * bugfix: regression of XTGETTCAP responses leaking into first call for empty/non-response
+    terminals (libvte/Gnome Terminal), :ghpull:`383`.
+
 1.42
   * bugfix: regression in :meth:`~.Terminal.cbreak` and :meth:`~.Terminal.raw` were not thread-safe
     broken in versions 1.40 and 1.41, remove signal ignore of SIGTTOU :ghissue:`380`.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,7 +4,7 @@ Version History
 ===============
 1.43
   * bugfix: regression of XTGETTCAP responses leaking into first call for empty/non-response
-    terminals (libvte/Gnome Terminal), :ghpull:`383`.
+    terminals (libvte/Gnome Terminal), in versions 1.40 to 1.42 :ghpull:`383`.
 
 1.42
   * bugfix: regression in :meth:`~.Terminal.cbreak` and :meth:`~.Terminal.raw` were not thread-safe

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -338,10 +338,13 @@ def test_parse_xtgettcap_boolean_capability():
 def test_parse_xtgettcap_malformed_empty_name():
     """Parse malformed DCS +r response with empty capability name (VTE/GNOME Terminal)."""
     raw = '\x1bP0+r\x1b\\'
-    capabilities = TermcapResponse.parse_capabilities(raw)
-    assert capabilities == {}
-    remaining = TermcapResponse._RE_XTGETTCAP_RESPONSE.sub('', raw)
-    assert remaining == ''
+    # parse_capabilities skips valid=0 responses.
+    assert not TermcapResponse.parse_capabilities(raw)
+    # The regex must match; sub() must consume the entire string.
+    assert TermcapResponse._RE_XTGETTCAP_RESPONSE.sub('', raw) == ''
+    # The regex must NOT consume unrelated text around the malformed response.
+    mixed = 'abc\x1bP0+r\x1b\\def'
+    assert TermcapResponse._RE_XTGETTCAP_RESPONSE.sub('', mixed) == 'abcdef'
 
 
 def test_does_xtgettcap_with_cached():

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -335,6 +335,15 @@ def test_parse_xtgettcap_boolean_capability():
     assert capabilities['bce'] == ''
 
 
+def test_parse_xtgettcap_malformed_empty_name():
+    """Parse malformed DCS +r response with empty capability name (VTE/GNOME Terminal)."""
+    raw = '\x1bP0+r\x1b\\'
+    capabilities = TermcapResponse.parse_capabilities(raw)
+    assert capabilities == {}
+    remaining = TermcapResponse._RE_XTGETTCAP_RESPONSE.sub('', raw)
+    assert remaining == ''
+
+
 def test_does_xtgettcap_with_cached():
     """does_xtgettcap returns True with cached supported result."""
     stream = io.StringIO()


### PR DESCRIPTION
With GNOME Terminal, some awful leaking of null XTGETTCAP responses are received into the next call to inkey():

        $ python bin/keyboard_kitty_simple.py
        Press and hold keys to see raw kitty keystrokes and their names (press 'q' to quit)
        kitty keyboard state: None
        name=KEY_ALT_SHIFT_P value=P kind=pressed, sequence='\x1bP'
        name=None value=0 kind=pressed, sequence='0'
        name=None value=+ kind=pressed, sequence='+'
        name=None value=r kind=pressed, sequence='r'
        name=KEY_ALT_\ value=\ kind=pressed, sequence='\x1b\\'
        name=KEY_ALT_SHIFT_P value=P kind=pressed, sequence='\x1bP'
        name=None value=0 kind=pressed, sequence='0'
        name=None value=+ kind=pressed, sequence='+'
        name=None value=r kind=pressed, sequence='r'
        name=KEY_ALT_\ value=\ kind=pressed, sequence='\x1b\\'
        name=KEY_ALT_SHIFT_P value=P kind=pressed, sequence='\x1bP'
        name=None value=0 kind=pressed, sequence='0'
        name=None value=+ kind=pressed, sequence='+'
        name=None value=r kind=pressed, sequence='r'
        name=KEY_ALT_\ value=\ kind=pressed, sequence='\x1b\\'
        name=KEY_ALT_SHIFT_P value=P kind=pressed, sequence='\x1bP'
        name=None value=0 kind=pressed, sequence='0'
        name=None value=+ kind=pressed, sequence='+'
        name=None value=r kind=pressed, sequence='r'
        name=KEY_ALT_\ value=\ kind=pressed, sequence='\x1b\\'
        name=KEY_ALT_SHIFT_P value=P kind=pressed, sequence='\x1bP'
        name=None value=0 kind=pressed, sequence='0'
        name=None value=+ kind=pressed, sequence='+'
        name=None value=r kind=pressed, sequence='r'
        name=KEY_ALT_\ value=\ kind=pressed, sequence='\x1b\\'
        name=KEY_ALT_SHIFT_P value=P kind=pressed, sequence='\x1bP'
        name=None value=0 kind=pressed, sequence='0'
        name=None value=+ kind=pressed, sequence='+'
        name=None value=r kind=pressed, sequence='r'
        name=KEY_ALT_\ value=\ kind=pressed, sequence='\x1b\\'
        name=KEY_ALT_SHIFT_P value=P kind=pressed, sequence='\x1bP'
        name=None value=0 kind=pressed, sequence='0'
        name=None value=+ kind=pressed, sequence='+'
        name=None value=r kind=pressed, sequence='r'
        name=KEY_ALT_\ value=\ kind=pressed, sequence='\x1b\\'

In this case, exactly 7 "no data" XTGETTCAP responses are received,
which is XTGETTCAP_INIT_CAPABILITIES: 10 - 7 = 3,
3 = colors, TN, and 'RGB', which do succeed.

`ungetch()` is done after XTGETTCAP for any data that does not match, to help ensure natural pass-through of terminal input during Terminal initialization, so inkey() gets it but should not.

We fix by changing only `_RE_GETTCAP_RESPONSE` for zero or more ``*`` instead of 1 or more ``+`` matcher on the hex sequence that is missing by libvte, so they are "consumed" but otherwise have no effect