### PR TITLE
bugfix less common KEY_ALT_ENTER input using LF

### DIFF
--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -117,9 +117,10 @@ _PUA_KEYPAD_NAMES = {
 
 # Alt-only control character name mappings
 ALT_CONTROL_NAMES = {
+    0x0d: 'KEY_ALT_ENTER',      # CR
+    0x0a: 'KEY_ALT_ENTER',      # LF
     0x1b: 'KEY_ALT_ESCAPE',     # ESC
     0x7f: 'KEY_ALT_BACKSPACE',  # DEL
-    0x0d: 'KEY_ALT_ENTER',      # CR
     0x09: 'KEY_ALT_TAB',        # TAB
 }
 
@@ -243,8 +244,8 @@ class Keystroke(str):
 
             # Special C0 controls that should be Alt-only per legacy spec
             # These represent common Alt+key combinations that are unambiguous
-            # (Enter, Escape, DEL, Tab)
-            if char_code in {0x0d, 0x1b, 0x7f, 0x09}:
+            # (Enter (CR/LF), Escape, DEL, Tab)
+            if char_code in {0x0a, 0x0d, 0x1b, 0x7f, 0x09}:
                 return 1 + KittyModifierBits.alt  # 1 + alt flag = 3
 
             # Other control characters represent Ctrl+Alt combinations

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -7,6 +7,7 @@ Version History
     matching of its illegal DA1 response.
   * bugfix: legacy SGR mouse decoder reported no-button motion event (mode 1003) as ``LEFT_MOTION``
     instead of ``MOTION``, :ghpull:`398`.
+  * bugfix: match keyboard input ``\x1b\n`` as ``KEY_ALT_ENTER`` instead of ``KEY_CTRL_ALT_J``.
 
 1.46
   * bugfix: :meth:`~Terminal.does_sixel` failed to detect DA1 and caused the response to "leak" into

--- a/tests/test_modifiers_keyboard.py
+++ b/tests/test_modifiers_keyboard.py
@@ -143,6 +143,7 @@ def test_keystroke_value_by_keycode(code, expected_value):
     ('\x1b\x1f', 'KEY_CTRL_ALT__', 7),
     ('\x1b\x1b', 'KEY_ALT_ESCAPE', 3),
     ('\x1b\x7f', 'KEY_ALT_BACKSPACE', 3),
+    ('\x1b\x0a', 'KEY_ALT_ENTER', 3),
     ('\x1b\x0d', 'KEY_ALT_ENTER', 3),
     ('\x1b\x09', 'KEY_ALT_TAB', 3),
     ('\x1b[', 'CSI', 3),
@@ -1244,7 +1245,6 @@ def test_get_meta_escape_name_branch_coverage():
         ('\x1b\x03', 7, 'KEY_CTRL_ALT_C'),
         ('\x1b\x04', 7, 'KEY_CTRL_ALT_D'),
         ('\x1b\x07', 7, 'KEY_CTRL_ALT_G'),
-        ('\x1b\x0a', 7, 'KEY_CTRL_ALT_J'),
         ('\x1b\x0b', 7, 'KEY_CTRL_ALT_K'),
         ('\x1b\x0c', 7, 'KEY_CTRL_ALT_L'),
         ('\x1b\x0e', 7, 'KEY_CTRL_ALT_N'),
@@ -1259,6 +1259,7 @@ def test_get_meta_escape_name_branch_coverage():
         ('\x1b\x18', 7, 'KEY_CTRL_ALT_X'),
         ('\x1b\x19', 7, 'KEY_CTRL_ALT_Y'),
         ('\x1b\x0d', 3, 'KEY_ALT_ENTER'),
+        ('\x1b\x0a', 3, 'KEY_ALT_ENTER'),
         ('\x1b\x09', 3, 'KEY_ALT_TAB'),
     ]
 


### PR DESCRIPTION
ALT+RETURN key sends LF instead of CR for foot terminal and probably
others, support them as detected as ALT_RETURN outside of kitty keyboard
protocol.

Closes #395
