### PR TITLE
Do not XTGETTCAP query for ConEmu.exe or Terminal.app

### DIFF
--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -302,6 +302,15 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
     def __init__xtgettcap(self) -> TermcapResponse:
         """Probe for core XTGETTCAP capabilities."""
         _xtgettcap_cache = TermcapResponse(supported=False)
+        # These prominent terminals "leak" VT100 Mode DCS queries, meaning the hexedecimal ascii
+        # payloads meant for the terminal to process are displayed as visible text to the user.  Try
+        # our best to avoid to query them, but these variables are not forwarded over SSH.
+        if os.environ.get('ANSICON') or os.environ.get('ConEmuANSI'):
+            self.errors.append('XTGETTCAP probe: skipped, ansicon')
+            return _xtgettcap_cache
+        if os.environ.get('TERM_PROGRAM') == 'Apple_Terminal':
+            self.errors.append('XTGETTCAP probe: skipped, Terminal.app')
+            return _xtgettcap_cache
         if (self.is_a_tty and self._keyboard_fd is not None):
             try:
                 _xtgettcap_cache = self._xtgettcap_batch(
@@ -1218,7 +1227,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
         # Fallback: use TERM_PROGRAM and TERM_PROGRAM_VERSION environment
         # variables, set by many modern terminal emulators (iTerm2, Apple
-        # Terminal, VS Code, WezTerm, Hyper, mintty, etc.)
+        # Terminal, VS Code, WezTerm, Hyper, mintty, etc.), however, they
+        # are not forwarded over protocols like ssh, less unreliable.
         term_program = os.environ.get('TERM_PROGRAM', '')
         term_version = os.environ.get('TERM_PROGRAM_VERSION', '')
         raw = ' '.join(filter(None, (term_program, term_version)))

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -1176,3 +1176,36 @@ def test_get_xtgettcap_applies_overlay_to_jinxed():
     result = term.get_xtgettcap(timeout=0.1, force=True, caps=['dim'])
     assert result is not None
     assert result['dim'] == '\x1b[2m'
+
+
+def test_xtgettcap_skip_ansicon_env():
+    """XTGETTCAP init probe skipped when ANSICON env var is set."""
+    with mock.patch.dict(os.environ, {'ANSICON': '1'}), \
+            mock.patch('os.isatty', return_value=True), \
+            mock.patch.object(Terminal, '_xtgettcap_batch') as mock_batch:
+        t = Terminal(stream=sys.__stdout__, force_styling=True)
+        mock_batch.assert_not_called()
+        assert any('ansicon' in err for err in t.errors)
+        assert t._xtgettcap_cache.supported is False
+
+
+def test_xtgettcap_skip_conemuansi_env():
+    """XTGETTCAP init probe skipped when ConEmuANSI env var is set."""
+    with mock.patch.dict(os.environ, {'ConEmuANSI': 'ON'}), \
+            mock.patch('os.isatty', return_value=True), \
+            mock.patch.object(Terminal, '_xtgettcap_batch') as mock_batch:
+        t = Terminal(stream=sys.__stdout__, force_styling=True)
+        mock_batch.assert_not_called()
+        assert any('ansicon' in err for err in t.errors)
+        assert t._xtgettcap_cache.supported is False
+
+
+def test_xtgettcap_skip_Terminal_app():
+    """XTGETTCAP init probe skipped when TERM_PROGRAM is 'Apple_Terminal'."""
+    with mock.patch.dict(os.environ, {'TERM_PROGRAM': 'Apple_Terminal'}), \
+            mock.patch('os.isatty', return_value=True), \
+            mock.patch.object(Terminal, '_xtgettcap_batch') as mock_batch:
+        t = Terminal(stream=sys.__stdout__, force_styling=True)
+        mock_batch.assert_not_called()
+        assert any('Terminal.app' in err for err in t.errors)
+        assert t._xtgettcap_cache.supported is False


### PR DESCRIPTION
Closes #382 

Terminal.app and ConEmu.exe "leak output", they are not processing VT100 Mode DCS strings, they are not VT100 compliant. Alhough ConEmu.exe is more complex, we can workaround it by writing through WriteConsoleW, which is how python's REPL works, maybe we will later.

As for Terminal.app, we can only prevent it by checking for TERM_PROGRAM equal to 'Apple_Terminal', we can later also use `TERM_PROGRAM_VERSION` if they ever fix it.

Unfortunately SSH will not forward these variables, so this is fix isn't perfect.