### PR TITLE
bugfix DA1 response for some terminals (kitty)

### DIFF
--- a/bin/display-modes.py
+++ b/bin/display-modes.py
@@ -244,7 +244,10 @@ def main():
     if show_all:
         display_all_dec_modes(term)
     else:
-        print(term.bold_black("Use --all to query all DEC Private Modes"))
+        print(term.lightgray("Use --all to query all DEC Private Modes"))
+
+    remainder = term.flushinp()
+    assert not remainder, ("erroneous input remains!", remainder)
 
 
 if __name__ == '__main__':

--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -15,4 +15,4 @@ else:
 from blessed.line_editor import LineEditor, LineHistory
 
 __all__ = ('Terminal', 'LineEditor', 'LineHistory')
-__version__ = "1.45.0"
+__version__ = "1.46.0"

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -2206,7 +2206,7 @@ class DeviceAttribute():
     supported extensions/capabilities.
     """
 
-    RE_RESPONSE = re.compile(r'\x1b\[\?([0-9]+)((?:;[0-9]+)*)c')
+    RE_RESPONSE = re.compile(r'\x1b\[\?([0-9]+)((?:;[0-9]+)*);*c')
 
     def __init__(self, raw: str, service_class: int,
                  extensions: typing.Optional[typing.List[int]]) -> None:

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,6 +2,10 @@
 
 Version History
 ===============
+1.46
+  * bugfix: :meth:`~Terminal.does_sixel` failed to detect DA1 and caused the response to "leak" into
+    next call to :meth:`~Terminal.inkey` for some terminals of unmatched patterns (e.g., kitty).
+
 1.45
   * bugfix: name consistency of kitty keyboard modifiers :ghpull:`390`.
 

--- a/docs/sequences.rst
+++ b/docs/sequences.rst
@@ -22,7 +22,7 @@ Stripping Sequences
 The :meth:`~.Terminal.strip_seqs` method removes all escape sequences from a string, leaving only
 the printable text:
 
-    >>> phrase = term.bold_black('coffee')
+    >>> phrase = term.sienna4('coffee')
     >>> phrase
     '\x1b[1m\x1b[30mcoffee\x1b(B\x1b[m'
     >>> term.strip_seqs(phrase)

--- a/tests/test_device_attribute.py
+++ b/tests/test_device_attribute.py
@@ -55,6 +55,8 @@ pytestmark = pytest.mark.skipif(
     ('\x1b[?64;1;2c', 64, {1, 2}, False),
     ('\x1b[?1c', 1, set(), False),
     ('\x1b[?62;1;4;6c', 62, {1, 4, 6}, True),
+    ('\x1b[?62;52;c', 62, {52}, False),
+    ('\x1b[?62;c', 62, set(), False),
 ])
 def test_device_attribute_from_match(response, service_class, extensions, supports_sixel):
     """Test DeviceAttribute.from_match() with various response formats."""


### PR DESCRIPTION
We parsed for DA1 responses like::

    \x1b[?1c'

But some terminals have a "trailing semicolon", e.g. kitty:

    \x1b[?1;c
