### PR TITLE
Improve Terminal() init speed for 0,0 winsz

### DIFF
--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -303,6 +303,16 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         """Probe for core XTGETTCAP capabilities."""
         _xtgettcap_cache = TermcapResponse(supported=False)
         if (self.is_a_tty and self._keyboard_fd is not None):
+            # A default PTY has a window size of (0, 0). If Terminal() is instantiated with a (0, 0)
+            # window size, it is most definitely some automation or dummy script, smart enough for
+            # 'is_a_tty' but very unlikely to answer to XTGETTCAP or CPR queries!
+            try:
+                winsz = self._winsize(self._init_descriptor)
+                if winsz.ws_row == 0 or winsz.ws_col == 0:
+                    self.errors.append('XTGETTCAP probe: skipped, zero-size PTY ')
+                    return _xtgettcap_cache
+            except OSError:
+                pass
             try:
                 _xtgettcap_cache = self._xtgettcap_batch(
                     caps=XTGETTCAP_INIT_CAPABILITIES,

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -85,6 +85,7 @@ IS_WINDOWS = platform.system() == 'Windows'
 if IS_WINDOWS:
     # 3rd party
     from jinxed.win32 import get_console_input_encoding
+    HAS_TTY = False  # fcntl/termios/tty are not available on Windows
 else:
     try:
         # std imports

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -85,7 +85,8 @@ IS_WINDOWS = platform.system() == 'Windows'
 if IS_WINDOWS:
     # 3rd party
     from jinxed.win32 import get_console_input_encoding
-    HAS_TTY = False  # fcntl/termios/tty are not available on Windows
+    # fcntl/termios/tty are not available on Windows 
+    HAS_TTY = False # pylint: disable=invalid-name
 else:
     try:
         # std imports

--- a/tests/accessories.py
+++ b/tests/accessories.py
@@ -301,7 +301,8 @@ def _setwinsize(fd, rows, cols):
 
 
 def pty_test(child_func, parent_func=None, test_name=None, rows=24, cols=80,
-             _xtgettcap_data=None, _xtgettcap_timeout=None):
+             _xtgettcap_data=None, _xtgettcap_timeout=None,
+             skip_winsize: bool = False):
     """
     Wrapper for PTY-based tests to reduce boilerplate.
 
@@ -317,6 +318,7 @@ def pty_test(child_func, parent_func=None, test_name=None, rows=24, cols=80,
         test_name: Optional name for coverage tracking. Auto-derived from child_func if None.
         rows: Terminal height in rows (default 24)
         cols: Terminal width in columns (default 80)
+        skip_winsize: When True, do not call TIOCSWINSZ (leaves kernel default of 0,0).
 
     Returns:
         str: Output from child process (everything written to stdout)
@@ -336,7 +338,7 @@ def pty_test(child_func, parent_func=None, test_name=None, rows=24, cols=80,
     """
     # pylint: disable=too-complex,too-many-branches,too-many-locals
     # pylint: disable=missing-raises-doc,missing-type-doc,too-many-statements
-    # assert False, _xtgettcap_data
+    # pylint: disable=too-many-positional-arguments
     if _xtgettcap_data is not NO_XTGETTCAP_DATA:
         _xtgettcap_data = (_xtgettcap_data if _xtgettcap_data is not None
                            else DEFAULT_TERMCAP_RESPONSE)
@@ -361,8 +363,9 @@ def pty_test(child_func, parent_func=None, test_name=None, rows=24, cols=80,
         attrs = termios.tcgetattr(master_fd)
         attrs[3] = attrs[3] & ~termios.ECHO
         termios.tcsetattr(master_fd, termios.TCSANOW, attrs)
-        # Set window size
-        _setwinsize(master_fd, rows, cols)
+        # Set window size (unless testing kernel-default 0,0)
+        if not skip_winsize:
+            _setwinsize(master_fd, rows, cols)
         # Signal child that setup is complete
         os.write(master_fd, SEND_SEMAPHORE)
 

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -1095,6 +1095,33 @@ def test_terminal_init_xtgettcap_unsupported():
     assert 'OK' in output
 
 
+@pytestmark_pty
+def test_terminal_init_xtgettcap_zero_size_pty():
+    """Terminal() init skips XTGETTCAP probe when PTY has (0,0) window size."""
+    def child(term):
+        assert term._xtgettcap_cache is not None
+        assert term._xtgettcap_cache.supported is False
+        assert any('zero-size' in err for err in term.errors)
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_terminal_init_xtgettcap_zero_size_pty',
+                      _xtgettcap_data=NO_XTGETTCAP_DATA,
+                      skip_winsize=True)
+    assert 'OK' in output
+
+
+def test_xtgettcap_probe_winsize_oserror():
+    """XTGETTCAP probe proceeds when self._winsize() raises OSError."""
+    with mock.patch('os.isatty', return_value=True), \
+        mock.patch.object(Terminal, '_winsize', side_effect=OSError('bad fd')), \
+        mock.patch.object(Terminal, '_xtgettcap_batch',
+                          return_value=TermcapResponse(supported=False)):
+        t = Terminal(stream=sys.__stdout__, force_styling=True)
+        assert not any('zero-size' in err for err in t.errors)
+        assert any('no support' in err for err in t.errors)
+
+
 def test_init_cache_populated_from_xtgettcap_data():
     """Injected XTGETTCAP data populates _xtgettcap_cache."""
     xt_data = TermcapResponse(

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -136,7 +136,7 @@ def test_init_descriptor_stdout_valueerror():
     with mock.patch.object(sys.__stdout__, 'fileno',
                            side_effect=ValueError('detached stdout')), \
             mock.patch('blessed.terminal.jinxed.Terminal', return_value=mock_term), \
-            mock.patch('blessed.terminal.platform.version', return_value='1.0.0'):
+            mock.patch('blessed.terminal.platform.version', return_value='9.99.9999'):
         t = Terminal(stream=io.StringIO(), force_styling=True)
         assert any('stdout may be detached or closed' in err for err in t.errors)
         assert t.number_of_colors == 0

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -12,7 +12,7 @@ from unittest import mock
 
 # local
 from blessed._capabilities import TermcapResponse, ITerm2Capabilities
-from blessed.terminal import Terminal
+from blessed import Terminal
 from .conftest import IS_WINDOWS
 from .accessories import TestTerminal, pty_test, NO_XTGETTCAP_DATA
 

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -135,7 +135,8 @@ def test_init_descriptor_stdout_valueerror():
     mock_term.tigetnum.return_value = 0
     with mock.patch.object(sys.__stdout__, 'fileno',
                            side_effect=ValueError('detached stdout')), \
-            mock.patch('blessed.terminal.jinxed.Terminal', return_value=mock_term):
+            mock.patch('blessed.terminal.jinxed.Terminal', return_value=mock_term), \
+            mock.patch('blessed.terminal.platform.version', return_value='1.0.0'):
         t = Terminal(stream=io.StringIO(), force_styling=True)
         assert any('stdout may be detached or closed' in err for err in t.errors)
         assert t.number_of_colors == 0


### PR DESCRIPTION
A default PTY has a window size of (0, 0). If Terminal() is instantiated
with a (0, 0) window size, it is most definitely some automation or
dummy script, smart enough for 'is_a_tty' but very unlikely to answer to
XTGETTCAP or CPR queries!

I'm not sure how much this will help, pexpect for example will always
set an (80, 24) window size, any pty automation worth its mustard will,
but a default ``ptyprocess.fork()`` call, and possibly many kinds of
automations may be perfectly happy with using blessed for only its
string capabilities in a 0-sized window, and they should not have to
suffer for any delay in startup time
