### PR TITLE
bugfix mouse button decoding

### DIFF
--- a/bin/keymatrix.py
+++ b/bin/keymatrix.py
@@ -227,7 +227,7 @@ class MouseModeManager:
             self.active_context.__exit__(None, None, None)
             self.active_context = None
 
-        # Build modes list — include SGR (1006) only when report_sgr is ON
+        # Build modes list, include SGR (1006) only when report_sgr is ON
         modes = []
         if self.report_sgr:
             modes.append(DecPrivateMode.MOUSE_EXTENDED_SGR)

--- a/blessed/mouse.py
+++ b/blessed/mouse.py
@@ -3,6 +3,11 @@
 import re
 from typing import Match
 
+BUTTON_LEGACY_UNKNOWN = 3
+
+# shift (4), meta (8), ctrl (16) and motion (32) share the button byte
+BUTTON_MODIFIER_MASK = 4 | 8 | 16 | 32
+
 
 class MouseEvent:  # pylint: disable=too-many-instance-attributes
     """
@@ -12,8 +17,8 @@ class MouseEvent:  # pylint: disable=too-many-instance-attributes
     dynamic button property that returns human-readable button names like "LEFT", "SCROLL_UP",
     "CTRL_LEFT", etc.
 
-    :ivar int button_value: Raw button number (0=left, 1=middle, 2=right, 64=scroll up, 65=scroll
-        down, or higher for extended buttons).
+    :ivar int button_value: Raw button number with modifiers stripped (0=left, 1=middle, 2=right,
+        3=none, 64=scroll up, 65=scroll down, 66-67 for buttons 6-7, and 128-131 for buttons 8-11).
     :ivar int x: Horizontal position (0-indexed, in cells or pixels depending on mode).
     :ivar int y: Vertical position (0-indexed, in cells or pixels depending on mode).
     :ivar bool released: True if this is a button release event.
@@ -57,14 +62,15 @@ class MouseEvent:  # pylint: disable=too-many-instance-attributes
         :rtype: str
         :returns: Base button name like "LEFT", "MIDDLE", "RIGHT", or "BUTTON_6".
         """
-        if self.button_value < 66:
+        if self.button_value < 64:
             return {
                 0: "LEFT",
                 1: "MIDDLE",
                 2: "RIGHT",
             }.get(self.button_value, '')
-        # Extended buttons (button_value >= 66)
-        return f"BUTTON_{self.button_value - 60}"
+        # Extended buttons, bit 6 (64) selects buttons 4-7, bit 7 (128) selects buttons 8-11
+        first_of_bank = 8 if self.button_value & 128 else 4
+        return f"BUTTON_{first_of_bank + (self.button_value & 3)}"
 
     @property
     def button(self) -> str:
@@ -72,13 +78,15 @@ class MouseEvent:  # pylint: disable=too-many-instance-attributes
         Return human-readable button name.
 
         Generates button names that include modifiers, button type, motion/release state:
+
         - "LEFT", "MIDDLE", "RIGHT" for standard mouse buttons
         - "LEFT_RELEASED", "MIDDLE_RELEASED", "RIGHT_RELEASED" for button releases
+        - "RELEASED" for a legacy release, which does not report which button was released
         - "SCROLL_UP", "SCROLL_DOWN" for wheel events
         - "MOTION" for mouse movement with no button pressed
         - "LEFT_MOTION", "MIDDLE_MOTION", "RIGHT_MOTION" for drag events
         - "CTRL_LEFT", "SHIFT_SCROLL_UP", "CTRL_SHIFT_META_MOTION" with modifiers
-        - "BUTTON_6", "BUTTON_7", etc. for extended mouse buttons
+        - "BUTTON_6" through "BUTTON_11" for extended mouse buttons
 
         :rtype: str
         :returns: Button name with modifiers, button type, and motion/release state.
@@ -90,25 +98,27 @@ class MouseEvent:  # pylint: disable=too-many-instance-attributes
             if getattr(self, modifier):
                 button_name += f'{modifier.upper()}_'
 
-        # Handle wheel events first (legacy uses button_value 0/1, SGR uses 64/65)
+        # Handle wheel events first, buttons 4 (64) and 5 (65)
         if self.is_wheel:
-            # Legacy wheel: button_value 0=up, 1=down
-            # SGR wheel: button_value 64=up, 65=down
-            if self.button_value in {0, 64}:
+            if self.button_value == 64:
                 button_name += "SCROLL_UP"
-            elif self.button_value in {1, 65}:
+            elif self.button_value == 65:
                 button_name += "SCROLL_DOWN"
             # Wheel events don't have motion or release variants in typical usage
             return button_name
 
         # Handle motion events specially
         if self.is_motion:
-            # Motion with no button pressed (button_value=3 means no button in SGR motion)
-            if self.button_value == 3:
+            # Motion with no button pressed
+            if self.button_value == BUTTON_LEGACY_UNKNOWN:
                 button_name += "MOTION"
             else:
                 # Dragging with a specific button
                 button_name += f"{self._get_base_button_name()}_MOTION"
+        elif self.released and self.button_value == BUTTON_LEGACY_UNKNOWN:
+            # Legacy protocols (modes 1000, 1002, 1003) do not report which
+            # button was released, so it is named without one.
+            button_name += "RELEASED"
         else:
             # Regular click or release events
             button_name += self._get_base_button_name()
@@ -137,8 +147,10 @@ class MouseEvent:  # pylint: disable=too-many-instance-attributes
 
         Handles both SGR (mode 1006) and SGR-Pixels (mode 1016) since they
         use identical wire formats: CSI < b;x;y m/M. The difference is semantic:
+
         - Mode 1006: coordinates represent character cell positions
         - Mode 1016: coordinates represent pixel positions
+
         Applications must interpret x,y coordinates based on which mode was enabled.
 
         The protocol sends 1-indexed coordinates (top-left is 1,1), but we convert
@@ -163,13 +175,10 @@ class MouseEvent:  # pylint: disable=too-many-instance-attributes
         # Extract motion/drag flags
         is_motion = bool(b & 32)
 
-        # Check for wheel events (button 64-65) by masking modifiers
-        # Wheel events: button & ~(shift|meta|ctrl|motion) gives base button
-        base_button = b & ~(4 | 8 | 16 | 32)
-        is_wheel = base_button in {64, 65}  # wheel up/down
-
-        # Get base button (0-2 for left/middle/right, or 64-65 for wheel)
-        button = b & 3 if not is_wheel else base_button
+        # Strip modifiers to get the button, 0-2 for left/middle/right, 3 for none, and
+        # 64-67 or 128-131 for the extended buttons 4-7 and 8-11
+        button = b & ~BUTTON_MODIFIER_MASK
+        is_wheel = button in {64, 65}  # buttons 4 and 5 are wheel up/down
 
         return cls(
             button_value=button,
@@ -191,6 +200,12 @@ class MouseEvent:  # pylint: disable=too-many-instance-attributes
         The protocol sends 1-indexed coordinates (top-left is 1,1), but we convert to 0-indexed
         (top-left is 0,0) to match blessed's terminal movement functions.
 
+        Each coordinate is transmitted as a single byte of ``value + 32``, so no position beyond
+        223 can be expressed.  Windows Terminal and the console host (``conhost.exe``) share a VT
+        input layer that *discards* any legacy mouse event where either coordinate exceeds 95,
+        rather than transmit a byte above 127.  Both are limitations of the terminal without
+        workaround, the SGR protocol is the only remedy.
+
         :param Match match: Regex match object with groups 'cb', 'cx', 'cy'.
         :rtype: MouseEvent
         :returns: Parsed MouseEvent instance.
@@ -202,26 +217,20 @@ class MouseEvent:  # pylint: disable=too-many-instance-attributes
         # Extract motion/drag flags
         is_motion = bool(cb & 32)
 
-        # Extract button and modifiers from cb
-        button = cb & 3
+        # Strip modifiers to get the button, matching the SGR decoder
+        button = cb & ~BUTTON_MODIFIER_MASK
+        is_wheel = button in {64, 65}  # buttons 4 and 5 are wheel up/down
         # A low-bits value of 3 means "no button". When stationary this is a
         # button release; with the motion bit set (mode 1003 all-motion
         # tracking) it is a no-button motion event, which must keep button_value
         # 3 so it reports as "MOTION" rather than "LEFT_MOTION", matching the
         # SGR decoder.
-        released = button == 3 and not is_motion
-        if released:
-            button = 0  # Release doesn't specify which button
+        released = button == BUTTON_LEGACY_UNKNOWN and not is_motion
 
         # Extract modifier flags
         shift = bool(cb & 4)
         meta = bool(cb & 8)
         ctrl = bool(cb & 16)
-
-        # Wheel events
-        is_wheel = cb >= 64
-        if is_wheel:
-            button = cb - 64  # 0=wheel up, 1=wheel down
 
         return cls(
             button_value=button,
@@ -250,4 +259,5 @@ RE_PATTERN_MOUSE_LEGACY = re.compile(r'\x1b\[M(?P<cb>.)(?P<cx>.)(?P<cy>.)')
 
 
 __all__ = ('MouseEvent', 'MouseSGREvent', 'MouseLegacyEvent',
-           'RE_PATTERN_MOUSE_SGR', 'RE_PATTERN_MOUSE_LEGACY')
+           'RE_PATTERN_MOUSE_SGR', 'RE_PATTERN_MOUSE_LEGACY',
+           'BUTTON_LEGACY_UNKNOWN', 'BUTTON_MODIFIER_MASK')

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,11 @@
 Version History
 ===============
 1.48
+  * bugfix: :ref:`legacy mouse` event names and button values, mouse release events returned by
+    :meth:`~Terminal.inkey` were always ``MOUSE_LEFT_RELEASED`` for all buttons, they now report
+    ``MOUSE_RELEASED``, :ghpull:`406`.
+  * bugfix: Mouse buttons 6 through 11 were erroneously decoded as left, middle, or right instead of
+    ``MOUSE_BUTTON_6`` through ``MOUSE_BUTTON_11``, :ghpull:`406`.
   * improve: all parameterized capabilities are now memorized, about 50x faster, :ghpull:`404`.  *
     bugfix: :meth:`~Terminal.truncate` by bump of dependency ``wcwidth>=0.8.3``, :ghissue:`402`.  *
     bugfix: :meth:`~Terminal.async_inkey` dropped keystrokes while another task is busy,

--- a/docs/mouse.rst
+++ b/docs/mouse.rst
@@ -74,9 +74,12 @@ following the pattern ``MOUSE_[MODIFIERS_]BUTTON[_RELEASED]``:
 - Basic events: ``MOUSE_LEFT``, ``MOUSE_MIDDLE``, ``MOUSE_RIGHT``, ``MOUSE_SCROLL_UP``,
   ``MOUSE_SCROLL_DOWN``
 - Release events: ``MOUSE_LEFT_RELEASED``, ``MOUSE_MIDDLE_RELEASED``,
-  ``MOUSE_RIGHT_RELEASED``
+  ``MOUSE_RIGHT_RELEASED``, or plain ``MOUSE_RELEASED`` when the terminal does
+  not say which button was released, see :ref:`legacy mouse`
 - With modifiers: ``MOUSE_CTRL_LEFT``, ``MOUSE_SHIFT_SCROLL_UP``, ``MOUSE_META_RIGHT``,
   ``MOUSE_CTRL_SHIFT_META_MIDDLE``
+- Extended buttons: ``MOUSE_BUTTON_6`` through ``MOUSE_BUTTON_11``, reported by mice with
+  thumb or tilt buttons
 
 Modifiers are included in order ``CTRL``, ``SHIFT``, and ``META``
 
@@ -213,3 +216,19 @@ pattern (e.g., ``'MOUSE_LEFT'``) and magic method predicates (e.g.,
 ``inp.is_mouse_left()``). The :attr:`~.Keystroke.x` and :attr:`~.Keystroke.y`
 properties represent pixels instead of character cells.
 
+.. _`legacy mouse`:
+
+Legacy Mouse Protocols
+----------------------
+
+Blessed always prefers the SGR protocol (:ref:`dec private modes` 1006 and 1016), and
+:meth:`~.Terminal.mouse_enabled` negotiates it for you.  However, a legacy terminal
+supporting the X10-era protocol of modes 1000, 1002, and 1003 is decoded when it arrives, but is
+reached only by historical terminals that dot support SGR.
+
+Legacy mouse protocols have one major difference, that a button release does not report *which*
+button was released.  Blessed names this ``MOUSE_RELEASED`` (or, with modifiers,
+``MOUSE_CTRL_RELEASED``).
+
+Legacy mouse protocols also have coordinate limitations, values above 223 cannot be encoded, and,
+some terminals like ``conhost.exe`` are even further limited to 95.

--- a/tests/test_mouse.py
+++ b/tests/test_mouse.py
@@ -52,11 +52,11 @@ class TestMouseEventMatching:
 
     @pytest.mark.parametrize("mode,sequence,expected_release,expected_button", [
         (1000, '\x1b[M   ', False, 0),  # MOUSE_REPORT_CLICK - Press event
-        (1000, '\x1b[M#@@', True, 0),   # MOUSE_REPORT_CLICK - Release
+        (1000, '\x1b[M#@@', True, 3),   # MOUSE_REPORT_CLICK - Release
         (1002, '\x1b[M   ', False, 0),  # MOUSE_REPORT_DRAG - Press event
-        (1002, '\x1b[M#@@', True, 0),   # MOUSE_REPORT_DRAG - Release
+        (1002, '\x1b[M#@@', True, 3),   # MOUSE_REPORT_DRAG - Release
         (1003, '\x1b[M   ', False, 0),  # MOUSE_ALL_MOTION - Press event
-        (1003, '\x1b[M#@@', True, 0),   # MOUSE_ALL_MOTION - Release
+        (1003, '\x1b[M#@@', True, 3),   # MOUSE_ALL_MOTION - Release
     ])
     def test_mouse_legacy_events(self, mode, sequence, expected_release, expected_button):
         """Test legacy mouse events work with all three legacy mouse modes."""
@@ -400,6 +400,15 @@ def test_mouse_event_keystroke_name():  # pylint: disable=too-many-locals
     ks_legacy_left = _match_dec_event('\x1b[M   ', dec_mode_cache=cache)
     assert ks_legacy_left.name == "MOUSE_LEFT"
 
+    # A legacy release does not report which button was released
+    ks_legacy_rel = _match_dec_event('\x1b[M#  ', dec_mode_cache=cache)
+    assert ks_legacy_rel.name == "MOUSE_RELEASED"
+    assert ks_legacy_rel._mode_values.button_value == 3
+
+    # ... but modifiers are still reported, ctrl (16) + no-button (3) = 19, '3'
+    ks_legacy_ctrl_rel = _match_dec_event('\x1b[M3  ', dec_mode_cache=cache)
+    assert ks_legacy_ctrl_rel.name == "MOUSE_CTRL_RELEASED"
+
     # Test that regular keystrokes don't have MOUSE_ names
     ks_regular = Keystroke('a')
     assert ks_regular.name is None or not ks_regular.name.startswith('MOUSE_')
@@ -620,7 +629,8 @@ def test_mouse_legacy_encoding_systematic():
             continue
         button, x, y, shift, meta, ctrl, released, is_motion = test_cases[idx]
         parts = result.split(',')
-        assert int(parts[0]) == button
+        # a legacy release reports no button, decoded as button_value 3
+        assert int(parts[0]) == (3 if released else button)
         assert int(parts[1]) == x
         assert int(parts[2]) == y
         assert bool(int(parts[3])) == shift
@@ -807,7 +817,7 @@ def test_mouse_legacy_wheel_events():
 
     values = ks_wheel_up._mode_values
     assert values.is_wheel
-    assert values.button_value == 0
+    assert values.button_value == 64
     assert ks_wheel_up.name == 'MOUSE_SCROLL_UP'
 
     # Wheel down: cb=65 → chr(65+32)='a'
@@ -816,7 +826,7 @@ def test_mouse_legacy_wheel_events():
 
     values_down = ks_wheel_down._mode_values
     assert values_down.is_wheel
-    assert values_down.button_value == 1
+    assert values_down.button_value == 65
     assert ks_wheel_down.name == 'MOUSE_SCROLL_DOWN'
 
 
@@ -1003,3 +1013,65 @@ def test_inkey_with_cjk_followed_by_legacy_mouse():
             assert evt.x == 150
             assert evt.y == 145
     child()
+
+
+def test_mouse_sgr_extended_buttons():
+    """Test SGR buttons 6-11 decode as BUTTON_n instead of collapsing onto left/middle/right."""
+    cache = make_enabled_dec_cache()
+
+    # bit 6 (64) selects buttons 4-7, bit 7 (128) selects buttons 8-11
+    for cb, expected in ((66, "BUTTON_6"), (67, "BUTTON_7"), (128, "BUTTON_8"),
+                         (129, "BUTTON_9"), (130, "BUTTON_10"), (131, "BUTTON_11")):
+        ks = _match_dec_event(f'\x1b[<{cb};10;20M', dec_mode_cache=cache)
+        values = ks._mode_values
+        assert values.button == expected
+        assert values.button_value == cb
+        assert not values.is_wheel
+
+    # modifiers, motion and release decode alongside the extended button
+    ks_shift = _match_dec_event('\x1b[<70;10;20M', dec_mode_cache=cache)
+    assert ks_shift._mode_values.button == "SHIFT_BUTTON_6"
+
+    ks_ctrl = _match_dec_event('\x1b[<144;10;20M', dec_mode_cache=cache)
+    assert ks_ctrl._mode_values.button == "CTRL_BUTTON_8"
+
+    ks_motion = _match_dec_event('\x1b[<98;10;20M', dec_mode_cache=cache)
+    assert ks_motion._mode_values.button == "BUTTON_6_MOTION"
+
+    ks_released = _match_dec_event('\x1b[<128;10;20m', dec_mode_cache=cache)
+    assert ks_released._mode_values.button == "BUTTON_8_RELEASED"
+
+    # the motion bit does not disturb a wheel event
+    ks_wheel_motion = _match_dec_event('\x1b[<96;10;20M', dec_mode_cache=cache)
+    assert ks_wheel_motion._mode_values.button == "SCROLL_UP"
+
+
+def test_mouse_legacy_extended_buttons():
+    """Test legacy buttons 6-11 decode as BUTTON_n."""
+    cache = make_enabled_dec_cache()
+
+    for cb, expected in ((66, "BUTTON_6"), (67, "BUTTON_7"), (128, "BUTTON_8"),
+                         (129, "BUTTON_9"), (130, "BUTTON_10"), (131, "BUTTON_11")):
+        ks = _match_dec_event(f'\x1b[M{chr(cb + 32)}@@', dec_mode_cache=cache)
+        values = ks._mode_values
+        assert values.button == expected
+        assert values.button_value == cb
+        assert not values.is_wheel
+
+
+def test_mouse_legacy_wheel_with_modifiers():
+    """Test legacy wheel events keep their name when a modifier is held."""
+    cache = make_enabled_dec_cache()
+
+    # shift (4) and ctrl (16) are packed into the same byte as the wheel button
+    for cb, expected in ((68, "SHIFT_SCROLL_UP"), (69, "SHIFT_SCROLL_DOWN"),
+                         (80, "CTRL_SCROLL_UP"), (81, "CTRL_SCROLL_DOWN"),
+                         (72, "META_SCROLL_UP")):
+        ks = _match_dec_event(f'\x1b[M{chr(cb + 32)}@@', dec_mode_cache=cache)
+        values = ks._mode_values
+        assert values.is_wheel
+        assert values.button == expected
+
+    # the motion bit does not disturb a wheel event
+    ks_wheel_motion = _match_dec_event(f'\x1b[M{chr(96 + 32)}@@', dec_mode_cache=cache)
+    assert ks_wheel_motion._mode_values.button == "SCROLL_UP"


### PR DESCRIPTION
* bugfix: "legacy mouse" event names and button values, mouse release events returned by ``~Terminal.inkey`` were always ``MOUSE_LEFT_RELEASED`` for all buttons, they now report ``MOUSE_RELEASED``.
* bugfix: Mouse buttons 6 through 11 were erroneously decoded as left, middle, or right instead of ``MOUSE_BUTTON_6`` through ``MOUSE_BUTTON_11``.
