### PR TITLE
Improved remote truecolor detection by unique TERM

### DIFF
--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -80,6 +80,13 @@ from ._capabilities import (CAPABILITY_DATABASE,
 
 _ALL_XTGETTCAP_CAPS = frozenset({c[0] for c in XTGETTCAP_CAPABILITIES})
 
+# TERM types that uniquely identify 24-bit color terminals.
+# Used as fallback when COLORTERM is absent (e.g. remote SSH sessions).
+_KIND_24BIT = frozenset({
+    'alacritty', 'contour', 'foot', 'ghostty', 'xterm-ghostty',
+    'kitty', 'xterm-kitty', 'mlterm', 'rio',
+})
+
 HAS_TTY = True  # pylint: disable=invalid-name
 IS_WINDOWS = platform.system() == 'Windows'
 if IS_WINDOWS:
@@ -493,10 +500,12 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         """Initialize color distance algorithm and determine Terminal.number_of_colors."""
         # Resolution order:
         # - COLORTERM environment value
-        # - XTGETTCAP 'RGB' (24-bit), then 'colors'
-        # - termcap 'colors' (jinxed)
+        # - XTGETTCAP 'RGB' (24-bit)
+        # - TERM type heuristic ('-direct' suffix, known 24-bit TERMs)
+        # - XTGETTCAP 'colors' (fallback count)
         # - Windows native console (vtwin10) and Microsoft Terminal (ms-terminal) get
         #   24-bit boost
+        # - termcap 'colors' (jinxed)
         self._color_distance_algorithm = 'cie2000'
         if not self.does_styling:
             return 0
@@ -508,6 +517,10 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
                     return 1 << 24
             except ValueError:
                 pass
+        # TERM type heuristic for remote sessions where
+        # COLORTERM is not forwarded and XTGETTCAP may be unavailable.
+        if self._kind.endswith('-direct') or self._kind in _KIND_24BIT:
+            return 1 << 24
         if (xt_colors := self._xtgettcap_cache.capabilities.get('colors')) and xt_colors.isdigit():
             return int(xt_colors)
         _win_build = tuple(int(n) for n in platform.version().split('.')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1103,3 +1103,37 @@ def test_windows_ms_terminal_truecolor():
             assert term.number_of_colors == 1 << 24
     finally:
         bt.IS_WINDOWS = original_is_windows
+
+
+def test_kind_truecolor():
+    """Known 24-bit TERM types yield 1<<24 colors without COLORTERM or XTGETTCAP."""
+    term = TestTerminal(stream=StringIO(), kind='rio', force_styling=True,
+                        _xtgettcap_data=NO_XTGETTCAP_DATA)
+    assert term.number_of_colors == 1 << 24
+
+
+def test_kind_direct_suffix():
+    """TERM types ending in '-direct' yield 1<<24 colors."""
+    term = TestTerminal(stream=StringIO(), kind='xterm-256color', force_styling=True,
+                        _xtgettcap_data=NO_XTGETTCAP_DATA)
+    term._kind = 'xterm-direct'
+    term.number_of_colors = term._Terminal__init__color_capabilities()
+    assert term.number_of_colors == 1 << 24
+
+
+def test_xterm_kind_not_24bit():
+    """Generic xterm-256color without other signals falls through to jinxed (256)."""
+    term = TestTerminal(stream=StringIO(), kind='xterm-256color', force_styling=True,
+                        _xtgettcap_data=NO_XTGETTCAP_DATA)
+    assert term.number_of_colors == 256
+
+
+def test_kind_beats_xtgettcap_colors():
+    """Known 24-bit TERM beats XTGETTCAP colors=256."""
+    term = TestTerminal(
+        stream=StringIO(), kind='kitty', force_styling=True,
+        _xtgettcap_data=TermcapResponse(
+            supported=True,
+            capabilities={'colors': '256'},
+        ))
+    assert term.number_of_colors == 1 << 24


### PR DESCRIPTION
Closes #386. For remote sessions, like SSH, only ``TERM`` environment variable is transmitted reliably. 

In addition to ``RGB`` check via ``XTGETTCAP``, we found **only kitty terminal** requires a different lookup mechanism (using ``DECRQSS``). However, ``TERM=kitty`` in that case. Using results from ucs-detect project, we have determined a unique set of unique terminal types that identify as 24-bit color.

