### PR TITLE
Fix legacy mouse decoder reporting no-button motion (mode 1003) as a phantom button

### DIFF
--- a/blessed/mouse.py
+++ b/blessed/mouse.py
@@ -199,9 +199,17 @@ class MouseEvent:  # pylint: disable=too-many-instance-attributes
         cx = ord(match.group('cx')) - 32 - 1  # Convert from 1-indexed to 0-indexed
         cy = ord(match.group('cy')) - 32 - 1  # Convert from 1-indexed to 0-indexed
 
+        # Extract motion/drag flags
+        is_motion = bool(cb & 32)
+
         # Extract button and modifiers from cb
         button = cb & 3
-        released = button == 3
+        # A low-bits value of 3 means "no button". When stationary this is a
+        # button release; with the motion bit set (mode 1003 all-motion
+        # tracking) it is a no-button motion event, which must keep button_value
+        # 3 so it reports as "MOTION" rather than "LEFT_MOTION", matching the
+        # SGR decoder.
+        released = button == 3 and not is_motion
         if released:
             button = 0  # Release doesn't specify which button
 
@@ -209,9 +217,6 @@ class MouseEvent:  # pylint: disable=too-many-instance-attributes
         shift = bool(cb & 4)
         meta = bool(cb & 8)
         ctrl = bool(cb & 16)
-
-        # Extract motion/drag flags
-        is_motion = bool(cb & 32)
 
         # Wheel events
         is_wheel = cb >= 64

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,8 @@ Version History
 ===============
 
 1.46
+  * bugfix: legacy mouse decoder reported a no-button motion event (mode 1003) as a phantom
+    ``LEFT_MOTION`` release instead of ``MOTION``, disagreeing with the SGR decoder :ghpull:`396`.
   * bugfix: :meth:`~Terminal.does_sixel` failed to detect DA1 and caused the response to "leak" into
     next call to :meth:`~Terminal.inkey` for some terminals of unmatched patterns (e.g., kitty).
   * improve: add new sugar for extended cap-defined styles, like 'clear_scrollback' (common),

--- a/tests/test_mouse.py
+++ b/tests/test_mouse.py
@@ -9,7 +9,8 @@ import pytest
 # local
 from blessed import Terminal
 from blessed.keyboard import Keystroke, _match_dec_event
-from blessed.mouse import MouseEvent, MouseSGREvent, MouseLegacyEvent
+from blessed.mouse import (MouseEvent, MouseSGREvent, MouseLegacyEvent,
+                           RE_PATTERN_MOUSE_SGR, RE_PATTERN_MOUSE_LEGACY)
 from blessed.dec_modes import DecModeResponse
 from .accessories import TestTerminal, make_enabled_dec_cache
 from .conftest import IS_WINDOWS
@@ -508,6 +509,42 @@ def test_mouse_motion_event_naming():
     # Motion events should NOT have _RELEASED suffix
     ks_motion_not_released = _match_dec_event('\x1b[<32;10;20m', dec_mode_cache=cache)
     assert not ks_motion_not_released.name.endswith('_RELEASED')
+
+
+@pytest.mark.parametrize("mod_bits,sgr_button,expected_name", [
+    (0, 35, "MOUSE_MOTION"),        # plain no-button motion
+    (16, 51, "MOUSE_CTRL_MOTION"),  # ctrl held
+    (4, 39, "MOUSE_SHIFT_MOTION"),  # shift held
+    (8, 43, "MOUSE_META_MOTION"),   # meta held
+])
+def test_mouse_legacy_no_button_motion_matches_sgr(mod_bits, sgr_button, expected_name):
+    """Legacy no-button motion (mode 1003) must report as MOTION, like SGR.
+
+    Regression: the legacy decoder collapsed the "no button" code (low bits 3)
+    into a release *before* checking the motion bit, so an all-motion (mode
+    1003) move with no button held was mis-decoded as a left-button event
+    ("LEFT_MOTION", released=True) instead of "MOTION". The SGR decoder, on the
+    identical semantic event, keeps button_value 3 and reports "MOTION"; the
+    two sibling decoders must agree.
+    """
+    cb = 3 | 0x20 | mod_bits  # no-button (low bits 3) + motion bit + modifiers
+    legacy_seq = '\x1b[M' + chr(cb + 32) + chr(10 + 32) + chr(20 + 32)
+    sgr_seq = '\x1b[<%d;11;21M' % sgr_button
+
+    legacy = MouseEvent.from_legacy_match(RE_PATTERN_MOUSE_LEGACY.match(legacy_seq))
+    sgr = MouseEvent.from_sgr_match(RE_PATTERN_MOUSE_SGR.match(sgr_seq))
+
+    # Sibling consistency: legacy decoder must agree with the SGR decoder.
+    assert legacy.button == sgr.button
+    assert legacy.button == expected_name[len("MOUSE_"):]
+    assert legacy.button_value == 3
+    assert legacy.is_motion is True
+    assert legacy.released is False
+
+    # Full pipeline via mode 1003: Keystroke.name must not be a click/release.
+    ks = _match_dec_event(legacy_seq, dec_mode_cache={1003: DecModeResponse.SET})
+    assert ks.name == expected_name
+    assert not ks.name.endswith("_RELEASED")
 
 
 def test_mouse_coordinate_properties():


### PR DESCRIPTION
The two mouse decoders in `blessed/mouse.py` disagree on a common, valid event.

`MouseEvent.from_legacy_match` computes `released = (button == 3)` and zeroes the button *before* consulting the motion bit. In the xterm legacy protocol the low-bits value `3` means "no button": when stationary that is a release, but **with the motion bit set (mode 1003, all-motion tracking) it is a no-button motion event** — the defining case of mode 1003.

Collapsing it to a release yields a phantom left-button drag:

```
mode-1003 no-button move  ESC [ M <35+something>
  legacy decoder -> button="LEFT_MOTION", button_value=0, released=True
  SGR decoder    -> button="MOTION",      button_value=3, released=False   (ESC[<35;x;yM)
```

So `Keystroke.name` comes out `MOUSE_LEFT_MOTION` (a released left-drag that never happened) instead of `MOUSE_MOTION`. The SGR sibling — and your own `test_mouse_motion_event_naming` — already treat button `3` + motion bit as `MOTION`; the legacy path simply lacked a no-button-motion test.

**Fix.** Compute `is_motion` first and only treat "no button" as a release when stationary (`released = button == 3 and not is_motion`), keeping `button_value = 3` for motion so it reports `MOTION`, matching `from_sgr_match`. Release-when-stationary and left/middle/right drag paths are unchanged.

**Test.** A parametrized `test_mouse_legacy_no_button_motion_matches_sgr` asserts the legacy decoder agrees with the SGR decoder (plain + ctrl/shift/meta) on button name, `button_value == 3`, `is_motion`, `released is False`, and checks the full mode-1003 `Keystroke.name`. `tests/test_mouse.py`: 71 passed, 1 skipped.