### PR TITLE
Improve performance of automatic query responses

### DIFF
--- a/bin/keymatrix.py
+++ b/bin/keymatrix.py
@@ -4,7 +4,8 @@ Advanced keyboard and special modes interaction and testing tool.
 
 Usage:
 - F1-F7:    Toggle DEC private modes
-- F8:       Toggle SGR mouse mode (1006). Turn OFF for legacy ``ESC [ M`` format
+- F8:       Toggle SGR mouse mode (1006), OFF activates the legacy
+            ``ESC [ M`` report format of mode 1000
 - F9:       Toggle drag tracking (1002)
 - F10:      Toggle all-motion tracking (1003)
 - F11:      Toggle pixel coordinates (1016)
@@ -189,17 +190,19 @@ class MouseModeManager:
     def probe(self) -> List[str]:
         """Probe terminal for mouse support and return log messages."""
         self.supported = self.term.does_mouse()
-        if self.supported:
-            return ["Mouse support detected!"]
-        return ["Mouse support not available!"]
+        if not self.supported:
+            return ["Mouse support not available!"]
+        return ["Mouse support detected!", self._apply()]
 
-    def _pick_tracking_mode(self) -> Optional[DecPrivateMode]:
-        """Return the highest-priority tracking DEC mode, or None."""
+    def _pick_tracking_mode(self) -> DecPrivateMode:
+        """Return the highest-priority tracking DEC mode."""
+        # A tracking mode is what makes the terminal report at all: without one, mode
+        # 1006 only selects the encoding of reports that are never sent.
         if self.report_motion:
             return DecPrivateMode.MOUSE_ALL_MOTION
         if self.report_drag:
             return DecPrivateMode.MOUSE_REPORT_DRAG
-        return None
+        return DecPrivateMode.MOUSE_REPORT_CLICK
 
     def toggle_by_index(self, f_idx: int) -> str:
         """Toggle mouse mode by F-key index and return log message."""
@@ -222,24 +225,25 @@ class MouseModeManager:
         elif mode_name == 'pixels':
             self.report_pixels = not self.report_pixels
 
+        return self._apply()
+
+    def _apply(self) -> str:
+        """Re-enable the DEC modes selected by the current flags."""
         # Clean up old context
         if self.active_context is not None:
             self.active_context.__exit__(None, None, None)
             self.active_context = None
 
-        # Build modes list — include SGR (1006) only when report_sgr is ON
-        modes = []
+        # Build modes list — include SGR (1006) only when report_sgr is ON, so that
+        # switching it off activates the legacy 'ESC [ M' report format.
+        modes = [self._pick_tracking_mode()]
         if self.report_sgr:
             modes.append(DecPrivateMode.MOUSE_EXTENDED_SGR)
-        tracking_mode = self._pick_tracking_mode()
-        if tracking_mode is not None:
-            modes.append(tracking_mode)
         if self.report_pixels:
             modes.append(DecPrivateMode.MOUSE_SGR_PIXELS)
 
-        if modes:
-            self.active_context = self.term.dec_modes_enabled(*modes)
-            self.active_context.__enter__()
+        self.active_context = self.term.dec_modes_enabled(*modes)
+        self.active_context.__enter__()
 
         return (
             f'Mouse: sgr={self.report_sgr} '
@@ -252,17 +256,15 @@ class MouseModeManager:
         """Return header message showing current mouse modes."""
         if not self.supported:
             return "Mouse: not supported"
-        status = []
-        if self.report_sgr:
-            status.append("SGR")
+        status = ["SGR" if self.report_sgr else "legacy"]
         if self.report_drag:
             status.append("drag")
         if self.report_motion:
             status.append("motion")
         if self.report_pixels:
             status.append("pixels")
-        status_str = "+".join(status) if status else "disabled"
-        return f"Mouse: {status_str} [F8=SGR F9=drag F10=motion F11=pixels]"
+        return (f'Mouse: {"+".join(status)} '
+                f'[F8=SGR/legacy F9=drag F10=motion F11=pixels]')
 
     def toggle_keynames(self) -> List[str]:
         """Return list of key names that toggle mouse modes."""

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -1504,39 +1504,38 @@ def _read_until(term: 'Terminal',
     must ensure any such keyboard data is well-received by the next call to
     term.inkey() without delay.
     """
-    # Maximum buffer size to prevent runaway condition -- one such example is automatic terminal
-    # responses that get echoed back indefinitely in an accidental LINEMODE telnet server. 64KB is
-    # far more than any legitimate automatic terminal response could be.
+    # Maximum buffer size to prevent runaway condition. 64KB is more than any query blessed makes
+    # for automatic terminal response. This prevents "loops" by misbehaving protocols and clients.
     max_buffer_size = 65536
 
+    # pylint: disable=protected-access
     stime = time.time()
     match, buf = None, ''
     while True:  # pragma: no branch
-        # block as long as necessary to ensure at least one character is
-        # received on input or remaining timeout has elapsed.
-        ucs = term.inkey(timeout=_time_left(stime, timeout), esc_delay=0)
-        # while the keyboard buffer is "hot" (has input), we continue to
-        # aggregate all awaiting data.  We do this to ensure slow I/O
-        # calls do not unnecessarily give up within the first 'while' loop
-        # for short timeout periods.
-        while ucs:
-            buf += ucs
-            # Check buffer size limit to catch echo loops early
-            if len(buf) > max_buffer_size:
-                break
-            ucs = term.inkey(timeout=0, esc_delay=0)
+        # Take whatever a previous query left in buffer.
+        while term._keyboard_buf:
+            buf += term._keyboard_buf.pop()
+
+        # and then all data immediately available on input, if any
+        buf += term._read_available()
 
         match = re.search(pattern=pattern, string=buf)
         if match is not None:
             # match
             break
 
+        if len(buf) > max_buffer_size:
+            # buffer overflow - likely an echo loop or misbehaving terminal
+            break
+
         if timeout is not None and not _time_left(stime, timeout):
             # timeout
             break
 
-        if len(buf) > max_buffer_size:
-            # buffer overflow - likely an echo loop or misbehaving terminal
+        # block as long as necessary to ensure at least one character is received on
+        # input, or the remaining timeout has elapsed.
+        if not term.kbhit(timeout=_time_left(stime, timeout)):
+            # timeout
             break
 
     return match, buf

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -137,6 +137,9 @@ _RE_COLOR_SCHEME_MODE_RESPONSE = re.compile(r'\x1b\[\?997;([12])n')
 # DECRQSS: DCS Ps $ r Pt ST (Ps=1 means valid)
 _RE_DECRQSS_RESPONSE = re.compile(r'\x1bP([01])\$r([^\x1b]*)\x1b\\')
 
+# Number of bytes read by a single system call of Terminal._read_available()
+_KEYBOARD_READ_SIZE = 4096
+
 
 class Terminal():  # pylint: disable=attribute-defined-outside-init
     """
@@ -270,6 +273,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         self._init_descriptor = None
         self._is_a_tty = False
         self._keyboard_buf: 'collections.deque[str]' = collections.deque()
+        self._mouse_latin1_pending = 0
         self._dec_mode_cache: Dict[int, int] = {}
         self.__init__streams()
         self.__init_set_styling(force_styling)
@@ -902,6 +906,49 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
                 ctx.__exit__(None, None, None)
 
         return feature_match
+
+    def _query_boundary_multiple(self, query_str: str,
+                                 feature_re: "re.Pattern[str]",
+                                 timeout: Optional[float],
+                                 requires_styling: bool = True
+                                 ) -> Optional[List[Match[str]]]:
+        """Like _query_with_boundary(), but for a query with many replies."""
+        # Returns every match of *feature_re* in the data read, an empty list when the
+        # CPR boundary arrived without any, or None when the stream is not a TTY, or
+        # *requires_styling* is unmet, or the CPR boundary itself never arrived.  Data
+        # that is not a match is pushed back for inkey().
+        if not self.is_a_tty:
+            return None
+        if requires_styling and not self.does_styling:
+            return None
+
+        ctx = None
+        try:
+            if self._line_buffered:
+                ctx = self.cbreak()
+                ctx.__enter__()
+
+            # note: a literal CPR, not self.u7, because this runs during
+            # Terminal.__init__, before any terminfo capability may be resolved.
+            self.stream.write(query_str + '\x1b[6n')
+            self.stream.flush()
+
+            cpr_match, data = _read_until(
+                self, _RE_CPR_BOUNDARY.pattern, timeout)
+
+            if cpr_match is None:
+                return None
+
+            data = data[:cpr_match.start()] + data[cpr_match.end():]
+            results = list(feature_re.finditer(data))
+
+            self.ungetch(feature_re.sub('', data))
+
+        finally:
+            if ctx is not None:
+                ctx.__exit__(None, None, None)
+
+        return results
 
     @contextlib.contextmanager
     def location(self, x: Optional[int] = None, y: Optional[int]
@@ -1775,36 +1822,21 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         if not caps:
             return None
 
-        ctx = None
-        try:
-            if self._line_buffered:
-                ctx = self.cbreak()
-                ctx.__enter__()
-            for capname in caps:
-                self.stream.write(
-                    f'\x1bP+q{TermcapResponse.hex_encode(capname)}\x1b\\')
-            self.stream.write('\x1b[6n')  # CPR fence
-            self.stream.flush()
-            match, data = _read_until(self, _RE_CPR_BOUNDARY.pattern, timeout)
-        finally:
-            if ctx is not None:
-                ctx.__exit__(None, None, None)
-
-        if match is None:
+        query_str = ''.join(
+            f'\x1bP+q{TermcapResponse.hex_encode(capname)}\x1b\\'
+            for capname in caps)
+        # pylint: disable=protected-access
+        if (matches := self._query_boundary_multiple(
+                query_str, TermcapResponse._RE_XTGETTCAP_RESPONSE, timeout,
+                requires_styling=False)) is None:
             return TermcapResponse()
 
-        # Strip the CPR itself from the response data
-        data = data[:match.start()] + data[match.end():]
-
         capabilities: Dict[str, str] = {}
-        if data:
-            capabilities.update(TermcapResponse.parse_capabilities(data))
-            # pylint: disable=protected-access
-            remaining = TermcapResponse._RE_XTGETTCAP_RESPONSE.sub('', data)
-            if remaining:
-                self.ungetch(remaining)
+        for match in matches:
+            if match.group(1) == '1':
+                name, value = TermcapResponse.from_match(match)
+                capabilities[name] = value
 
-        # Record None sentinel for any requested cap that wasn't answered.
         for capname in caps:
             if capname not in capabilities:
                 capabilities[capname] = None  # type: ignore[assignment]
@@ -3876,6 +3908,77 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         finally:
             self.stream.write(self.rmkx)
             self.stream.flush()
+
+    def _decode_bytes(self, data: bytes) -> str:
+        """Decode input bytes by the keyboard encoding, never raising."""
+        # Undecodable input is not worth interrupting a keyboard read for: a single byte
+        # of line noise would otherwise raise UnicodeDecodeError from any read that
+        # received it.  Decode such bytes as U+FFFD, and reset the incremental decoder,
+        # which may be left holding the bytes it could not decode.
+        try:
+            return self._keyboard_decoder.decode(data, final=False)
+        except UnicodeDecodeError:
+            self._keyboard_decoder.reset()
+            return data.decode(self._encoding, errors='replace')
+
+    def _decode_keyboard(self, data: bytes) -> str:
+        """Decode input bytes, decoding legacy mouse coordinates as latin-1."""
+        # The three bytes following legacy mouse sequence '\x1b[M' are 8-bit values,
+        # 32 + value, so any coordinate beyond 95 is a byte outside of ASCII, rarely
+        # valid in the keyboard encoding.  Decode just those as latin-1, a 1:1 mapping
+        # of byte to codepoint, and all surrounding input normally: a single read may
+        # contain both a mouse report and UTF-8 keystrokes.  A report divided across
+        # reads is continued by self._mouse_latin1_pending, the number of coordinate
+        # bytes still owed.
+        ucs = ''
+        pos = 0
+        while pos < len(data):
+            if self._mouse_latin1_pending:
+                n_bytes = min(self._mouse_latin1_pending, len(data) - pos)
+                ucs += data[pos:pos + n_bytes].decode('latin1')
+                self._mouse_latin1_pending -= n_bytes
+                pos += n_bytes
+                continue
+            idx = data.find(b'\x1b[M', pos)
+            if idx == -1:
+                break
+            ucs += self._decode_bytes(data[pos:idx + 3])
+            self._mouse_latin1_pending = 3
+            pos = idx + 3
+        return ucs + self._decode_bytes(data[pos:])
+
+    def _read_available(self) -> str:
+        """Read and decode all input immediately available, without blocking."""
+        # Unlike a loop of getch(), input is read in blocks, one system call for many
+        # bytes rather than one for each.  This supports keyboard._read_until(), where
+        # the reply to a terminal query may run to many kilobytes.  Legacy mouse
+        # sequences are decoded by _decode_keyboard(), wherever they occur in the input.
+        if self._keyboard_fd is None:
+            return ''
+        ucs = ''
+        # Any trailing bytes held back as a partial '\x1b[M' prefix: a mouse report may
+        # be divided by the block boundary, and the coordinate bytes that follow must
+        # still be decoded as latin-1.
+        carry = b''
+        while self.kbhit(timeout=0):
+            try:
+                data = os.read(self._keyboard_fd, _KEYBOARD_READ_SIZE)
+            except OSError:
+                break
+            if not data:
+                self._keyboard_eof = True
+                break
+            data = carry + data
+            carry = b''
+            if not self._mouse_latin1_pending:
+                for prefix in (b'\x1b[', b'\x1b'):
+                    if data.endswith(prefix):
+                        data, carry = data[:-len(prefix)], prefix
+                        break
+            ucs += self._decode_keyboard(data)
+        # no more input is immediately available, so anything held back is not the
+        # beginning of a mouse report after all, but input in its own right.
+        return ucs + self._decode_keyboard(carry)
 
     def flushinp(self, timeout: float = 0) -> str:
         r"""

--- a/blessed/win_terminal.py
+++ b/blessed/win_terminal.py
@@ -159,6 +159,27 @@ class Terminal(_Terminal):
             rtn += msvcrt.getwch()
         return rtn
 
+    def _read_available(self) -> str:
+        """Read and decode all input immediately available, without blocking."""
+        # The bulk read of the base implementation cannot be used here: console events
+        # are synthesized into escape sequences by getch(), and older versions of Windows
+        # read through msvcrt rather than from a file descriptor.  Only the three
+        # coordinate bytes that follow legacy mouse sequence '\x1b[M' are decoded as
+        # latin-1, matching Terminal._decode_keyboard() of the base implementation.
+        ucs = ''
+        pending = self._mouse_latin1_pending
+        while self.kbhit(timeout=0):
+            try:
+                ucs += self.getch(decode_latin1=pending > 0)
+            except EOFError:
+                break
+            if pending:
+                pending -= 1
+            elif ucs.endswith('\x1b[M'):
+                pending = 3
+        self._mouse_latin1_pending = pending
+        return ucs
+
     def kbhit(self, timeout: Optional[float] = None) -> bool:
         """
         Return whether a keypress has been detected on the keyboard.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,7 @@
 Version History
 ===============
 1.48
+  * improve: performance of automatic terminal query replies, :ghpull:`405`.
   * improve: all parameterized capabilities are now memorized, about 50x faster, :ghpull:`404`.  *
     bugfix: :meth:`~Terminal.truncate` by bump of dependency ``wcwidth>=0.8.3``, :ghissue:`402`.  *
     bugfix: :meth:`~Terminal.async_inkey` dropped keystrokes while another task is busy,

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,5 +1,6 @@
 """Performance benchmarks for blessed Sequence methods."""
 # local
+from blessed.keyboard import _read_until
 from .accessories import TestTerminal
 
 
@@ -220,3 +221,20 @@ def test_color_256(benchmark):
         return ''.join(term.color(idx) for idx in range(256))
     term = TestTerminal(force_styling=True)
     benchmark(_all_256_colors, term)
+
+
+# _read_until() benchmarks
+
+
+def test_read_until_long_reply(benchmark):
+    """Benchmark _read_until() digesting a multi-kilobyte query reply."""
+    long_query_reply = (
+        ''.join(f'\x1bP1+r{idx:04x}=31\x1b\\' for idx in range(1024)) +
+        '\x1b[10;20R')
+
+    def _read_buffered(term, reply):
+        term.ungetch(reply)
+        return _read_until(term, r'\d+;\d+R', timeout=1.0)
+
+    term = TestTerminal(force_styling=True)
+    benchmark(_read_buffered, term, long_query_reply)

--- a/tests/test_full_keyboard.py
+++ b/tests/test_full_keyboard.py
@@ -863,13 +863,14 @@ def test_read_until_max_buffer_size():
     chunks = (['x' * 7000] * 9) + ['x' * 2536, 'x']
     chars = iter(chunks)
 
-    def mock_inkey(timeout=None, esc_delay=None):
+    def mock_read_available():
         try:
             return next(chars)
         except StopIteration:
             return ''
 
-    with mock.patch.object(term, 'inkey', side_effect=mock_inkey):
+    with mock.patch.object(term, '_read_available', side_effect=mock_read_available), \
+            mock.patch.object(term, 'kbhit', return_value=True):
         match, buf = _read_until(term, r'NEVER_MATCH', timeout=1.0)
 
     assert match is None

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -3,6 +3,7 @@
 import io
 import os
 import sys
+import codecs
 import tempfile
 import collections
 from unittest import mock
@@ -12,6 +13,8 @@ import pytest
 import jinxed
 
 # local
+from blessed.keyboard import _read_until
+from blessed.terminal import _KEYBOARD_READ_SIZE
 from .conftest import IS_WINDOWS
 from .accessories import TestTerminal, as_subprocess
 
@@ -36,7 +39,6 @@ def test_getch_raises_eoferror_on_eof():
 def test_flushinp_handles_eof():
     """flushinp() returns buffered data when keyboard fd reaches EOF."""
     def child():
-        import codecs
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         read_fd, write_fd = os.pipe()
         os.write(write_fd, b'xy')
@@ -90,7 +92,6 @@ def test_kbhit_returns_false_after_eof():
 def test_inkey_raises_EOF():
     """inkey() returns empty Keystroke when keyboard fd is at EOF."""
     def child():
-        import codecs
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         read_fd, write_fd = os.pipe()
         os.close(write_fd)
@@ -692,4 +693,85 @@ def test_is_incomplete_keystroke():
         assert not term._is_incomplete_keystroke('')
         assert not term._is_incomplete_keystroke('x')
         assert not term._is_incomplete_keystroke('xyz')
+    child()
+
+
+# a legacy mouse report is ESC[M followed by three 8-bit values, 32 + value, so any
+# coordinate beyond 95 is a byte that is not valid UTF-8: only those three are decoded
+# as latin-1, wherever in a bulk read they land.
+@pytest.mark.skipif(IS_WINDOWS, reason="no tty module")
+@pytest.mark.parametrize('exchanges', [
+    # a mouse report and a query reply in one read
+    [(b'\x1b[M\x20\xe8\x52\x1b[10;20R', '\x1b[M \xe8\x52\x1b[10;20R')],
+    # decoding returns to the keyboard encoding after the coordinates
+    [(b'\x1b[M\x20\xe8\x52' + 'é中'.encode('utf-8'), '\x1b[M \xe8\x52é中')],
+    # a report divided across two calls, continued by _mouse_latin1_pending
+    [(b'\x1b[M\x20', '\x1b[M '), (b'\xe8\x52', '\xe8\x52')],
+    # a report divided by the block read, at either half of the '\x1b[' prefix
+    [(b'x' * (_KEYBOARD_READ_SIZE - 2) + b'\x1b[M\x20\xe8\x52',
+      'x' * (_KEYBOARD_READ_SIZE - 2) + '\x1b[M \xe8\x52')],
+    [(b'x' * (_KEYBOARD_READ_SIZE - 1) + b'\x1b[M\x20\xe8\x52',
+      'x' * (_KEYBOARD_READ_SIZE - 1) + '\x1b[M \xe8\x52')],
+    # a trailing ESC is held back as a possible '\x1b[M', then returned as itself
+    [(b'x\x1b', 'x\x1b')],
+    # undecodable input is replaced, never raised
+    [(b'\xe8x', '�x')],
+])
+def test_read_available_decoding(exchanges):
+    """_read_available() decodes only legacy mouse coordinates as latin-1."""
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        read_fd, write_fd = os.pipe()
+        term._keyboard_fd = read_fd
+        term._keyboard_decoder = codecs.getincrementaldecoder('utf-8')()
+        try:
+            for data, expected in exchanges:
+                os.write(write_fd, data)
+                assert term._read_available() == expected
+            assert term._mouse_latin1_pending == 0
+        finally:
+            os.close(write_fd)
+            os.close(read_fd)
+    child()
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="no tty module")
+def test_read_available_read_failures():
+    """_read_available() returns empty on read error, and flags end-of-file."""
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        read_fd, write_fd = os.pipe()
+        term._keyboard_fd = read_fd
+        term._keyboard_decoder = codecs.getincrementaldecoder('utf-8')()
+        try:
+            os.write(write_fd, b'xyz')
+            with mock.patch('os.read', side_effect=OSError):
+                assert term._read_available() == ''
+            assert term._keyboard_eof is False
+            os.close(write_fd)
+            os.read(read_fd, _KEYBOARD_READ_SIZE)
+            assert term._read_available() == ''
+            assert term._keyboard_eof is True
+        finally:
+            os.close(read_fd)
+    child()
+
+
+@pytest.mark.skipif(IS_WINDOWS, reason="no tty module")
+def test_read_until_with_legacy_mouse():
+    """_read_until() matches a query reply received alongside a legacy mouse report."""
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        term._line_buffered = False
+        read_fd, write_fd = os.pipe()
+        term._keyboard_fd = read_fd
+        term._keyboard_decoder = codecs.getincrementaldecoder('utf-8')()
+        try:
+            os.write(write_fd, b'\x1b[M\x20\xe8\x52\x1b[10;20R')
+            match, buf = _read_until(term, r'\x1b\[(\d+);(\d+)R', timeout=1)
+            assert match.groups() == ('10', '20')
+            assert buf == '\x1b[M \xe8\x52\x1b[10;20R'
+        finally:
+            os.close(write_fd)
+            os.close(read_fd)
     child()

--- a/tests/test_kitty_protocol.py
+++ b/tests/test_kitty_protocol.py
@@ -1424,19 +1424,16 @@ def test_kitty_control_key_integration(sequence, expected_name, expected_code, e
     child()
 
 
-@pytest.mark.skipif(not TEST_KEYBOARD, reason="TEST_KEYBOARD not specified")
+@pytest.mark.skipif(not TEST_KEYBOARD or IS_WINDOWS, reason="Requires TTY")
 def test_kitty_negotiation_timing_cached_failure():
     """Test timing of cached failure returns immediately."""
-    def child():
-        term = TestTerminal(stream=io.StringIO(), force_styling=True)
-        term._is_a_tty = True
-
+    def child(term):
         stime = time.time()
         flags1 = term.get_kitty_keyboard_state(timeout=0.025)
         assert flags1 is None
         assert term._kitty_kb_first_query_failed is True
         elapsed_ms = (time.time() - stime) * 1000
-        assert 24 <= elapsed_ms <= 35
+        assert 24 <= elapsed_ms <= 60, elapsed_ms
 
         # any subsequent calls return immediately (as failed)
         stime = time.time()
@@ -1444,17 +1441,15 @@ def test_kitty_negotiation_timing_cached_failure():
         elapsed_ms = (time.time() - stime) * 1000
         assert flags2 is None
         assert elapsed_ms < 5
+        return b'OK'
 
-    child()
+    assert 'OK' in pty_test(child, test_name='test_kitty_negotiation_timing_cached_failure')
 
 
-@pytest.mark.skipif(not TEST_KEYBOARD, reason="TEST_KEYBOARD not specified")
+@pytest.mark.skipif(not TEST_KEYBOARD or IS_WINDOWS, reason="Requires TTY")
 def test_kitty_negotiation_force_True_incurs_second_timeout():
     """Test timing of force=True incurs timeout again."""
-    def child():
-        term = TestTerminal(stream=io.StringIO(), force_styling=True)
-        term._is_a_tty = True
-
+    def child(term):
         flags1 = term.get_kitty_keyboard_state(timeout=0.025)
         assert flags1 is None
         assert term._kitty_kb_first_query_failed is True
@@ -1466,9 +1461,11 @@ def test_kitty_negotiation_force_True_incurs_second_timeout():
         elapsed_ms = (time.time() - stime) * 1000
 
         assert flags2 is None
-        assert 20 <= elapsed_ms <= 35
+        assert 20 <= elapsed_ms <= 60, elapsed_ms
+        return b'OK'
 
-    child()
+    assert 'OK' in pty_test(
+        child, test_name='test_kitty_negotiation_force_True_incurs_second_timeout')
 
 
 def test_kitty_keyboard_protocol_report_all_keys_setter_false():

--- a/tests/test_win_terminal.py
+++ b/tests/test_win_terminal.py
@@ -407,3 +407,27 @@ def test_poll_kbhit_period():
     """Test POLL_KBHIT_PERIOD is a reasonable positive value."""
     assert isinstance(POLL_KBHIT_PERIOD, float)
     assert 0 < POLL_KBHIT_PERIOD < 2.0
+
+
+def test_read_available_legacy_mouse():
+    """_read_available() decodes only legacy mouse coordinates as latin-1."""
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        term._keyboard_fd = 0
+        term._event_buf.extend('\x1b[M \xe8\x52')
+        with mock.patch.object(term, 'kbhit',
+                               side_effect=lambda timeout=None: bool(term._event_buf)):
+            assert term._read_available() == '\x1b[M \xe8\x52'
+        assert term._mouse_latin1_pending == 0
+    child()
+
+
+def test_read_available_eof():
+    """_read_available() stops at end-of-file."""
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        term._keyboard_fd = 0
+        with mock.patch.object(term, 'kbhit', return_value=True), \
+                mock.patch.object(term, 'getch', side_effect=EOFError):
+            assert term._read_available() == ''
+    child()

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -1209,3 +1209,13 @@ def test_xtgettcap_skip_Terminal_app():
         mock_batch.assert_not_called()
         assert any('Terminal.app' in err for err in t.errors)
         assert t._xtgettcap_cache.supported is False
+
+
+def test_query_boundary_multiple_unqueryable():
+    """_query_boundary_multiple() returns None without a tty, or without styling."""
+    term = TestTerminal(stream=io.StringIO(), force_styling=True)
+    query = ('', TermcapResponse._RE_XTGETTCAP_RESPONSE, 0)
+    assert term._query_boundary_multiple(*query) is None, 'not a tty'
+    term._is_a_tty = True
+    term._does_styling = False
+    assert term._query_boundary_multiple(*query) is None, 'no styling'


### PR DESCRIPTION
Improve performance of automatic query response
    
Use "bulk reads" for automatic query response, requires careful dancing
around "latin1" legacy mouse protocol decoding, needs some testing.

Also, fixes legacy mouse reporting in keymatrix.py !
