### PR TITLE
Improved performance by caching jinxed.tparm calls

### DIFF
--- a/bin/scroller.py
+++ b/bin/scroller.py
@@ -5,6 +5,12 @@ import time
 import blessed
 from wcwidth import TextSizing, TextSizingParams, iter_graphemes, wcswidth
 
+TARGET_FPS = 60.0
+SCROLL_RATE = 4.0        # graphemes per second
+SWEEP_PERIOD = 16.0      # seconds per spatial-frequency sweep
+BOUNCE_RATE = 0.6        # radians per second
+SHIMMER_PERIOD = 18.0    # seconds per color shimmer cycle
+
 FRACTIONS = [(n, d) for d in range(1, 16) for n in range(0, d)]
 
 
@@ -99,13 +105,22 @@ def main():
     graphemes = list(iter_graphemes(_MESSAGE))
     graph_len = len(graphemes)
 
+    frame_budget = 1.0 / TARGET_FPS
+    sweep_w = 2 * math.pi / SWEEP_PERIOD
+    shimmer_w = 2 * math.pi / SHIMMER_PERIOD
+
     with term.cbreak(), term.hidden_cursor():
-        t = 0.0
-        scroll_pos = 0.0
-        bounce_phase = 0.0
+        # animation is a function of elapsed time, so that its speed is independent of how
+        # quickly any given terminal can draw a frame.
+        anim = 0.0
+        prev = time.monotonic()
         paused = False
 
         while True:
+            now = time.monotonic()
+            delta = now - prev
+            prev = now
+
             if term.kbhit(timeout=0):
                 key = term.inkey(timeout=0)
                 if key == 'q' or key == '\x03':
@@ -117,14 +132,14 @@ def main():
                 time.sleep(0.042)
                 continue
 
-            t += 1.0
-            scroll_pos += 0.003
-            bounce_phase += 0.0006
+            anim += delta
+            scroll_pos = anim * SCROLL_RATE
+            bounce_phase = anim * BOUNCE_RATE
 
             graph_offset = int(scroll_pos) % graph_len
 
             base_freq = 2 * math.pi / screen_w
-            spatial_freq = base_freq * (0.2 + 1.8 * (math.sin(t * 0.0004) + 1.0) / 2.0)
+            spatial_freq = base_freq * (0.2 + 1.8 * (math.sin(anim * sweep_w) + 1.0) / 2.0)
 
             col_scales = []
             for col in range(screen_w):
@@ -158,7 +173,7 @@ def main():
                     break
 
                 lerp_t = (y - (screen_h // 2 - vert_amp)) / max(1, vert_amp * 2)
-                lerp_t += 0.15 * math.sin(t * 0.00035)
+                lerp_t += 0.15 * math.sin(anim * shimmer_w)
                 lerp_t = max(0.0, min(1.0, lerp_t))
                 fg = _fire_color(lerp_t)
 
@@ -167,6 +182,11 @@ def main():
 
             with term.dec_modes_enabled(term.DecPrivateMode.SYNCHRONIZED_OUTPUT):
                 print(buf, end='', flush=True)
+
+            # sleep out whatever remains of this frame's budget, if anything.
+            slack = frame_budget - (time.monotonic() - now)
+            if slack > 0:
+                time.sleep(slack)
 
 
 if __name__ == '__main__':

--- a/blessed/formatters.py
+++ b/blessed/formatters.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import pkgutil
 import warnings
+import functools
 import importlib
 from typing import TYPE_CHECKING, Set, List, Tuple, Union, Callable
 
@@ -74,6 +75,41 @@ COMPOUNDABLES: Set[str] = {'bold', 'underline', 'reverse', 'blink', 'dim', 'ital
                            'standout', 'strikethrough', 'overline'}
 
 
+@functools.lru_cache(maxsize=16384)
+def _tparm_cached(cap: str, args: Tuple[object, ...]) -> str:
+    """Memoized call to :func:`jinxed.tparm`."""
+    return jinxed.tparm(cap.encode('latin1'), *args).decode('latin1')
+
+
+def _tparm(cap: str, args: Tuple[object, ...]) -> str:
+    r"""
+    Return evaluated capability ``cap`` for ``args``, memoized where safe.
+
+    :func:`jinxed.tparm` is a pure-python reimplementation of ``tparm(3)``,
+    but a bit slow. tparm() is pure function, and so results are cached.
+
+    :arg str cap: parameterized capability string.
+    :arg tuple args: arguments for ``cap``.
+    :rtype: str
+    :returns: evaluated capability.
+    """
+    # '%PA'-'%PZ' pop the stack into a terminfo static variable, read back by '%gA'-'%gZ'.  jinxed
+    # holds these on a single module-level tparm instance, where they outlive the call that set
+    # them, so such a capability is *not* a pure function of (cap, args) and must never be cached.
+    # (lowercase '%Pa'-'%Pz' are reset each call, but this cheap test does not distinguish case)
+    if '%P' in cap or '%g' in cap:
+        return jinxed.tparm(cap.encode('latin1'), *args).decode('latin1')
+    try:
+        # Hashability tested up front, rather than by catching TypeError from lru_cache, so that a
+        # TypeError raised by tparm() itself does not get retried.
+        hash(args)
+    except TypeError:
+        # an unhashable argument cannot be cached (and is surely an error), call through tparm() to
+        # allow it to (probably) raise on its own.
+        return jinxed.tparm(cap.encode('latin1'), *args).decode('latin1')
+    return _tparm_cached(cap, args)
+
+
 class ParameterizingString(str):
     r"""
     A Unicode string which can be called as a parameterizing termcap.
@@ -115,14 +151,10 @@ class ParameterizingString(str):
         :returns: Callable string for given parameters
         """
         try:
-            # Re-encode the cap, because tparm() takes a bytestring in Python
-            # 3. However, appear to be a plain Unicode string otherwise so
-            # concats work.
-            attr = jinxed.tparm(self.encode('latin1'), *args).decode('latin1')
+            attr = _tparm(self, args)
             return FormattingString(attr, self._normal)
         except TypeError as err:
-            # If the first non-int (i.e. incorrect) arg was a string, suggest
-            # something intelligent:
+            # If the first non-int arg was a string, suggest something helpful:
             if args and isinstance(args[0], str):
                 raise TypeError(
                     f"Unknown terminal capability, {self._name!r}, or, TypeError "

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,7 +3,10 @@
 Version History
 ===============
 1.48
-  * bugfix: :meth:`~Terminal.async_inkey` dropped keystrokes while another task is busy.
+  * improve: all parameterized capabilities are now memorized, about 50x faster, :ghpull:`404`.  *
+    bugfix: :meth:`~Terminal.truncate` by bump of dependency ``wcwidth>=0.8.3``, :ghissue:`402`.  *
+    bugfix: :meth:`~Terminal.async_inkey` dropped keystrokes while another task is busy,
+    :ghissue:`401`.
 
 1.47
   * bugfix: :meth:`~Terminal.does_sixel` now returns ``True`` for SyncTERM using special-case

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ classifiers = [
     'Typing :: Typed',
 ]
 dependencies = [
-    'wcwidth>=0.8.1',
+    'wcwidth>=0.8.3',
     'jinxed>=2.1,<3',
 ]
 dynamic = ['version']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,9 @@ import platform
 # 3rd party
 import pytest
 
+# local
+from blessed.formatters import _tparm_cached
+
 
 def pytest_configure(config: pytest.Config) -> None:
     """Normalize environment for consistent test results outside of tox."""
@@ -28,6 +31,15 @@ except ImportError:
         return _passthrough
 
 IS_WINDOWS = platform.system() == 'Windows'
+
+
+@pytest.fixture(autouse=True)
+def clear_tparm_cache():
+    """Discard memoized tparm() results between tests."""
+    _tparm_cached.cache_clear()
+    yield
+    _tparm_cached.cache_clear()
+
 
 many_lines_params = [40, 80]
 # we must test a '1' column for conditional in _handle_long_word

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -204,3 +204,19 @@ def test_wrap_emoji_zwj(benchmark):
     """Benchmark wrap() with ZWJ emoji sequences."""
     term = TestTerminal(force_styling=True)
     benchmark(term.wrap, TEXT_EMOJI_ZWJ, 40)
+
+
+def test_move_yx_full_screen(benchmark):
+    """Benchmark move_yx() once per cell of a full screen."""
+    def _full_screen_moves(term):
+        return ''.join(term.move_yx(y, x) for y in range(24) for x in range(80))
+    term = TestTerminal(force_styling=True)
+    benchmark(_full_screen_moves, term)
+
+
+def test_color_256(benchmark):
+    """Benchmark color() across all indexes of a 256-color terminal."""
+    def _all_256_colors(term):
+        return ''.join(term.color(idx) for idx in range(256))
+    term = TestTerminal(force_styling=True)
+    benchmark(_all_256_colors, term)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -101,6 +101,7 @@ def test_parameterizing_string_args(monkeypatch):
 
 def test_parameterizing_string_memoized(tparm_calls):
     """Test formatters.ParameterizingString memoizes tparm() results."""
+    # pylint: disable=redefined-outer-name
     # local
     from blessed.formatters import ParameterizingString
 
@@ -136,6 +137,7 @@ def test_parameterizing_string_memoized(tparm_calls):
 
 def test_parameterizing_string_static_vars_not_memoized(tparm_calls):
     """Test capabilities using terminfo static variables are never memoized."""
+    # pylint: disable=redefined-outer-name
     # local
     from blessed.formatters import ParameterizingString
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -26,6 +26,19 @@ def fn_tparm(*args):
     ).encode('latin1')
 
 
+@pytest.fixture
+def tparm_calls(monkeypatch):
+    """Patch jinxed.tparm() by :func:`fn_tparm`, returning a list of its calls."""
+    calls = []
+
+    def fn_tparm_counted(*args):
+        calls.append(args)
+        return fn_tparm(*args)
+
+    monkeypatch.setattr(jinxed, 'tparm', fn_tparm_counted)
+    return calls
+
+
 def test_parameterizing_string_args_unspecified(monkeypatch):
     """Test default args of formatters.ParameterizingString."""
     # local
@@ -86,12 +99,79 @@ def test_parameterizing_string_args(monkeypatch):
     assert onetwo('text') == 'cap~1~2textnorm'
 
 
+def test_parameterizing_string_memoized(tparm_calls):
+    """Test formatters.ParameterizingString memoizes tparm() results."""
+    # local
+    from blessed.formatters import ParameterizingString
+
+    pstr = ParameterizingString('cap', 'norm', 'seq-name')
+
+    assert pstr(0) == 'cap~0'
+    assert pstr(0) == 'cap~0'
+    assert len(tparm_calls) == 1
+
+    # a distinct instance of the same capability shares the cache, and
+    # differing arguments are cached separately.
+    assert ParameterizingString('cap', 'norm', 'seq-name')(0) == 'cap~0'
+    assert len(tparm_calls) == 1
+    assert pstr(1) == 'cap~1'
+    assert len(tparm_calls) == 2
+
+    # the terminating sequence is not part of the cache key: this instance
+    # differs from ``pstr`` only by its ``normal``, so it hits the entry
+    # memoized above for ('cap', (0,)) without calling tparm() again,
+    other = ParameterizingString('cap', 'other-norm', 'seq-name')(0)
+    assert len(tparm_calls) == 2
+
+    # ... and yet the sequence it terminates with is its own 'other-norm',
+    # rather than the 'norm' of the instance that populated that entry.
+    assert other('text') == 'cap~0textother-norm'
+
+    # an unhashable argument is never cached: hashability is tested before
+    # the cache is consulted, so each call reaches tparm() exactly once.
+    assert pstr(['unhashable']) == "cap~['unhashable']"
+    assert pstr(['unhashable']) == "cap~['unhashable']"
+    assert len(tparm_calls) == 4
+
+
+def test_parameterizing_string_static_vars_not_memoized(tparm_calls):
+    """Test capabilities using terminfo static variables are never memoized."""
+    # local
+    from blessed.formatters import ParameterizingString
+
+    # '%PA' pops the stack into terminfo static variable 'A', pushed back by '%gA'.  Unlike
+    # parameters, such variables outlive the call that set them, so a capability using them
+    # reads or writes state, is not a pure function of (cap, args), and is never memoized.
+    for cap in ('cap%PA', 'cap%gA'):
+        del tparm_calls[:]
+        pstr = ParameterizingString(cap, 'norm', 'seq-name')
+        pstr(0)
+        pstr(0)
+        assert len(tparm_calls) == 2, cap
+
+
+def test_parameterizing_string_unhashable_arg():
+    """Test formatters.ParameterizingString with an argument that cannot be cached."""
+    # local
+    from blessed.formatters import ParameterizingString
+
+    pstr = ParameterizingString('\x1b[%i%p1%d;%p2%dH', 'norm', 'cup')
+
+    # an unhashable argument cannot be memoized, tparm() still raises on its
+    # own terms rather than 'unhashable type' from the cache.
+    with pytest.raises(TypeError, match='Parameters must be integers or bytes'):
+        pstr(['not', 'hashable'], 2)
+
+
 def test_parameterizing_string_type_error(monkeypatch):
     """Test formatters.ParameterizingString raising TypeError."""
     # local
     from blessed.formatters import ParameterizingString
 
+    calls = []
+
     def tparm_raises_TypeError(*args):
+        calls.append(args)
         raise TypeError('custom_err')
 
     monkeypatch.setattr(jinxed, 'tparm', tparm_raises_TypeError)
@@ -115,6 +195,9 @@ def test_parameterizing_string_type_error(monkeypatch):
         assert False, "previous call should have raised TypeError"
     except TypeError as err:
         assert err.args[0] == "custom_err"
+
+    # a TypeError raised by tparm() itself is not retried by the cache.
+    assert len(calls) == 2
 
 
 def test_formattingstring(monkeypatch):

--- a/tests/test_full_keyboard.py
+++ b/tests/test_full_keyboard.py
@@ -303,8 +303,8 @@ def test_keystroke_0s_cbreak_sequence():
     assert math.floor(time.time() - stime) == 0.0
 
 
-def test_keystroke_20ms_cbreak_with_input():
-    """1-second keystroke w/multibyte sequence; should return after ~1 second."""
+def test_keystroke_15ms_cbreak_with_input():
+    """Multibyte sequence arriving after 15ms returns then, not at inkey()'s 5 second timeout."""
     def child(term):
         os.write(sys.__stdout__.fileno(), SEMAPHORE)
         with term.cbreak():
@@ -317,9 +317,9 @@ def test_keystroke_20ms_cbreak_with_input():
         os.write(master_fd, '\x1b[C'.encode('ascii'))
 
     stime = time.time()
-    output = pty_test(child, parent, 'test_keystroke_20ms_cbreak_with_input')
+    output = pty_test(child, parent, 'test_keystroke_15ms_cbreak_with_input')
     assert output == 'KEY_RIGHT'
-    assert_elapsed_range_ms(stime, 5, 25)
+    assert_elapsed_range_ms(stime, 1, 25)
 
 
 def test_esc_delay_cbreak():

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -9,8 +9,8 @@ import pytest
 
 # local
 from .conftest import IS_WINDOWS
-from .accessories import (
-    TestTerminal, unicode_cap, unicode_parm, pty_test)
+from blessed.sequences import Termcap
+from .accessories import (TestTerminal, unicode_cap, unicode_parm, pty_test)
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="requires real tty")
@@ -616,9 +616,6 @@ def test_formatting_other_string(any_term):
 def test_termcap_match_optional():
     """When match_optional is given, numeric matches are optional"""
     def child():
-        # local
-        from blessed.sequences import Termcap
-
         t = TestTerminal(force_styling=True)
         cap = Termcap.build('move_right', t.cuf, 'cuf', nparams=1,
                             match_grouped=True, match_optional=True)
@@ -638,27 +635,52 @@ def test_termcap_match_optional():
     child()
 
 
-def test_truncate(any_term):
+def test_truncate():
     """Test terminal.truncate and make sure it agrees with terminal.length"""
-    def child(kind):
-        # local
-
-        term = TestTerminal(kind=kind)
-
+    def child():
+        term = TestTerminal(kind='xterm', force_styling=True)
         test_string = (
-            f'{term.red("Testing")} {term.yellow("makes")} {term.green("me")} '
-            f'{term.blue("feel")} {term.indigo("good")}{term.normal}'
+            f'{term.red("Testing")} {term.yellow("yellow")} {term.green("peppers")} '
+            f'{term.blue("and blue")} {term.indigo("berries")}{term.normal}'
         )
         stripped_string = term.strip_seqs(test_string)
         for i in range(len(stripped_string)):
             test_l = term.length(term.truncate(test_string, i))
             assert test_l == len(stripped_string[:i])
 
-        # Verify truncating removes "good" - check length and visible content
-        target_width = term.length(test_string) - len("good")
-        trunc = term.truncate(test_string, target_width)
-        assert term.length(trunc) == target_width
-        assert term.strip_seqs(trunc) == "Testing makes me feel "
+        truncate_width = term.length(test_string) - len(" and blue berries")
+        result = term.truncate(test_string, truncate_width)
+        assert term.length(result) == truncate_width
+        assert term.strip_seqs(result) == "Testing yellow peppers"
+        assert result == '\x1b[31mTesting\x1b[m \x1b[33myellow\x1b[m \x1b[32mpeppers\x1b[0m'
+
+        # leading sequence is preserved, and, a reset sequence is appended.
+        result = term.truncate(test_string, 7)
+        assert result == '\x1b[31mTesting\x1b[0m'
+
+    child()
+
+
+def test_truncate_inner_sequences(any_term):
+    """Sequences within the truncated region remain at their original position, #402."""
+    def child(kind):
+        # local
+        term = TestTerminal(kind=kind, force_styling=True)
+
+        # a string that fits entirely is returned unmodified, except that a
+        # trailing reset may be appended when styling is still active.
+        given = f'{term.bold("bold")} normal'
+        assert term.truncate(given, term.length(given)).startswith(given)
+
+        # (the trailing reset may be re-spelled as the canonical '\x1b[0m')
+        given = f'{term.red("red")}{term.green("green")}'
+        trunc = term.truncate(given, term.length(given))
+        assert trunc.startswith(f'{term.red("red")}{term.green}green')
+        assert term.strip_seqs(trunc) == 'redgreen'
+
+        # and when the tail is truncated away, the sequences of the remaining
+        # region are still emitted in place.
+        assert term.truncate(given, 4).startswith(f'{term.red("red")}{term.green}g')
 
     child(any_term)
 
@@ -682,7 +704,7 @@ def test_truncate_wcwidth_clipping(any_term):
     def child(kind):
         # local
 
-        term = TestTerminal(kind=kind)
+        term = TestTerminal(kind=kind, force_styling=True)
         assert term.truncate("", 4) == ""
         # Control character \x01 has zero width
         test_string = term.blue("one\x01two")
@@ -698,7 +720,7 @@ def test_truncate_padding(any_term):
     def child(kind):
         # local
 
-        term = TestTerminal(kind=kind)
+        term = TestTerminal(kind=kind, force_styling=True)
 
         if term.move_right(5):
             test_right_string = term.blue(f"one{term.move_right(5)}two")


### PR DESCRIPTION
This is a more general-purpose version of #403 by @btpence, to improve performance of repeated calls to `jinxed.tparm`, like the many ``move_yx()`` calls done in bin/scroller.py.

A few releases ago, we used python's curses.tparm on linux, which was faster but not as portable or thread-safe as our pure python tparm() in jinxed.
