### PR TITLE
Fix legacy mouse mode motion

### DIFF
--- a/bin/keymatrix.py
+++ b/bin/keymatrix.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python
 """
-Advanced keyboard and special modes interaction example.
+Advanced keyboard and special modes interaction and testing tool.
 
 Usage:
-- F1-F11: Toggle DEC private modes (bracketed paste, mouse, etc.)
-- Shift+F1-F5: Toggle Kitty keyboard protocol flags
-- 'q': Exit
-
-All modes that elicit responses are activated for demonstration.
+- F1-F7:    Toggle DEC private modes
+- F8:       Toggle SGR mouse mode (1006). Turn OFF for legacy ``ESC [ M`` format
+- F9:       Toggle drag tracking (1002)
+- F10:      Toggle all-motion tracking (1003)
+- F11:      Toggle pixel coordinates (1016)
+- Shift+F1-F5:  Toggle Kitty keyboard protocol flags
+- 'q'/^C:   Exit
 """
 # std imports
 import sys
@@ -91,7 +93,7 @@ class DecModeManager:
 
     def toggle_keynames(self) -> List[str]:
         """Return list of key names that toggle DEC modes."""
-        return [f'KEY_F{i}' for i in range(1, 12)]
+        return [f'KEY_F{i}' for i in range(1, 1 + len(self.test_modes))]
 
     def get_index_by_key(self, key_name: str) -> int:
         """Convert key name to toggle index."""
@@ -174,16 +176,15 @@ class KittyKeyboardManager:
 
 
 class MouseModeManager:
-    """Manages mouse mode probing and toggling."""
-
     def __init__(self, term: Terminal):
         self.term = term
         self.supported: bool = False
         self.active_context: Optional[Any] = None
+        self.report_sgr: bool = True
         self.report_drag: bool = False
         self.report_motion: bool = False
         self.report_pixels: bool = False
-        self.mode_names = ['drag', 'motion', 'pixels']
+        self.mode_names = ['sgr', 'drag', 'motion', 'pixels']
 
     def probe(self) -> List[str]:
         """Probe terminal for mouse support and return log messages."""
@@ -191,6 +192,14 @@ class MouseModeManager:
         if self.supported:
             return ["Mouse support detected!"]
         return ["Mouse support not available!"]
+
+    def _pick_tracking_mode(self) -> Optional[DecPrivateMode]:
+        """Return the highest-priority tracking DEC mode, or None."""
+        if self.report_motion:
+            return DecPrivateMode.MOUSE_ALL_MOTION
+        if self.report_drag:
+            return DecPrivateMode.MOUSE_REPORT_DRAG
+        return None
 
     def toggle_by_index(self, f_idx: int) -> str:
         """Toggle mouse mode by F-key index and return log message."""
@@ -200,10 +209,16 @@ class MouseModeManager:
         mode_name = self.mode_names[f_idx]
 
         # Toggle the flag
-        if mode_name == 'drag':
+        if mode_name == 'sgr':
+            self.report_sgr = not self.report_sgr
+        elif mode_name == 'drag':
             self.report_drag = not self.report_drag
+            if self.report_drag:
+                self.report_motion = False
         elif mode_name == 'motion':
             self.report_motion = not self.report_motion
+            if self.report_motion:
+                self.report_drag = False
         elif mode_name == 'pixels':
             self.report_pixels = not self.report_pixels
 
@@ -212,18 +227,25 @@ class MouseModeManager:
             self.active_context.__exit__(None, None, None)
             self.active_context = None
 
-        # Create new context if any mode is enabled
-        if self.report_drag or self.report_motion or self.report_pixels:
-            self.active_context = self.term.mouse_enabled(
-                report_drag=self.report_drag,
-                report_motion=self.report_motion,
-                report_pixels=self.report_pixels
-            )
-            self.active_context.__enter__()  # pylint: disable=unnecessary-dunder-call
+        # Build modes list — include SGR (1006) only when report_sgr is ON
+        modes = []
+        if self.report_sgr:
+            modes.append(DecPrivateMode.MOUSE_EXTENDED_SGR)
+        tracking_mode = self._pick_tracking_mode()
+        if tracking_mode is not None:
+            modes.append(tracking_mode)
+        if self.report_pixels:
+            modes.append(DecPrivateMode.MOUSE_SGR_PIXELS)
+
+        if modes:
+            self.active_context = self.term.dec_modes_enabled(*modes)
+            self.active_context.__enter__()
 
         return (
-            f'Mouse: drag={self.report_drag} '
-            f'motion={self.report_motion} pixels={self.report_pixels}'
+            f'Mouse: sgr={self.report_sgr} '
+            f'drag={self.report_drag} '
+            f'motion={self.report_motion} '
+            f'pixels={self.report_pixels}'
         )
 
     def header_msg(self) -> str:
@@ -231,6 +253,8 @@ class MouseModeManager:
         if not self.supported:
             return "Mouse: not supported"
         status = []
+        if self.report_sgr:
+            status.append("SGR")
         if self.report_drag:
             status.append("drag")
         if self.report_motion:
@@ -238,16 +262,16 @@ class MouseModeManager:
         if self.report_pixels:
             status.append("pixels")
         status_str = "+".join(status) if status else "disabled"
-        return f"Mouse: {status_str} [F9=drag F10=motion F11=pixels]"
+        return f"Mouse: {status_str} [F8=SGR F9=drag F10=motion F11=pixels]"
 
     def toggle_keynames(self) -> List[str]:
         """Return list of key names that toggle mouse modes."""
-        return ['KEY_F9', 'KEY_F10', 'KEY_F11']
+        return ['KEY_F8', 'KEY_F9', 'KEY_F10', 'KEY_F11']
 
     def get_index_by_key(self, key_name: str) -> int:
         """Convert key name to toggle index."""
         f_num = int(key_name.split('_')[-1][1:])
-        return f_num - 9  # F9 -> index 0, F10 -> index 1, F11 -> index 2
+        return f_num - 8  # F8 -> index 0, F9 -> index 1, F10 -> index 2, F11 -> index 3
 
     def cleanup(self) -> None:
         """Clean up active context manager."""

--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -15,4 +15,4 @@ else:
 from blessed.line_editor import LineEditor, LineHistory
 
 __all__ = ('Terminal', 'LineEditor', 'LineHistory')
-__version__ = "1.46.0"
+__version__ = "1.47.0"

--- a/blessed/mouse.py
+++ b/blessed/mouse.py
@@ -199,9 +199,17 @@ class MouseEvent:  # pylint: disable=too-many-instance-attributes
         cx = ord(match.group('cx')) - 32 - 1  # Convert from 1-indexed to 0-indexed
         cy = ord(match.group('cy')) - 32 - 1  # Convert from 1-indexed to 0-indexed
 
+        # Extract motion/drag flags
+        is_motion = bool(cb & 32)
+
         # Extract button and modifiers from cb
         button = cb & 3
-        released = button == 3
+        # A low-bits value of 3 means "no button". When stationary this is a
+        # button release; with the motion bit set (mode 1003 all-motion
+        # tracking) it is a no-button motion event, which must keep button_value
+        # 3 so it reports as "MOTION" rather than "LEFT_MOTION", matching the
+        # SGR decoder.
+        released = button == 3 and not is_motion
         if released:
             button = 0  # Release doesn't specify which button
 
@@ -209,9 +217,6 @@ class MouseEvent:  # pylint: disable=too-many-instance-attributes
         shift = bool(cb & 4)
         meta = bool(cb & 8)
         ctrl = bool(cb & 16)
-
-        # Extract motion/drag flags
-        is_motion = bool(cb & 32)
 
         # Wheel events
         is_wheel = cb >= 64

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,6 +4,8 @@ Version History
 ===============
 
 1.46
+  * bugfix: legacy mouse decoder reported a no-button motion event (mode 1003) as a phantom
+    ``LEFT_MOTION`` release instead of ``MOTION``, disagreeing with the SGR decoder :ghpull:`396`.
   * bugfix: :meth:`~Terminal.does_sixel` failed to detect DA1 and caused the response to "leak" into
     next call to :meth:`~Terminal.inkey` for some terminals of unmatched patterns (e.g., kitty).
   * improve: add new sugar for extended cap-defined styles, like 'clear_scrollback' (common),

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -4,8 +4,8 @@ Version History
 ===============
 
 1.47
-  * bugfix: legacy mouse decoder reported a no-button motion event (mode 1003) as a phantom
-    ``LEFT_MOTION`` release instead of ``MOTION``, disagreeing with the SGR decoder :ghpull:`396`.
+  * bugfix: legacy SGR mouse decoder reported no-button motion event (mode 1003) as ``LEFT_MOTION``
+    instead of ``MOTION``, :ghpull:`398`.
 
 1.46
   * bugfix: :meth:`~Terminal.does_sixel` failed to detect DA1 and caused the response to "leak" into

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,8 +5,6 @@ Version History
 1.47
   * bugfix: :meth:`~Terminal.does_sixel` now returns ``True`` for SyncTERM using special-case
     matching of its illegal DA1 response.
-
-1.47
   * bugfix: legacy SGR mouse decoder reported no-button motion event (mode 1003) as ``LEFT_MOTION``
     instead of ``MOTION``, :ghpull:`398`.
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,9 +3,11 @@
 Version History
 ===============
 
-1.46
+1.47
   * bugfix: legacy mouse decoder reported a no-button motion event (mode 1003) as a phantom
     ``LEFT_MOTION`` release instead of ``MOTION``, disagreeing with the SGR decoder :ghpull:`396`.
+
+1.46
   * bugfix: :meth:`~Terminal.does_sixel` failed to detect DA1 and caused the response to "leak" into
     next call to :meth:`~Terminal.inkey` for some terminals of unmatched patterns (e.g., kitty).
   * improve: add new sugar for extended cap-defined styles, like 'clear_scrollback' (common),

--- a/tests/test_mouse.py
+++ b/tests/test_mouse.py
@@ -9,8 +9,7 @@ import pytest
 # local
 from blessed import Terminal
 from blessed.keyboard import Keystroke, _match_dec_event
-from blessed.mouse import (MouseEvent, MouseSGREvent, MouseLegacyEvent,
-                           RE_PATTERN_MOUSE_SGR, RE_PATTERN_MOUSE_LEGACY)
+from blessed.mouse import (MouseEvent, MouseSGREvent, MouseLegacyEvent)
 from blessed.dec_modes import DecModeResponse
 from .accessories import TestTerminal, make_enabled_dec_cache
 from .conftest import IS_WINDOWS
@@ -511,42 +510,6 @@ def test_mouse_motion_event_naming():
     assert not ks_motion_not_released.name.endswith('_RELEASED')
 
 
-@pytest.mark.parametrize("mod_bits,sgr_button,expected_name", [
-    (0, 35, "MOUSE_MOTION"),        # plain no-button motion
-    (16, 51, "MOUSE_CTRL_MOTION"),  # ctrl held
-    (4, 39, "MOUSE_SHIFT_MOTION"),  # shift held
-    (8, 43, "MOUSE_META_MOTION"),   # meta held
-])
-def test_mouse_legacy_no_button_motion_matches_sgr(mod_bits, sgr_button, expected_name):
-    """Legacy no-button motion (mode 1003) must report as MOTION, like SGR.
-
-    Regression: the legacy decoder collapsed the "no button" code (low bits 3)
-    into a release *before* checking the motion bit, so an all-motion (mode
-    1003) move with no button held was mis-decoded as a left-button event
-    ("LEFT_MOTION", released=True) instead of "MOTION". The SGR decoder, on the
-    identical semantic event, keeps button_value 3 and reports "MOTION"; the
-    two sibling decoders must agree.
-    """
-    cb = 3 | 0x20 | mod_bits  # no-button (low bits 3) + motion bit + modifiers
-    legacy_seq = '\x1b[M' + chr(cb + 32) + chr(10 + 32) + chr(20 + 32)
-    sgr_seq = '\x1b[<%d;11;21M' % sgr_button
-
-    legacy = MouseEvent.from_legacy_match(RE_PATTERN_MOUSE_LEGACY.match(legacy_seq))
-    sgr = MouseEvent.from_sgr_match(RE_PATTERN_MOUSE_SGR.match(sgr_seq))
-
-    # Sibling consistency: legacy decoder must agree with the SGR decoder.
-    assert legacy.button == sgr.button
-    assert legacy.button == expected_name[len("MOUSE_"):]
-    assert legacy.button_value == 3
-    assert legacy.is_motion is True
-    assert legacy.released is False
-
-    # Full pipeline via mode 1003: Keystroke.name must not be a click/release.
-    ks = _match_dec_event(legacy_seq, dec_mode_cache={1003: DecModeResponse.SET})
-    assert ks.name == expected_name
-    assert not ks.name.endswith("_RELEASED")
-
-
 def test_mouse_coordinate_properties():
     """Test that mouse events have mouse_yx and mouse_xy properties."""
     cache = make_enabled_dec_cache()
@@ -612,6 +575,11 @@ def test_mouse_legacy_encoding_systematic():
         (0, 200, 190, False, False, False, False, False),
         (1, 210, 200, False, True, False, False, False),
         (2, 220, 210, False, False, True, False, False),
+        # no-button motion: low bits 3 + motion bit (mode 1003 all-motion).
+        # before commit 37128c5 the legacy decoder collapsed cb&3==3 into a
+        # release before checking the motion bit, misreporting this as a
+        # left-button event (released=True) instead of no-button MOTION.
+        (3, 100, 150, False, False, False, False, True),
     ]
 
     def child(term):

--- a/tests/test_mouse.py
+++ b/tests/test_mouse.py
@@ -9,7 +9,8 @@ import pytest
 # local
 from blessed import Terminal
 from blessed.keyboard import Keystroke, _match_dec_event
-from blessed.mouse import MouseEvent, MouseSGREvent, MouseLegacyEvent
+from blessed.mouse import (MouseEvent, MouseSGREvent, MouseLegacyEvent,
+                           RE_PATTERN_MOUSE_SGR, RE_PATTERN_MOUSE_LEGACY)
 from blessed.dec_modes import DecModeResponse
 from .accessories import TestTerminal, make_enabled_dec_cache
 from .conftest import IS_WINDOWS
@@ -508,6 +509,42 @@ def test_mouse_motion_event_naming():
     # Motion events should NOT have _RELEASED suffix
     ks_motion_not_released = _match_dec_event('\x1b[<32;10;20m', dec_mode_cache=cache)
     assert not ks_motion_not_released.name.endswith('_RELEASED')
+
+
+@pytest.mark.parametrize("mod_bits,sgr_button,expected_name", [
+    (0, 35, "MOUSE_MOTION"),        # plain no-button motion
+    (16, 51, "MOUSE_CTRL_MOTION"),  # ctrl held
+    (4, 39, "MOUSE_SHIFT_MOTION"),  # shift held
+    (8, 43, "MOUSE_META_MOTION"),   # meta held
+])
+def test_mouse_legacy_no_button_motion_matches_sgr(mod_bits, sgr_button, expected_name):
+    """Legacy no-button motion (mode 1003) must report as MOTION, like SGR.
+
+    Regression: the legacy decoder collapsed the "no button" code (low bits 3)
+    into a release *before* checking the motion bit, so an all-motion (mode
+    1003) move with no button held was mis-decoded as a left-button event
+    ("LEFT_MOTION", released=True) instead of "MOTION". The SGR decoder, on the
+    identical semantic event, keeps button_value 3 and reports "MOTION"; the
+    two sibling decoders must agree.
+    """
+    cb = 3 | 0x20 | mod_bits  # no-button (low bits 3) + motion bit + modifiers
+    legacy_seq = '\x1b[M' + chr(cb + 32) + chr(10 + 32) + chr(20 + 32)
+    sgr_seq = '\x1b[<%d;11;21M' % sgr_button
+
+    legacy = MouseEvent.from_legacy_match(RE_PATTERN_MOUSE_LEGACY.match(legacy_seq))
+    sgr = MouseEvent.from_sgr_match(RE_PATTERN_MOUSE_SGR.match(sgr_seq))
+
+    # Sibling consistency: legacy decoder must agree with the SGR decoder.
+    assert legacy.button == sgr.button
+    assert legacy.button == expected_name[len("MOUSE_"):]
+    assert legacy.button_value == 3
+    assert legacy.is_motion is True
+    assert legacy.released is False
+
+    # Full pipeline via mode 1003: Keystroke.name must not be a click/release.
+    ks = _match_dec_event(legacy_seq, dec_mode_cache={1003: DecModeResponse.SET})
+    assert ks.name == expected_name
+    assert not ks.name.endswith("_RELEASED")
 
 
 def test_mouse_coordinate_properties():


### PR DESCRIPTION
Closes #396

- **Fix legacy mouse decoder mis-reporting no-button motion as a button**
- **docs: changelog entry for legacy mouse motion fix (#396)**
- **improve keymatrix.py to allow enabling legacy "SGR" mode**
- **simplify test into existing paramterized test**
