### PR TITLE
bugfix dropped keysrokes in async_inkey

### DIFF
--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -15,4 +15,4 @@ else:
 from blessed.line_editor import LineEditor, LineHistory
 
 __all__ = ('Terminal', 'LineEditor', 'LineHistory')
-__version__ = "1.47.0"
+__version__ = "1.48.0"

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -4159,6 +4159,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
             raise RuntimeError(
                 "async_inkey requires a keyboard file descriptor")
         fut: asyncio.Future[bytes] = loop.create_future()
+        timed_out = False
 
         def _on_readable() -> None:
             if not fut.done():
@@ -4168,16 +4169,23 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
                 except OSError as exc:
                     fut.set_exception(exc)
 
+        def _on_timeout() -> None:
+            nonlocal timed_out
+            if not fut.done():
+                timed_out = True
+                fut.set_result(b"")
+
         loop.add_reader(self._keyboard_fd, _on_readable)
+        handle = loop.call_later(timeout, _on_timeout) if timeout is not None else None
         try:
-            if timeout is not None:
-                try:
-                    return await asyncio.wait_for(fut, timeout=timeout)
-                except asyncio.TimeoutError:
-                    return None
-            return await fut
+            data = await fut
         finally:
+            if handle is not None:
+                handle.cancel()
             loop.remove_reader(self._keyboard_fd)
+        if timed_out:
+            return None
+        return data
 
 
 class WINSZ(collections.namedtuple('WINSZ', (

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,6 +2,9 @@
 
 Version History
 ===============
+1.48
+  * bugfix: :meth:`~Terminal.async_inkey` dropped keystrokes while another task is busy.
+
 1.47
   * bugfix: :meth:`~Terminal.does_sixel` now returns ``True`` for SyncTERM using special-case
     matching of its illegal DA1 response.

--- a/tests/test_async_inkey.py
+++ b/tests/test_async_inkey.py
@@ -328,3 +328,55 @@ def test_async_inkey_no_keyboard_fd():
         finally:
             loop.close()
     child()
+
+
+def test_async_read_byte_deadline_same_iteration_no_loss():
+    """A byte arriving while the loop is busy past the deadline is not lost."""
+    def child(term):
+        with term.cbreak():
+            loop = asyncio.new_event_loop()
+            try:
+                def busy():
+                    os.write(sys.__stdout__.fileno(), SEMAPHORE)
+                    time.sleep(1.0)
+
+                loop.call_later(0.05, busy)
+                result = loop.run_until_complete(
+                    term._async_read_byte(loop, timeout=0.1))
+            finally:
+                loop.close()
+            assert result == b'x', f'byte lost: _async_read_byte returned {result!r}'
+            return b'OK'
+
+    def parent(master_fd):
+        read_until_semaphore(master_fd)
+        os.write(master_fd, b'x')
+
+    output = pty_test(child, parent, 'test_async_read_byte_deadline_same_iteration_no_loss')
+    assert output == 'OK'
+
+
+def test_async_read_byte_deadline_wins_byte_stays():
+    """A byte arriving after a deadline win is read by the next call."""
+    def child(term):
+        os.write(sys.__stdout__.fileno(), SEMAPHORE)
+        with term.cbreak():
+            loop = asyncio.new_event_loop()
+            try:
+                result = loop.run_until_complete(
+                    term._async_read_byte(loop, timeout=0.05))
+                assert result is None
+                result2 = loop.run_until_complete(
+                    term._async_read_byte(loop, timeout=1.0))
+                assert result2 == b'x'
+            finally:
+                loop.close()
+            return b'OK'
+
+    def parent(master_fd):
+        read_until_semaphore(master_fd)
+        time.sleep(0.1)
+        os.write(master_fd, b'x')
+
+    output = pty_test(child, parent, 'test_async_read_byte_deadline_wins_byte_stays')
+    assert output == 'OK'

--- a/tests/test_full_keyboard.py
+++ b/tests/test_full_keyboard.py
@@ -881,7 +881,7 @@ def test_esc_delay_while_loop_with_continued_input():
     def child(term):
         os.write(sys.__stdout__.fileno(), SEMAPHORE)
         with term.cbreak():
-            ks = term.inkey(timeout=1.0, esc_delay=TEST_TIMEOUT_SHORT)
+            ks = term.inkey(timeout=1.0, esc_delay=0.3)
             return ks.name.encode('ascii')
 
     def parent(master_fd):


### PR DESCRIPTION
Problem
------------

`async_inkey()` is more likely to drop some keystrokes when another task is busy, due to a race condition between `_on_timeout` and `_on_readable` around its shared future, a byte could be read for `fut` Future, but not returned!

Solution
------------

Make an `_on_timeout` that shares the same `fut` Future result, so that only one of the reader or timeout callbacks are successful, and the other is cancelled.