### PR TITLE
Add Terminal.does_font_have_codepoints() (draft)

### DIFF
--- a/bin/detect-tofus.py
+++ b/bin/detect-tofus.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+import sys
+import unicodedata
+
+import wcwidth
+
+from blessed import Terminal
+
+
+def main():
+    term = Terminal()
+
+    print('reading...' + term.clear_eol, end='', file=sys.stdout)
+    all_codepoints = set()
+    for filepath in sys.argv[1:]:
+        with open(filepath, 'r') as f:
+            all_codepoints.update(unicodedata.normalize('NFC', f.read()))
+
+    print('\rtesting...' + term.clear_eol, end='', file=sys.stdout)
+    codepoints_to_test = {cp for cp in all_codepoints if wcwidth.wcwidth(cp) != 0}
+    codepoints_str = ''.join(sorted(codepoints_to_test))
+    supported_str = ''
+    _batchsize = 100
+    for i in range(0, len(codepoints_str), _batchsize):
+        bs = '' if i == 0 else len(str(i - _batchsize)) * '\b'
+        print(f'{bs}{i}', end='', file=sys.stdout)
+        batch = codepoints_str[i:i + _batchsize]
+        result = term.does_font_have_codepoints(batch)
+        if result is None:
+            print('\rFont glyph protocol not supported by this terminal.',
+                  file=sys.stderr)
+            return 1
+        supported_str += result
+
+    unsupported = set(codepoints_to_test) - set(supported_str)
+
+    print('\rreporting' + term.clear_eol + '\r', end='', file=sys.stdout)
+    if not unsupported:
+        return 0
+
+    tofu_count = 0
+    for filepath in sys.argv[1:]:
+        with open(filepath, 'r') as f:
+            for lineno, line in enumerate(f, 1):
+                line = unicodedata.normalize('NFC', line.rstrip('\n'))
+                line_unsupported = [cp for cp in line if cp in unsupported]
+                n = len(line_unsupported)
+                if n == 0:
+                    continue
+                tofu_count += n
+                decorated = ''.join(
+                    term.bold_red(cp) if cp in unsupported else cp
+                    for cp in line)
+                print(f'{n} {filepath}:{lineno} {decorated}')
+
+    return 1 if tofu_count else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -12,6 +12,7 @@ import select
 import struct
 import asyncio
 import platform
+import unicodedata
 import warnings
 import contextlib
 import collections
@@ -1873,7 +1874,12 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
     def does_font_have_codepoints(self, codepoints: str,
                                   timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
-                                  force: bool = False) -> Optional[Tuple[bool, ...]]:
+                                  force: bool = False) -> Optional[str]:
+        # XXX cite both in documentation
+        # XXX describe combining caveats, to call unicodedata.normalize first
+        # XXX looks like rio has a bug .. report it ..
+        # that the string is returned as-is, up to the same length, with
+        # unsupported codepoints omitted .. 
         """
         Query whether each codepoint is supported by the terminal font.
 
@@ -1888,11 +1894,17 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             return None
         if not codepoints:
             return ()
-        # check for protocol support
-        if (result := self._query_font_mintty_protocol('blessed')):
-            self._does_mintty_font_protocol = bool(result)
-        elif self._does_glyph_protocol is None:
-            self._does_glyph_protocol = self._probe_glyph_protocol(timeout)
+        if unicodedata.normalize('NFC', codepoints) != codepoints:
+            raise TypeError(
+                'codepoints argument must be NFC-normalized; '
+                'use unicodedata.normalize("NFC", ...) on the input first')
+        # check for protocol support, first mintty's
+        self._does_mintty_font_protocol = (
+                self._query_font_mintty_protocol('blessed') == 'blessed')
+        if not self._does_mintty_font_protocol:
+            # then, rio's
+            kv = self._probe_glyph_protocol(timeout)
+            self._does_glyph_protocol = 'glyf' in kv.get('fmt', '')
         # conditionally return results, may be None (no support)
         return (
             self._query_font_mintty_protocol(codepoints, timeout)
@@ -1903,11 +1915,11 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
     def _probe_glyph_protocol(self, timeout: Optional[float]) -> Dict[str, str]:
         """
-        Probe for Glyph Protocol support using the 's' verb.
+        Probe for Glyph Protocol support using the ``'s'`` verb.
 
         :arg float timeout: Timeout in seconds.
-        :returns: Dict of CSV key=value pairs (e.g. ``{'fmt': 'glyf,colrv0,colrv1'}``), or empty
-            dict if unsupported.
+        :returns: Dict of pairs, e.g. ``{'fmt': 'glyf,colrv0,colrv1'}``),
+            empty dict when unsupported or timeout.
         :rtype: Dict[str, str]
         """
         if (match := self._query_with_boundary('\x1b_25a1;s\x1b\\',
@@ -1926,15 +1938,17 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             self,
             codepoints: str,
             timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS) -> Optional[str]:
-        int_codepoints = tuple(ord(cp) for cp in codepoints)
-        qsubstr = ';'.join(str(int_cp) for int_cp in int_codepoints)
+        int_codepoints = set(map(ord, codepoints))
+        qsubstr = ';'.join(map(str, int_codepoints))
         query = f'\x1b]7771;?;{qsubstr}\x07'
         if (match := self._query_with_boundary(
                 query, _RE_MINTTY_FONT_RESPONSE, timeout)) is None:
             return None
 
-        supported = set(int(str_val) for str_val in match.group(1).split(';') if str_val)
-        return ''.join(chr(int_val) for int_val in int_codepoints if int_val in supported)
+        supported = set(int(str_val)
+                        for str_val in match.group(1).split(';')
+                        if str_val)
+        return ''.join(cp for cp in codepoints if ord(cp) in supported)
 
     def _query_font_glyph_protocol(self, codepoints: str,
                                    timeout: Optional[float]) -> Optional[str]:
@@ -1944,11 +1958,10 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         if (matches := self._query_boundary_multiple(
                 queries, _RE_GLYPH_PROTOCOL_Q_RESPONSE, timeout)) is None:
             return None
-        supported = set()
-        for match in matches:
-            if match.group(2):
-                supported.add(int(match.group(1), 16))
-        return ''.join(chr(cp) for cp in int_codepoints if cp in supported)
+        supported = set(int(match.group(1), 16)
+                        for match in matches
+                        if match.group(2))
+        return ''.join(cp for cp in codepoints if ord(cp) in supported)
 
     def does_kitty_graphics(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                             force: bool = False) -> bool:

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -128,6 +128,14 @@ _RE_ITERM2_CAPABILITIES_RESPONSE = re.compile(
     r'\x1b\]1337;Capabilities=([^\x07\x1b]+)(?:\x07|\x1b\\)')
 _RE_KITTY_NOTIFICATIONS_RESPONSE = re.compile(
     r'\x1b\]99;([^\x07\x1b]*?)(?:\x07|\x1b\\)')
+# Mintty font glyph coverage: ESC ] 7771 ; ! ; cp1 ; cp2 ; ... BEL/ST
+_RE_MINTTY_FONT_RESPONSE = re.compile(
+    r'\x1b\]7771;!((?:;\d+)*)(?:\x07|\x1b\\)')
+# Glyph Protocol codepoint query response: ESC _ 25a1 ; q ; cp=HEX ; status=VALUE ST
+_RE_GLYPH_PROTOCOL_Q_RESPONSE = re.compile(
+    r'\x1b_25a1;q;cp=([0-9a-fA-F]+);status=([^\x1b\\]*)')
+# Glyph Protocol support probe response: ESC _ 25a1 ; s ; key=val... ST
+_RE_GLYPH_PROTOCOL_S_RESPONSE = re.compile(r'\x1b_25a1;s(;[^\x1b\\]*)')
 _RE_CPR_BOUNDARY = re.compile(r'\x1b\[[0-9]+;[0-9]+R')
 _RE_KITTY_CLIPBOARD = re.compile(r'\x1b\[\?5522;(\d+)\$y')
 _RE_KITTY_POINTER = re.compile(r'\x1b\]22;([^\x07\x1b]+)(?:\x07|\x1b\\)')
@@ -416,6 +424,9 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         self._color_scheme_supported: Optional[bool] = None
         # DECRQSS detection cache
         self._decrqss_supported: Optional[bool] = None
+        # Glyph Protocol probe result -- whether supported at all
+        self._does_mintty_font_protocol: Optional[bool] = None
+        self._does_glyph_protocol: Optional[Dict[str, str]] = None
 
     def __init_set_styling(self, force_styling: bool) -> None:
         self._does_styling = False
@@ -877,7 +888,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
                 ctx = self.cbreak()
                 ctx.__enter__()
 
-            self.stream.write(query_str + '\x1b[6n')
+            self.stream.write(query_str + (self.u7 or '\x1b[6n'))
             self.stream.flush()
 
             # Wait for CPR boundary -- this is always the last response
@@ -902,6 +913,58 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
                 ctx.__exit__(None, None, None)
 
         return feature_match
+
+    def _query_boundary_multiple(self, query_str: str,
+                                 feature_re: "re.Pattern[str]",
+                                 timeout: Optional[float],
+                                 requires_styling: bool = True
+                                 ) -> Optional[List[Match[str]]]:
+        """
+        Like :meth:`_query_with_boundary` but returns all regex matches.
+
+        Sends *query_str* + CPR, reads until the CPR boundary, then returns
+        every match of *feature_re* found in the response data.  Returns an
+        empty list when the terminal does not respond or the stream is not a
+        TTY.
+
+        :arg str query_str: Query string written to output.
+        :arg re.Pattern feature_re: Compiled regex for feature responses.
+        :arg float timeout: Timeout in seconds.
+        :arg bool requires_styling: When True (default), return empty list if
+            :attr:`does_styling` is False.
+        :rtype: List[re.Match]
+        """
+        if not self.is_a_tty:
+            return None
+        if requires_styling and not self.does_styling:
+            return None
+
+        ctx = None
+        try:
+            if self._line_buffered:
+                ctx = self.cbreak()
+                ctx.__enter__()
+
+            self.stream.write(query_str + '\x1b[6n')
+            self.stream.flush()
+
+            cpr_match, data = _read_until(
+                self, _RE_CPR_BOUNDARY.pattern, timeout)
+
+            if cpr_match is None:
+                return None
+
+            data = data[:cpr_match.start()] + data[cpr_match.end():]
+            results = list(feature_re.finditer(data))
+            data = feature_re.sub('', data)
+
+            self.ungetch(data)
+
+        finally:
+            if ctx is not None:
+                ctx.__exit__(None, None, None)
+
+        return results
 
     @contextlib.contextmanager
     def location(self, x: Optional[int] = None, y: Optional[int]
@@ -1188,9 +1251,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         if self._device_attributes_cache is not None and not force:
             return self._device_attributes_cache
 
-        query = '\x1b[c'
         match = self._query_with_boundary(
-            query,
+            self.u9 or '\x1b[c',
             (DeviceAttribute.RE_RESPONSE, DeviceAttribute.RE_RESPONSE_CTERM),
             timeout)
 
@@ -1214,9 +1276,9 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         ``TERM_PROGRAM_VERSION`` environment variables. Returns ``None``
         only if both methods fail.
 
-        **Successful responses are cached indefinitely** unless ``force=True`` is
-        specified. Unlike other query methods, there is no sticky failure mechanism -
-        each failed query can be retried.
+        **Only Successful responses are cached indefinitely** unless ``force=True`` is specified.
+        Unlike other query methods, there is no "sticky failure", failed queries are not cached and
+        are retried.
 
         .. note:: A ``timeout`` value should be set to avoid blocking when the
             terminal does not respond to XTVERSION queries, which may happen with
@@ -1775,36 +1837,21 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         if not caps:
             return None
 
-        ctx = None
-        try:
-            if self._line_buffered:
-                ctx = self.cbreak()
-                ctx.__enter__()
-            for capname in caps:
-                self.stream.write(
-                    f'\x1bP+q{TermcapResponse.hex_encode(capname)}\x1b\\')
-            self.stream.write('\x1b[6n')  # CPR fence
-            self.stream.flush()
-            match, data = _read_until(self, _RE_CPR_BOUNDARY.pattern, timeout)
-        finally:
-            if ctx is not None:
-                ctx.__exit__(None, None, None)
-
-        if match is None:
+        query_str = ''.join(
+            f'\x1bP+q{TermcapResponse.hex_encode(capname)}\x1b\\'
+            for capname in caps)
+        # pylint: disable=protected-access
+        if (matches := self._query_boundary_multiple(
+                query_str, TermcapResponse._RE_XTGETTCAP_RESPONSE, timeout,
+                requires_styling=False)) is None:
             return TermcapResponse()
 
-        # Strip the CPR itself from the response data
-        data = data[:match.start()] + data[match.end():]
-
         capabilities: Dict[str, str] = {}
-        if data:
-            capabilities.update(TermcapResponse.parse_capabilities(data))
-            # pylint: disable=protected-access
-            remaining = TermcapResponse._RE_XTGETTCAP_RESPONSE.sub('', data)
-            if remaining:
-                self.ungetch(remaining)
+        for match in matches:
+            if match.group(1) == '1':
+                name, value = TermcapResponse.from_match(match)
+                capabilities[name] = value
 
-        # Record None sentinel for any requested cap that wasn't answered.
         for capname in caps:
             if capname not in capabilities:
                 capabilities[capname] = None  # type: ignore[assignment]
@@ -1823,6 +1870,85 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         """
         result = self.get_xtgettcap(timeout=timeout, force=force)
         return result is not None
+
+    def does_font_have_codepoints(self, codepoints: str,
+                                  timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
+                                  force: bool = False) -> Optional[Tuple[bool, ...]]:
+        """
+        Query whether each codepoint is supported by the terminal font.
+
+        :arg str codepoints: String whose characters to query.
+        :arg float timeout: Seconds to wait.
+        :arg bool force: Bypass cache.
+        :rtype: Optional[str]
+        """
+        if not self.is_a_tty and not force:
+            return None
+        if not self.does_styling and not force:
+            return None
+        if not codepoints:
+            return ()
+        # check for protocol support
+        if (result := self._query_font_mintty_protocol('blessed')):
+            self._does_mintty_font_protocol = bool(result)
+        elif self._does_glyph_protocol is None:
+            self._does_glyph_protocol = self._probe_glyph_protocol(timeout)
+        # conditionally return results, may be None (no support)
+        return (
+            self._query_font_mintty_protocol(codepoints, timeout)
+            if self._does_mintty_font_protocol else
+            self._query_font_glyph_protocol(codepoints, timeout)
+            if self._does_glyph_protocol else
+            None)
+
+    def _probe_glyph_protocol(self, timeout: Optional[float]) -> Dict[str, str]:
+        """
+        Probe for Glyph Protocol support using the 's' verb.
+
+        :arg float timeout: Timeout in seconds.
+        :returns: Dict of CSV key=value pairs (e.g. ``{'fmt': 'glyf,colrv0,colrv1'}``), or empty
+            dict if unsupported.
+        :rtype: Dict[str, str]
+        """
+        if (match := self._query_with_boundary('\x1b_25a1;s\x1b\\',
+                                               _RE_GLYPH_PROTOCOL_S_RESPONSE,
+                                               timeout)) is None:
+            return {}
+        raw = match.group(1)  # ';fmt=glyf,colrv0,colrv1'
+        result: Dict[str, str] = {}
+        for item in raw.split(';'):
+            if '=' in item:
+                key, val = item.split('=', 1)
+                result[key] = val
+        return result
+
+    def _query_font_mintty_protocol(
+            self,
+            codepoints: str,
+            timeout: float = TERMINAL_QUERY_TIMEOUT_SECONDS) -> Optional[str]:
+        int_codepoints = tuple(ord(cp) for cp in codepoints)
+        qsubstr = ';'.join(str(int_cp) for int_cp in int_codepoints)
+        query = f'\x1b]7771;?;{qsubstr}\x07'
+        if (match := self._query_with_boundary(
+                query, _RE_MINTTY_FONT_RESPONSE, timeout)) is None:
+            return None
+
+        supported = set(int(str_val) for str_val in match.group(1).split(';') if str_val)
+        return ''.join(chr(int_val) for int_val in int_codepoints if int_val in supported)
+
+    def _query_font_glyph_protocol(self, codepoints: str,
+                                   timeout: Optional[float]) -> Optional[str]:
+        int_codepoints = set(map(ord, codepoints))
+        queries = ''.join(
+            f'\x1b_25a1;q;cp={cp:x}\x1b\\' for cp in int_codepoints)
+        if (matches := self._query_boundary_multiple(
+                queries, _RE_GLYPH_PROTOCOL_Q_RESPONSE, timeout)) is None:
+            return None
+        supported = set()
+        for match in matches:
+            if match.group(2):
+                supported.add(int(match.group(1), 16))
+        return ''.join(chr(cp) for cp in int_codepoints if cp in supported)
 
     def does_kitty_graphics(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                             force: bool = False) -> bool:

--- a/tests/test_font_glyph.py
+++ b/tests/test_font_glyph.py
@@ -1,0 +1,189 @@
+"""Test font glyph support detection (does_font_have_codepoints)."""
+import io
+
+import pytest
+
+from .conftest import IS_WINDOWS
+from .accessories import TestTerminal, pty_test
+
+pytestmark = pytest.mark.skipif(
+    IS_WINDOWS, reason="PTY testing not supported on Windows")
+
+_MINTTY_PROBE_REPLY = '\x1b]7771;!;98;108;101;115;100\x07\x1b[99;99R'
+
+
+def test_not_a_tty():
+    """does_font_have_codepoints returns None when not a TTY."""
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True,
+                            is_a_tty=False)
+        result = term.does_font_have_codepoints('abc', timeout=0.01)
+        assert result is None
+    child()
+
+
+def test_no_styling():
+    """does_font_have_codepoints returns None when does_styling is False."""
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=False)
+        result = term.does_font_have_codepoints('abc', timeout=0.01)
+        assert result is None
+    child()
+
+
+def test_empty_string():
+    """does_font_have_codepoints returns empty tuple for empty input."""
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        term._is_a_tty = True
+        result = term.does_font_have_codepoints('', timeout=0.01)
+        assert result == ()
+    child()
+
+
+def test_mintty_all_supported():
+    """Mintty reply lists all codepoints -> all in result string."""
+    def child(term):
+        term.ungetch(
+            _MINTTY_PROBE_REPLY +
+            '\x1b]7771;!;65;66;67\x07\x1b[10;20R')
+        result = term.does_font_have_codepoints('ABC', timeout=0.01)
+        assert result == 'ABC'
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_mintty_all_supported')
+    assert 'OK' in output
+
+
+def test_mintty_partial_support():
+    """Mintty reply omits unsupported codepoints from result."""
+    def child(term):
+        term.ungetch(
+            _MINTTY_PROBE_REPLY +
+            '\x1b]7771;!;65;67\x07\x1b[10;20R')
+        result = term.does_font_have_codepoints('ABC', timeout=0.01)
+        assert result == 'AC'
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_mintty_partial_support')
+    assert 'OK' in output
+
+
+def test_mintty_none_supported():
+    """Mintty reply with empty cp list -> empty result string."""
+    def child(term):
+        term.ungetch(
+            _MINTTY_PROBE_REPLY +
+            '\x1b]7771;!\x07\x1b[10;20R')
+        result = term.does_font_have_codepoints('AB', timeout=0.01)
+        assert result == ''
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_mintty_none_supported')
+    assert 'OK' in output
+
+
+def test_unsupported_protocol():
+    """No protocol probe succeeds -> None."""
+    def child(term):
+        result = term.does_font_have_codepoints('A', timeout=0.01)
+        assert result is None
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_unsupported_protocol')
+    assert 'OK' in output
+
+
+def test_chunking():
+    """Queries larger than _FONT_QUERY_CHUNK_SIZE are chunked."""
+    def child(term):
+        count = 257
+        chars = 'A' * count
+        supported_chunk1 = ''.join(f';{ord(c)}' for c in chars[:256])
+        supported_chunk2 = f';{ord(chars[256])}'
+        term.ungetch(
+            _MINTTY_PROBE_REPLY +
+            f'\x1b]7771;!{supported_chunk1}\x07\x1b[10;20R' +
+            f'\x1b]7771;!{supported_chunk2}\x07\x1b[30;40R')
+        result = term.does_font_have_codepoints(chars, timeout=0.01)
+        assert result == chars
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_chunking')
+    assert 'OK' in output
+
+
+def test_beyond_bmp():
+    """Codepoints beyond the Basic Multilingual Plane are handled."""
+    def child(term):
+        cps = '\U0001f600\U0001f601'
+        term.ungetch(
+            _MINTTY_PROBE_REPLY +
+            f'\x1b]7771;!;{ord(cps[0])};{ord(cps[1])}\x07\x1b[10;20R')
+        result = term.does_font_have_codepoints(cps, timeout=0.01)
+        assert result == cps
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_beyond_bmp')
+    assert 'OK' in output
+
+
+def test_mintty_regex_parsing():
+    """_RE_MINTTY_FONT_RESPONSE parses supported codepoint list."""
+    from blessed.terminal import _RE_MINTTY_FONT_RESPONSE
+
+    match = _RE_MINTTY_FONT_RESPONSE.search('\x1b]7771;!;65;66;67\x07')
+    assert match is not None
+    assert match.group(1) == ';65;66;67'
+
+    match = _RE_MINTTY_FONT_RESPONSE.search('\x1b]7771;!\x07')
+    assert match is not None
+    assert match.group(1) == ''
+
+    match = _RE_MINTTY_FONT_RESPONSE.search('\x1b]7771;!;128512\x1b\\')
+    assert match is not None
+    assert match.group(1) == ';128512'
+
+
+def test_glyph_font_regex_parsing():
+    """_RE_GLYPH_PROTOCOL_Q_RESPONSE parses cp and status fields."""
+    from blessed.terminal import _RE_GLYPH_PROTOCOL_Q_RESPONSE
+
+    matches = list(_RE_GLYPH_PROTOCOL_Q_RESPONSE.finditer(
+        '\x1b_25a1;q;cp=41;status=system\x1b\\'
+        '\x1b_25a1;q;cp=42;status=\x1b\\'
+        '\x1b_25a1;q;cp=43;status=system,glossary\x1b\\'))
+    assert len(matches) == 3
+    assert int(matches[0].group(1), 16) == 0x41
+    assert matches[0].group(2) == 'system'
+    assert int(matches[1].group(1), 16) == 0x42
+    assert matches[1].group(2) == ''
+    assert int(matches[2].group(1), 16) == 0x43
+    assert matches[2].group(2) == 'system,glossary'
+
+
+def test_glyph_protocol_support_regex():
+    """_RE_GLYPH_PROTOCOL_S_RESPONSE matches s verb response with capturing group."""
+    from blessed.terminal import _RE_GLYPH_PROTOCOL_S_RESPONSE
+
+    match = _RE_GLYPH_PROTOCOL_S_RESPONSE.search('\x1b_25a1;s;fmt=glyf,colrv0\x1b\\')
+    assert match is not None
+    assert match.group(1) == ';fmt=glyf,colrv0'
+
+    match = _RE_GLYPH_PROTOCOL_S_RESPONSE.search('\x1b_25a1;s;fmt=glyf\x1b\\')
+    assert match is not None
+    assert match.group(1) == ';fmt=glyf'
+
+    match = _RE_GLYPH_PROTOCOL_S_RESPONSE.search('\x1b_25a1;s;fmt=\x1b\\')
+    assert match is not None
+    assert match.group(1) == ';fmt='
+
+    assert _RE_GLYPH_PROTOCOL_S_RESPONSE.search('\x1b_25a1;s\x1b\\') is None
+    assert _RE_GLYPH_PROTOCOL_S_RESPONSE.search(
+        '\x1b_25a1;q;cp=41;status=system\x1b\\') is None


### PR DESCRIPTION
This adds support for detecting "tofu" or codepoints unsupported by the fonts used in the user's terminal, allows to detect for font/octant/v. limited emoji support.

- also refactors "spray and collect" pattern used by XTGETTCAP batch query to common internal method `_query_boundary_multiple`