### PR TITLE
Introduce Terminal.get_font_coverage()

### DIFF
--- a/bin/detect-tofus.py
+++ b/bin/detect-tofus.py
@@ -45,8 +45,11 @@ def is_drawn(char):
 
 def missing_codepoints(coverage, grapheme):
     """Return the drawn codepoints of *grapheme* the font has no glyph for."""
+    # a codepoint the terminal would not answer for is not a codepoint it called
+    # uncovered, and is assumed renderable, as reported by main() below
     return {char for char in unicodedata.normalize('NFC', grapheme)
-            if is_drawn(char) and char not in coverage}
+            if is_drawn(char) and char not in coverage
+            and ord(char) not in coverage.unknown}
 
 
 def describe(char):

--- a/bin/detect-tofus.py
+++ b/bin/detect-tofus.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+"""
+Report the "tofus" for codepoints found in filepaths given by argument.
+
+Requires a terminal implementing a font glyph coverage protocol, either mintty's ``OSC 7771`` or the
+``APC 25a1`` Glyph Protocol of Rio terminal.
+"""
+# std imports
+import sys
+import unicodedata
+
+# 3rd party
+from wcwidth import iter_graphemes
+
+# local
+from blessed import Terminal
+
+# Unicode Default_Ignorable_Code_Point ranges, of DerivedCoreProperties.txt.
+DEFAULT_IGNORABLE_RANGES = (
+    (0x000AD, 0x000AD),  # SOFT HYPHEN
+    (0x0034F, 0x0034F),  # COMBINING GRAPHEME JOINER
+    (0x0061C, 0x0061C),  # ARABIC LETTER MARK
+    (0x0115F, 0x01160),  # HANGUL CHOSEONG FILLER, HANGUL JUNGSEONG FILLER
+    (0x017B4, 0x017B5),  # KHMER VOWEL INHERENT AQ, AA
+    (0x0180B, 0x0180F),  # MONGOLIAN FREE VARIATION SELECTORS, VOWEL SEPARATOR
+    (0x0200B, 0x0200F),  # ZERO WIDTH SPACE through RIGHT-TO-LEFT MARK
+    (0x0202A, 0x0202E),  # bidi embedding and override
+    (0x02060, 0x0206F),  # WORD JOINER through NOMINAL DIGIT SHAPES
+    (0x03164, 0x03164),  # HANGUL FILLER
+    (0x0FE00, 0x0FE0F),  # VARIATION SELECTOR-1 through -16
+    (0x0FEFF, 0x0FEFF),  # ZERO WIDTH NO-BREAK SPACE
+    (0x0FFA0, 0x0FFA0),  # HALFWIDTH HANGUL FILLER
+    (0x0FFF0, 0x0FFF8),  # reserved
+    (0x1BCA0, 0x1BCA3),  # SHORTHAND FORMAT
+    (0x1D173, 0x1D17A),  # MUSICAL SYMBOL BEGIN BEAM through END PHRASE
+    (0xE0000, 0xE0FFF),  # LANGUAGE TAG, tag characters, VARIATION SELECTOR-17 to -256
+)
+
+
+def is_drawn(char):
+    """Whether *char* is drawn, and so needs a glyph of its own in the font."""
+    return not any(start <= ord(char) <= stop
+                   for start, stop in DEFAULT_IGNORABLE_RANGES)
+
+
+def missing_codepoints(coverage, grapheme):
+    """Return the drawn codepoints of *grapheme* the font has no glyph for."""
+    return {char for char in unicodedata.normalize('NFC', grapheme)
+            if is_drawn(char) and char not in coverage}
+
+
+def describe(char):
+    """Return the Unicode name of *char*, or its category when it has none."""
+    return unicodedata.name(char, '').title() or f'<{unicodedata.category(char)}>'
+
+
+def status(term, message):
+    """Overwrite the transient status line on stderr, cleared by an empty *message*."""
+    print('\r' + message + term.clear_eol, end='' if message else '\n',
+          file=sys.stderr, flush=True)
+
+
+def label_codepoints(grapheme, missing):
+    """Return ``'U+XXXX Name + ...'`` for the *missing* codepoints of *grapheme*."""
+    return ' + '.join(f'U+{ord(char):04X} {describe(char)}'
+                      for char in unicodedata.normalize('NFC', grapheme)
+                      if char in missing)
+
+
+def main():
+    term = Terminal()
+
+    graphemes = set()
+    for filepath in sys.argv[1:]:
+        with open(filepath, 'r', encoding='utf-8') as fin:
+            status(term, f'read: {filepath}')
+            graphemes.update(iter_graphemes(fin.read()))
+    if not graphemes:
+        print(f'usage: {sys.executable} {__file__} FILE [FILE ...]', file=sys.stderr)
+        return 2
+
+    # zero-width graphemes occupy no cell of their own to be a tofu in
+    to_test = sorted(gr for gr in graphemes if term.length(gr) != 0)
+
+    status(term, 'testing...')
+    # one call resolves every codepoint of every grapheme, in batched round-trips
+    coverage = term.get_font_coverage(''.join(
+        unicodedata.normalize('NFC', grapheme) for grapheme in to_test))
+    if not coverage:
+        status(term, '')
+        print('Font glyph protocol not supported by this terminal.', file=sys.stderr)
+        return 1
+    if coverage.unknown:
+        print(f'{len(coverage.unknown)} codepoints went unanswered by the terminal, '
+              f'and are assumed renderable.', file=sys.stderr)
+
+    missing = {grapheme: found
+               for grapheme in to_test
+               if (found := missing_codepoints(coverage, grapheme))}
+
+    status(term, 'reporting...')
+    if not missing:
+        status(term, '')
+        print(f'No tofus discovered of {len(to_test)} graphemes tested', file=sys.stderr)
+        return 0
+
+    # collect first, so that the columns may be sized to the widest of them
+    rows = []
+    for filepath in sys.argv[1:]:
+        with open(filepath, 'r', encoding='utf-8') as fin:
+            for lineno, line in enumerate(fin, 1):
+                cells = list(iter_graphemes(line.rstrip('\n')))
+                for grapheme in dict.fromkeys(cells):
+                    if grapheme in missing:
+                        rows.append((cells.count(grapheme),
+                                     f'{filepath}:{lineno}', grapheme))
+
+    count_width = max(len(str(count)) for count, _, _ in rows)
+    where_width = max(len(where) for _, where, _ in rows)
+    tofu_count = sum(count for count, _, _ in rows)
+
+    status(term, '')
+    print(f'{tofu_count} tofus of {len(to_test)} graphemes tested, listed with the '
+          f'codepoints the font has no glyph for:\n', file=sys.stderr)
+
+    for count, where, grapheme in rows:
+        # the cluster occupies one or two cells, pad the narrow ones to align
+        cell = grapheme + ' ' * (2 - term.length(grapheme))
+        prefix = f'{count:>{count_width}} {where:<{where_width}} │{cell}│ '
+        codepoints = label_codepoints(grapheme, missing[grapheme])
+        print(term.truncate(prefix + codepoints, term.width))
+
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -15,4 +15,4 @@ else:
 from blessed.line_editor import LineEditor, LineHistory
 
 __all__ = ('Terminal', 'LineEditor', 'LineHistory')
-__version__ = "1.48.0"
+__version__ = "1.49.0"

--- a/blessed/_capabilities.py
+++ b/blessed/_capabilities.py
@@ -2,7 +2,7 @@
 # std imports
 import re
 import typing
-from typing import Set, Dict, Optional
+from typing import Set, Dict, Union, Optional
 from collections import OrderedDict
 
 # 3rd party
@@ -18,6 +18,7 @@ __all__ = (
     'Decrqss',
     'TermcapResponse',
     'ITerm2Capabilities',
+    'FontCoverage',
 )
 
 CAPABILITY_DATABASE: \
@@ -824,3 +825,79 @@ class TextSizingResult:
 
     def __repr__(self) -> str:
         return f"TextSizingResult(width={self.width}, scale={self.scale})"
+
+
+class FontCoverage:
+    r"""
+    Which codepoints the terminal reports its font has a glyph for, "tofu detection result".
+
+    :param dict sources: Mapping of codepoints to sources, such as ``'system'`` or
+        ``'system,glossary'``.
+    :param dict unknown: Mapping of codepoints to the reason it went unanswered.
+    :param str protocol: Name of the protocol that answered, ``'mintty'``, ``'glyph'``, or None for
+        no protocol support.
+    """
+
+    def __init__(self,
+                 sources: Optional[Dict[int, str]] = None,
+                 unknown: Optional[Dict[int, str]] = None,
+                 protocol: Optional[str] = None) -> None:
+        """Class initializer."""
+        self.sources: Dict[int, str] = sources or {}
+        self.unknown: Dict[int, str] = unknown or {}
+        self.protocol = protocol
+
+    @property
+    def supported(self) -> bool:
+        """Whether any font coverage protocol answered at all."""
+        return self.protocol is not None
+
+    @property
+    def covered(self) -> Set[int]:
+        """Codepoints the font has a glyph for."""
+        return {codepoint for codepoint, source in self.sources.items() if source}
+
+    @property
+    def uncovered(self) -> Set[int]:
+        """Codepoints the font has no glyph for."""
+        return {codepoint for codepoint, source in self.sources.items() if not source}
+
+    def covers(self, text: str) -> bool:
+        """Whether the font has a glyph for *every* codepoint of *text*."""
+        return all(self.sources.get(ord(char)) for char in text)
+
+    def __contains__(self, codepoint: Union[str, int]) -> bool:
+        """
+        Whether *codepoint*, an integer or a single character, is covered.
+
+        :arg codepoint: A codepoint, as an integer or as a string of length 1.
+        :raises TypeError: *codepoint* is neither, and so cannot be a codepoint at all.
+        :rtype: bool
+        """
+        if isinstance(codepoint, str):
+            if len(codepoint) != 1:
+                raise TypeError('codepoint must be an integer or a string of length 1, '
+                                f'got a string of length {len(codepoint)}')
+            codepoint = ord(codepoint)
+        elif not isinstance(codepoint, int):
+            raise TypeError('codepoint must be an integer or a string of length 1, '
+                            f'not {type(codepoint).__name__}')
+        return bool(self.sources.get(codepoint))
+
+    def __bool__(self) -> bool:
+        """Whether any font coverage protocol answered at all."""
+        return self.supported
+
+    def __eq__(self, other: object) -> bool:
+        """Compare equality with another :class:`FontCoverage`."""
+        if isinstance(other, FontCoverage):
+            return (self.sources == other.sources
+                    and self.unknown == other.unknown
+                    and self.protocol == other.protocol)
+        return NotImplemented
+
+    def __repr__(self) -> str:
+        """Programmer readable representation."""
+        return (f'FontCoverage(protocol={self.protocol!r}, '
+                f'covered={len(self.covered)}, uncovered={len(self.uncovered)}, '
+                f'unknown={len(self.unknown)})')

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -2028,9 +2028,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         :rtype: Optional[Dict[int, str]]
         :returns: Each of *codepoints* mapped to its covering sources, empty when
             uncovered.  This protocol names no sources, so ``'system'`` stands for the
-            font it answers about.  A codepoint answered about only in truncated form
-            is absent, and is reported through :attr:`~.FontCoverage.unknown` instead.
-            None when unanswered.
+            font it answers about.  None when unanswered.
         """
         decimals = ';'.join(map(str, codepoints))
         query = f'\x1b]7771;?;{decimals}\x07'
@@ -2042,23 +2040,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         # empty where it does not.  Only the separators mark the uncovered ones, so
         # the fields must be read by position and not as the set of names in them.
         fields = match.group(1).split(';')[1:]
-        if len(fields) != len(codepoints):
-            # not the field-for-field reply of the protocol: all that can be trusted
-            # of it is the set of codepoints it does name.
-            named = {int(field) for field in fields if field}
-            return {codepoint: 'system' if codepoint in named else ''
-                    for codepoint in codepoints}
-
-        answered: Dict[int, str] = {}
-        for codepoint, field in zip(codepoints, fields):
-            if field and int(field) != codepoint:
-                # mintty before 3.8.3 truncates each codepoint to 16 bits before
-                # looking it up, and has answered about some other character: the
-                # font's coverage of this one is not knowable from this reply.
-                self._font_coverage_unknown[codepoint] = 'truncated reply'
-            else:
-                answered[codepoint] = 'system' if field else ''
-        return answered
+        return {codepoint: 'system' if field else ''
+                for codepoint, field in zip(codepoints, fields)}
 
     def _query_font_glyph_protocol(self, codepoints: List[int],
                                    timeout: Optional[float]) -> Optional[Dict[int, str]]:

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -74,6 +74,7 @@ from ._capabilities import (CAPABILITY_DATABASE,
                             XTGETTCAP_INIT_CAPABILITIES,
                             CAPABILITIES_HORIZONTAL_DISTANCE,
                             Decrqss,
+                            FontCoverage,
                             TermcapResponse,
                             TextSizingResult,
                             ITerm2Capabilities)
@@ -128,9 +129,20 @@ _RE_ITERM2_CAPABILITIES_RESPONSE = re.compile(
     r'\x1b\]1337;Capabilities=([^\x07\x1b]+)(?:\x07|\x1b\\)')
 _RE_KITTY_NOTIFICATIONS_RESPONSE = re.compile(
     r'\x1b\]99;([^\x07\x1b]*?)(?:\x07|\x1b\\)')
+# Mintty font glyph coverage: ESC ] 7771 ; ! ; cp1 ; cp2 ; ... BEL/ST
+_RE_MINTTY_FONT_RESPONSE = re.compile(
+    r'\x1b\]7771;!((?:;\d+)*)(?:\x07|\x1b\\)')
+# Glyph Protocol codepoint query response: ESC _ 25a1 ; q ; cp=HEX ; status=VALUE ST
+_RE_GLYPH_PROTOCOL_Q_RESPONSE = re.compile(
+    r'\x1b_25a1;q;cp=([0-9a-fA-F]+);status=([^;\x1b\\]*)'
+    r'(?:;reason=([^;\x1b\\]*))?[^\x1b]*\x1b\\')
+# Glyph Protocol support probe response: ESC _ 25a1 ; s ; key=val... ST
+_RE_GLYPH_PROTOCOL_S_RESPONSE = re.compile(r'\x1b_25a1;s(;[^\x1b\\]*)\x1b\\')
 _RE_CPR_BOUNDARY = re.compile(r'\x1b\[[0-9]+;[0-9]+R')
 _RE_KITTY_CLIPBOARD = re.compile(r'\x1b\[\?5522;(\d+)\$y')
 _RE_KITTY_POINTER = re.compile(r'\x1b\]22;([^\x07\x1b]+)(?:\x07|\x1b\\)')
+_FONT_QUERY_CHUNK_SIZE = 256
+
 _RE_OSC52_RESPONSE = re.compile(r'\x1b\]52;[a-z]*;([^\x07\x1b]*)(?:\x07|\x1b\\)')
 # Color scheme (dark/light mode): CSI ? 997 ; Ps n
 _RE_COLOR_SCHEME_MODE_RESPONSE = re.compile(r'\x1b\[\?997;([12])n')
@@ -273,6 +285,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         self._init_descriptor = None
         self._is_a_tty = False
         self._keyboard_buf: 'collections.deque[str]' = collections.deque()
+        # Number of legacy mouse coordinate bytes still owed to a '\x1b[M' sequence that
+        # was received by a previous read, see :meth:`_decode_keyboard`.
         self._mouse_latin1_pending = 0
         self._dec_mode_cache: Dict[int, int] = {}
         self.__init__streams()
@@ -420,6 +434,14 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         self._color_scheme_supported: Optional[bool] = None
         # DECRQSS detection cache
         self._decrqss_supported: Optional[bool] = None
+        # Font glyph coverage: mintty OSC 7771 probe result
+        self._does_mintty_font_protocol: Optional[bool] = None
+        # Font glyph coverage: Glyph Protocol probe result, by advertised key=value
+        self._does_glyph_protocol: Optional[Dict[str, str]] = None
+        # Font glyph coverage: accumulated per-codepoint results, codepoint -> sources
+        self._font_coverage_cache: Dict[int, str] = {}
+        # Font glyph coverage: codepoints the terminal would not answer for, and why
+        self._font_coverage_unknown: Dict[int, str] = {}
 
     def __init_set_styling(self, force_styling: bool) -> None:
         self._does_styling = False
@@ -881,7 +903,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
                 ctx = self.cbreak()
                 ctx.__enter__()
 
-            self.stream.write(query_str + '\x1b[6n')
+            self.stream.write(query_str + (self.u7 or '\x1b[6n'))
             self.stream.flush()
 
             # Wait for CPR boundary -- this is always the last response
@@ -1235,9 +1257,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         if self._device_attributes_cache is not None and not force:
             return self._device_attributes_cache
 
-        query = '\x1b[c'
         match = self._query_with_boundary(
-            query,
+            self.u9 or '\x1b[c',
             (DeviceAttribute.RE_RESPONSE, DeviceAttribute.RE_RESPONSE_CTERM),
             timeout)
 
@@ -1261,9 +1282,9 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         ``TERM_PROGRAM_VERSION`` environment variables. Returns ``None``
         only if both methods fail.
 
-        **Successful responses are cached indefinitely** unless ``force=True`` is
-        specified. Unlike other query methods, there is no sticky failure mechanism -
-        each failed query can be retried.
+        **Only Successful responses are cached indefinitely** unless ``force=True`` is specified.
+        Unlike other query methods, there is no "sticky failure", failed queries are not cached and
+        are retried.
 
         .. note:: A ``timeout`` value should be set to avoid blocking when the
             terminal does not respond to XTVERSION queries, which may happen with
@@ -1855,6 +1876,201 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         """
         result = self.get_xtgettcap(timeout=timeout, force=force)
         return result is not None
+
+    def get_font_coverage(self, text: str,
+                          timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
+                          force: bool = False) -> FontCoverage:
+        r"""
+        Query which codepoints of *text* the terminal font has a glyph for.
+
+        :arg str text: Text whose codepoints to query.  Each distinct codepoint is asked
+            about once, in batches, however long *text* is and however often it repeats.
+        :arg float timeout: Seconds to wait for each round-trip.  A long *text* takes
+            several, so this bounds a single exchange and not the call.
+        :arg bool force: Discard the cached protocol probe and every cached codepoint
+            result, and query the terminal again.
+        :rtype: FontCoverage
+        :returns: Per-codepoint coverage.  When *text* is empty, or when neither
+            protocol answers, an empty result whose :attr:`~.FontCoverage.supported`
+            is False, which is falsey.  A codepoint the terminal declined to answer
+            for is reported through :attr:`~.FontCoverage.unknown` and is not asked
+            about again until ``force``.
+
+        Two protocols are tried, mintty's *Font Glyph Coverage Enquiry* (``OSC 7771``)
+        first, then the *Glyph Protocol* ``'q'`` verb (``APC 25a1``) of rio.  The
+        protocol that answers is remembered, as is the result for every codepoint
+        queried, so repeated calls over overlapping text cost no further round-trips.
+
+            >>> coverage = term.get_font_coverage('─│')
+            >>> if not coverage:
+            ...     print('terminal cannot say')
+            ... elif not coverage.covers('─│'):
+            ...     print('falling back to ASCII box drawing')
+
+        .. warning:: This reports *coverage of codepoints by a font*, and nothing more.
+            Neither protocol can be asked about a grapheme cluster, and neither reports
+            on the shaping that turns codepoints into drawn glyphs: ligatures, mark
+            positioning, ``ZWJ`` joining, ``VS-15``/``VS-16`` presentation, contextual
+            forms, or fallback to another font.  A cluster whose codepoints are all
+            covered may still fail to draw, and one with uncovered codepoints may draw
+            perfectly.  The text presentation watch, ``'⌚︎'``, renders correctly
+            on terminals whose font has no glyph for ``U+FE0E``, as no font does.
+            Deciding what will render is a heuristic built on this answer, and blessed
+            does not make it for you: see :ref:`detect-tofus.py` for one such heuristic.
+
+        .. seealso::
+            https://github.com/mintty/mintty/wiki/CtrlSeqs#font-glyph-coverage-enquiry
+            and https://rapha.land/introducing-glyph-protocol-for-terminals/
+        """
+        if not self.is_a_tty or not self.does_styling or not text:
+            return FontCoverage()
+
+        if force:
+            self._does_mintty_font_protocol = None
+            self._does_glyph_protocol = None
+            self._font_coverage_cache = {}
+            self._font_coverage_unknown = {}
+
+        wanted = {ord(char) for char in text}
+        self._query_font_codepoints(wanted, timeout)
+
+        protocol = ('mintty' if self._does_mintty_font_protocol else
+                    'glyph' if self._does_glyph_protocol else None)
+        if protocol is None:
+            return FontCoverage()
+
+        return FontCoverage(
+            sources={codepoint: self._font_coverage_cache[codepoint]
+                     for codepoint in wanted
+                     if codepoint in self._font_coverage_cache},
+            unknown={codepoint: self._font_coverage_unknown[codepoint]
+                     for codepoint in wanted
+                     if codepoint in self._font_coverage_unknown},
+            protocol=protocol)
+
+    def _query_font_codepoints(self, wanted: Set[int],
+                               timeout: Optional[float]) -> None:
+        """
+        Resolve the coverage of *wanted* codepoints into the per-codepoint caches.
+
+        :arg set wanted: Codepoints, as integers, to test.
+        :arg float timeout: Seconds to wait for each round-trip.
+        """
+        cache = self._font_coverage_cache
+        unknown = self._font_coverage_unknown
+        pending = sorted(codepoint for codepoint in wanted
+                         if codepoint not in cache and codepoint not in unknown)
+
+        if pending and self._does_mintty_font_protocol is None:
+            # the first chunk doubles as the probe: only mintty answers OSC 7771 at all,
+            # so a reply is itself the proof of support, no extra round-trip needed.
+            chunk, pending = (pending[:_FONT_QUERY_CHUNK_SIZE],
+                              pending[_FONT_QUERY_CHUNK_SIZE:])
+            result = self._query_font_mintty_protocol(chunk, timeout)
+            self._does_mintty_font_protocol = result is not None
+            if result is None:
+                pending = chunk + pending
+            else:
+                cache.update(result)
+
+        if pending and not self._does_mintty_font_protocol:
+            if self._does_glyph_protocol is None:
+                self._does_glyph_protocol = self._probe_glyph_protocol(timeout)
+            if not self._does_glyph_protocol:
+                return
+
+        query = (self._query_font_mintty_protocol if self._does_mintty_font_protocol
+                 else self._query_font_glyph_protocol)
+        for idx in range(0, len(pending), _FONT_QUERY_CHUNK_SIZE):
+            chunk = pending[idx:idx + _FONT_QUERY_CHUNK_SIZE]
+            result = query(chunk, timeout)
+            # the terminal answered the probe but not (all of) this query: record the
+            # codepoints as unanswered rather than guessing at their coverage.  An
+            # error reply has already recorded its own, more specific reason.
+            answered = result or {}
+            cache.update(answered)
+            unknown.update((codepoint, 'no reply') for codepoint in chunk
+                           if codepoint not in answered and codepoint not in unknown)
+
+    def _probe_glyph_protocol(self, timeout: Optional[float]) -> Dict[str, str]:
+        """
+        Probe for Glyph Protocol support using the ``'s'`` verb.
+
+        :arg float timeout: Timeout in seconds.
+        :rtype: Dict[str, str]
+        :returns: Advertised key=value pairs, such as ``{'fmt': 'glyf,colrv0'}``, an empty dict when
+            the terminal does not support the protocol. A terminal that answers but advertises
+            nothing still yields a non-empty dict, so that the result is falsey *only* for
+            "unsupported".
+        """
+        if (match := self._query_with_boundary('\x1b_25a1;s\x1b\\',
+                                               _RE_GLYPH_PROTOCOL_S_RESPONSE,
+                                               timeout)) is None:
+            return {}
+        raw = match.group(1)  # ';fmt=glyf,colrv0,colrv1'
+        result: Dict[str, str] = {}
+        for item in raw.split(';'):
+            if '=' in item:
+                key, val = item.split('=', 1)
+                result[key] = val
+        # the 'q' verb is available to any terminal implementing the protocol, whatever
+        # registration formats it does or does not advertise for the 'r' verb.
+        return result or {'fmt': ''}
+
+    def _query_font_mintty_protocol(self, codepoints: List[int],
+                                    timeout: Optional[float]) -> Optional[Dict[int, str]]:
+        """
+        Query font coverage by mintty's ``OSC 7771`` Font Glyph Coverage Enquiry.
+
+        :arg list codepoints: Codepoints, as integers, to test.
+        :arg float timeout: Timeout in seconds.
+        :rtype: Optional[Dict[int, str]]
+        :returns: Each of *codepoints* mapped to its covering sources, empty when
+            uncovered.  This protocol names no sources, so ``'system'`` stands for the
+            font it answers about.  None when unanswered.
+        """
+        decimals = ';'.join(map(str, codepoints))
+        query = f'\x1b]7771;?;{decimals}\x07'
+        if (match := self._query_with_boundary(
+                query, _RE_MINTTY_FONT_RESPONSE, timeout)) is None:
+            return None
+        # the reply lists the covered codepoints, omitting the rest
+        covered = {int(value) for value in match.group(1).split(';') if value}
+        return {codepoint: 'system' if codepoint in covered else ''
+                for codepoint in codepoints}
+
+    def _query_font_glyph_protocol(self, codepoints: List[int],
+                                   timeout: Optional[float]) -> Optional[Dict[int, str]]:
+        """
+        Query font coverage by the Glyph Protocol ``'q'`` verb, ``APC 25a1``.
+
+        :arg list codepoints: Codepoints, as integers, to test.
+        :arg float timeout: Timeout in seconds.
+        :rtype: Optional[Dict[int, str]]
+        :returns: Each answered codepoint mapped to its covering sources, ``'system'``
+            and ``'glossary'`` so far, empty when uncovered.  A codepoint answered with
+            an error is absent, and is reported through
+            :attr:`~.FontCoverage.unknown` instead.  None when nothing was answered.
+        """
+        query = ''.join(f'\x1b_25a1;q;cp={cp:x}\x1b\\' for cp in codepoints)
+        if (matches := self._query_boundary_multiple(
+                query, _RE_GLYPH_PROTOCOL_Q_RESPONSE, timeout)) is None:
+            return None
+
+        answered: Dict[int, str] = {}
+        for match in matches:
+            codepoint, status, reason = (
+                int(match.group(1), 16), match.group(2), match.group(3))
+            if status.isdigit() and status != '0':
+                # An error reply says the terminal could not answer, which is not a
+                # statement about the font: leave it out of *answered* entirely, so
+                # that it is never mistaken for, or cached as, a missing glyph.
+                self._font_coverage_unknown[codepoint] = reason or f'status={status}'
+                continue
+            # 'status' names the sources that can render the codepoint, 'system' and
+            # 'glossary' so far, and is empty when none can.
+            answered[codepoint] = '' if status.isdigit() else status
+        return answered
 
     def does_kitty_graphics(self, timeout: Optional[float] = TERMINAL_QUERY_TIMEOUT_SECONDS,
                             force: bool = False) -> bool:

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -129,9 +129,10 @@ _RE_ITERM2_CAPABILITIES_RESPONSE = re.compile(
     r'\x1b\]1337;Capabilities=([^\x07\x1b]+)(?:\x07|\x1b\\)')
 _RE_KITTY_NOTIFICATIONS_RESPONSE = re.compile(
     r'\x1b\]99;([^\x07\x1b]*?)(?:\x07|\x1b\\)')
-# Mintty font glyph coverage: ESC ] 7771 ; ! ; cp1 ; cp2 ; ... BEL/ST
+# Mintty font glyph coverage: ESC ] 7771 ; ! ; cp1 ; ; cp3 ; ... BEL/ST, holding one
+# ';' prefixed field for each codepoint queried, empty where the font has no glyph.
 _RE_MINTTY_FONT_RESPONSE = re.compile(
-    r'\x1b\]7771;!((?:;\d+)*)(?:\x07|\x1b\\)')
+    r'\x1b\]7771;!([;0-9]*)(?:\x07|\x1b\\)')
 # Glyph Protocol codepoint query response: ESC _ 25a1 ; q ; cp=HEX ; status=VALUE ST
 _RE_GLYPH_PROTOCOL_Q_RESPONSE = re.compile(
     r'\x1b_25a1;q;cp=([0-9a-fA-F]+);status=([^;\x1b\\]*)'
@@ -2027,17 +2028,37 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         :rtype: Optional[Dict[int, str]]
         :returns: Each of *codepoints* mapped to its covering sources, empty when
             uncovered.  This protocol names no sources, so ``'system'`` stands for the
-            font it answers about.  None when unanswered.
+            font it answers about.  A codepoint answered about only in truncated form
+            is absent, and is reported through :attr:`~.FontCoverage.unknown` instead.
+            None when unanswered.
         """
         decimals = ';'.join(map(str, codepoints))
         query = f'\x1b]7771;?;{decimals}\x07'
         if (match := self._query_with_boundary(
                 query, _RE_MINTTY_FONT_RESPONSE, timeout)) is None:
             return None
-        # the reply lists the covered codepoints, omitting the rest
-        covered = {int(value) for value in match.group(1).split(';') if value}
-        return {codepoint: 'system' if codepoint in covered else ''
-                for codepoint in codepoints}
+        # the reply is positional: it repeats the query field for field, in the order
+        # asked, naming the codepoint where the font has a glyph for it and standing
+        # empty where it does not.  Only the separators mark the uncovered ones, so
+        # the fields must be read by position and not as the set of names in them.
+        fields = match.group(1).split(';')[1:]
+        if len(fields) != len(codepoints):
+            # not the field-for-field reply of the protocol: all that can be trusted
+            # of it is the set of codepoints it does name.
+            named = {int(field) for field in fields if field}
+            return {codepoint: 'system' if codepoint in named else ''
+                    for codepoint in codepoints}
+
+        answered: Dict[int, str] = {}
+        for codepoint, field in zip(codepoints, fields):
+            if field and int(field) != codepoint:
+                # mintty before 3.8.3 truncates each codepoint to 16 bits before
+                # looking it up, and has answered about some other character: the
+                # font's coverage of this one is not knowable from this reply.
+                self._font_coverage_unknown[codepoint] = 'truncated reply'
+            else:
+                answered[codepoint] = 'system' if field else ''
+        return answered
 
     def _query_font_glyph_protocol(self, codepoints: List[int],
                                    timeout: Optional[float]) -> Optional[Dict[int, str]]:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -231,6 +231,17 @@ This program demonstrates the various uses of :meth:`~.Terminal.text_sized`, the
 
 .. figure:: https://dxtz6bzwq9sxx.cloudfront.net/blessed_text_sizing_demo.png
 
+.. _detect-tofus.py:
+
+detect-tofus.py
+---------------
+https://github.com/jquast/blessed/blob/master/bin/detect-tofus.py
+
+This program demonstrates :meth:`~.Terminal.get_font_coverage`, which reports only per-codepoint
+coverage.  Given text files as arguments, reports any "tofus" that might result when rendering them
+to terminal. A "tofu" is drawn for characters the terminal font cannot render.  Requires a terminal
+implementing one of the font glyph coverage protocols.
+
 .. _scroller.py:
 
 scroller.py

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -2,7 +2,8 @@
 
 Version History
 ===============
-1.48
+
+1.49
   * introduce: :meth:`~Terminal.get_font_coverage` reports codepoints the terminal font has a glyph
     for, by mintty's ``OSC 7771`` Font Glyph Coverage Enquiry or the ``APC 25a1`` Glyph Protocol,
     :ghpull:`407`.
@@ -12,8 +13,11 @@ Version History
   * bugfix: Mouse buttons 6 through 11 were erroneously decoded as left, middle, or right instead of
     ``MOUSE_BUTTON_6`` through ``MOUSE_BUTTON_11``, :ghpull:`406`.
   * improve: performance of automatic terminal query replies, :ghpull:`405`.
-  * improve: all parameterized capabilities are now memorized, about 50x faster, :ghpull:`404`.  *
-    bugfix: :meth:`~Terminal.truncate` by bump of dependency ``wcwidth>=0.8.3``, :ghissue:`402`.  *
+  * improve: all parameterized capabilities are now memorized, about 50x faster, :ghpull:`404`.
+  * bugfix: :meth:`~Terminal.truncate` by bump of dependency ``wcwidth>=0.8.3``, :ghissue:`402`.
+
+1.48
+  *
     bugfix: :meth:`~Terminal.async_inkey` dropped keystrokes while another task is busy,
     :ghissue:`401`.
 

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,9 @@
 Version History
 ===============
 1.48
+  * introduce: :meth:`~Terminal.get_font_coverage` reports codepoints the terminal font has a glyph
+    for, by mintty's ``OSC 7771`` Font Glyph Coverage Enquiry or the ``APC 25a1`` Glyph Protocol,
+    :ghpull:`407`.
   * bugfix: :ref:`legacy mouse` event names and button values, mouse release events returned by
     :meth:`~Terminal.inkey` were always ``MOUSE_LEFT_RELEASED`` for all buttons, they now report
     ``MOUSE_RELEASED``, :ghpull:`406`.

--- a/docs/terminal.rst
+++ b/docs/terminal.rst
@@ -182,13 +182,79 @@ applications to display inline images directly in the terminal.
 You can check whether your terminal supports sixel graphics using the
 :meth:`~.Terminal.does_sixel` method:
 
-    >>> if term.does_sixel():
-    ...     display_sixel_image()
-    ... else:
-    ...     display_text_fallback()
+.. code-block:: python
+
+    if term.does_sixel():
+        display_sixel_image()
+    else:
+        display_text_fallback()
 
 Default ``timeout`` argument of 1 second is used to avoid blocking indefinitely
 when the terminal fails to respond to DA1 queries.
+
+Font Glyph Coverage
+-------------------
+
+When a terminal is asked to draw a character its font has no glyph for, it draws a placeholder in
+its place. These are called "tofu", after U+25A1 WHITE SQUARE (``□``) and its resemblance to the
+grocery food. It may also contain a large 'X', or the hexadecimal value of the codepoint.
+
+The :meth:`~.Terminal.get_font_coverage` method queries the terminal support for font glyphs,
+returning :class:`~.FontCoverage` that reports on each codepoint of the given text, and whether the
+font has a glyph for it.
+
+In this example, the terminal's font is tested for an Octant character, new in Unicode 16 (2024):
+
+.. code-block:: python
+
+    octant = '\U0001CDE4' # '𜷤'
+    font_result = term.get_font_coverage(octant)
+    if not font_result.supported:
+        print('This terminal cannot report about tofus, status of octants is unknown.')
+    elif not font_result.covers(octant):
+        print(f'This terminal does not support octants ({octant}).')
+    else:
+        print(f'This terminal does support octants ({octant}).')
+
+Two protocols are supported and tested in this order: mintty's `Font Glyph Coverage Enquiry
+<https://github.com/mintty/mintty/wiki/CtrlSeqs#font-glyph-coverage-enquiry>`_ (``OSC 7771``), and
+the `Glyph Protocol <https://rapha.land/introducing-glyph-protocol-for-terminals/>`_ from Rio
+terminal.
+
+Answers are cached, so repeated calls do not incur further delay. Very long strings are broken down
+and queried in batches.  Use argument ``force=True`` to forcefully re-query terminal for new result,
+such as if a font change is detected.  A codepoint the terminal declines to answer for, whether by
+an error reply or timeout, is reported through :attr:`~.FontCoverage.unknown` together with the
+reason.
+
+.. warning::
+
+   Coverage is reported by each individual codepoint, no protocol allows for query of a *sequence*
+   of codepoints, `grahemes <https://mitchellh.com/writing/grapheme-clusters-in-terminals>`_ are not
+   supported, meaning a great many kinds of font glyphs that may "tofu" cannot be queried about,
+   which is a limitation of both terminal protocols.
+
+   A grapheme cluster may render correctly even though the protocol may report no support of its
+   individual codepoints. For example, U+231A WATCH followed by U+FE0E VARIATION SELECTOR-15, as no
+   font holds a glyph for a variation selector 15, the terminal truthfully reports it as "uncovered"
+   or "tofu", while otherwise drawing the cluster perfectly fine:
+
+    .. code-block:: python
+
+        >>> watch = '\u231a\ufe0e'  # '⌚︎'
+        >>> font_result = term.get_font_coverage(watch)
+        >>> font_result
+        FontCoverage(protocol='glyph', covered=1, uncovered=1, unknown=0)
+        >>> font_result.covers(watch)
+        False
+        >>> list(map(hex, font_result.covered))
+        ['0x231a']
+        >>> list(map(hex, font_result.uncovered))
+        ['0xfe0e']
+
+See example program, :ref:`detect-tofus.py`, which detects and reports "tofus" for the attached
+terminal, and performs NFC normalization and discards "default ignorable codepoints" from reporting,
+such as the variation selector, above.
 
 OSC 52 Clipboard
 -----------------

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -2,6 +2,7 @@
 # local
 from blessed.keyboard import _read_until
 from .accessories import TestTerminal
+from blessed.keyboard import _read_until
 
 
 # Test data (raw strings, no Terminal dependency at module level)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -2,7 +2,6 @@
 # local
 from blessed.keyboard import _read_until
 from .accessories import TestTerminal
-from blessed.keyboard import _read_until
 
 
 # Test data (raw strings, no Terminal dependency at module level)

--- a/tests/test_font_glyph.py
+++ b/tests/test_font_glyph.py
@@ -136,16 +136,6 @@ def test_mintty_covering_nothing_still_supports():
     assert coverage.uncovered == {0x25a1} and coverage.unknown == {}
 
 
-def test_mintty_truncated_reply_is_unknown():
-    """A codepoint answered about in truncated form is not answered about at all."""
-    # mintty before 3.8.3 looks up only the low 16 bits, so what it says of U+1F600 is
-    # really said of U+F600, a private use codepoint whose glyph proves nothing here
-    (coverage,), _ = run(f'\x1b]7771;!;{0x1f600 & 0xffff}\x07{CPR}', '\U0001f600',
-                         name='test_mintty_truncated_reply_is_unknown')
-    assert coverage.protocol == 'mintty' and coverage.sources == {}
-    assert coverage.unknown == {0x1f600: 'truncated reply'}
-
-
 @pytest.mark.parametrize('probe', [
     PROBE,                              # formats advertised
     f'\x1b_25a1;s;fmt=\x1b\\{CPR}',     # none advertised

--- a/tests/test_font_glyph.py
+++ b/tests/test_font_glyph.py
@@ -37,10 +37,12 @@ SAMPLE = FontCoverage(sources={0x41: 'system', 0x42: '', 0x43: 'system,glossary'
                       unknown={0x44: 'no reply'}, protocol='glyph')
 
 
-def mintty(*codepoints):
-    """Build a mintty OSC 7771 reply naming *codepoints* as covered."""
-    covered = ''.join(f';{cp}' for cp in codepoints)
-    return f'\x1b]7771;!{covered}\x07{CPR}'
+def mintty(*codepoints, missing=()):
+    """Build a mintty OSC 7771 reply for *codepoints*, those in *missing* uncovered."""
+    # the reply is positional, repeating the query field for field: every codepoint
+    # queried gets a ';', and only a covered one is named after it
+    fields = ''.join(';' if cp in missing else f';{cp}' for cp in codepoints)
+    return f'\x1b]7771;!{fields}\x07{CPR}'
 
 
 def glyph(*pairs):
@@ -105,8 +107,8 @@ def test_probes_are_not_repeated():
     # mintty names the covered codepoints, omitting the rest, and names no source of
     # its own, so 'system' stands for the font it answers about
     (mintty(65, 66, 67), 'ABC', {65: 'system', 66: 'system', 67: 'system'}),
-    (mintty(65, 67), 'ABC', {65: 'system', 66: '', 67: 'system'}),
-    (mintty(), 'AB', {65: '', 66: ''}),
+    (mintty(65, 66, 67, missing=(66,)), 'ABC', {65: 'system', 66: '', 67: 'system'}),
+    (mintty(65, 66, missing=(65, 66)), 'AB', {65: '', 66: ''}),
     (mintty(0x1f600), '\U0001f600', {0x1f600: 'system'}),
     # the Glyph Protocol names which sources cover each codepoint
     (NO_REPLY + PROBE + glyph((65, 'system'), (66, ''), (67, 'system,glossary')),
@@ -122,6 +124,26 @@ def test_sources(replies, text, sources):
     assert coverage.sources == sources
     assert coverage.unknown == {}
     assert coverage.protocol == ('mintty' if replies.startswith('\x1b]') else 'glyph')
+
+
+def test_mintty_covering_nothing_still_supports():
+    """A reply of separators alone names no codepoint, yet proves the protocol."""
+    # mintty answers field for field, so a font covering none of what was asked
+    # replies with the separators and nothing else, ';' for a single codepoint
+    (coverage,), _ = run(mintty(0x25a1, missing=(0x25a1,)), '\u25a1',
+                         name='test_mintty_covering_nothing_still_supports')
+    assert coverage.protocol == 'mintty' and coverage.supported
+    assert coverage.uncovered == {0x25a1} and coverage.unknown == {}
+
+
+def test_mintty_truncated_reply_is_unknown():
+    """A codepoint answered about in truncated form is not answered about at all."""
+    # mintty before 3.8.3 looks up only the low 16 bits, so what it says of U+1F600 is
+    # really said of U+F600, a private use codepoint whose glyph proves nothing here
+    (coverage,), _ = run(f'\x1b]7771;!;{0x1f600 & 0xffff}\x07{CPR}', '\U0001f600',
+                         name='test_mintty_truncated_reply_is_unknown')
+    assert coverage.protocol == 'mintty' and coverage.sources == {}
+    assert coverage.unknown == {0x1f600: 'truncated reply'}
 
 
 @pytest.mark.parametrize('probe', [
@@ -202,7 +224,8 @@ def test_only_new_codepoints_are_queried():
 
 def test_uncovered_is_cached_too():
     """A negative answer is remembered, and not asked for twice."""
-    coverages, written = run(mintty(65), 'AB', 'BB', name='test_uncovered_is_cached_too')
+    coverages, written = run(mintty(65, 66, missing=(66,)), 'AB', 'BB',
+                             name='test_uncovered_is_cached_too')
     assert all(coverage.uncovered == {66} for coverage in coverages)
     assert written.count('\x1b]7771;?') == 1
 
@@ -217,7 +240,7 @@ def test_result_is_scoped_to_the_text_asked_about():
 def test_force_discards_cache():
     """force=True re-probes the protocol and re-asks every codepoint."""
     def child(term):
-        term.ungetch(mintty(65) + mintty(65, 66))
+        term.ungetch(mintty(65, 66, missing=(66,)) + mintty(65, 66))
         assert term.get_font_coverage('AB', timeout=0.01).uncovered == {66}
         assert term.get_font_coverage(
             'AB', timeout=0.01, force=True).covered == {65, 66}
@@ -333,7 +356,9 @@ def test_coverage_equality_returns_notimplemented():
 
 @pytest.mark.parametrize('text, expected', [
     ('\x1b]7771;!;65;66;67\x07', ';65;66;67'),
-    ('\x1b]7771;!\x07', ''),                    # nothing covered
+    ('\x1b]7771;!;65;;67\x07', ';65;;67'),      # the middle one uncovered
+    ('\x1b]7771;!;;;\x07', ';;;'),              # three queried, none covered
+    ('\x1b]7771;!\x07', ''),                    # nothing was asked about
     ('\x1b]7771;!;128512\x1b\\', ';128512'),    # ST terminates, and past the BMP
     ('\x1b]7771;?;65\x07', None),               # a query, not a reply
 ])

--- a/tests/test_font_glyph.py
+++ b/tests/test_font_glyph.py
@@ -1,0 +1,407 @@
+"""Test font glyph coverage detection (get_font_coverage)."""
+# std imports
+import io
+import os
+import json
+import time
+import select
+
+# 3rd party
+import pytest
+
+# local
+from .conftest import IS_WINDOWS
+from .accessories import TestTerminal, pty_test
+from blessed._capabilities import FontCoverage
+from blessed.terminal import (_FONT_QUERY_CHUNK_SIZE,
+                              _RE_MINTTY_FONT_RESPONSE,
+                              _RE_GLYPH_PROTOCOL_Q_RESPONSE,
+                              _RE_GLYPH_PROTOCOL_S_RESPONSE)
+
+pytestmark = pytest.mark.skipif(
+    IS_WINDOWS, reason="PTY testing not supported on Windows")
+
+# a CPR reply, the boundary that ends every round-trip; alone, it is a round-trip in
+# which the terminal answered nothing
+CPR = NO_REPLY = '\x1b[10;20R'
+# a Glyph Protocol 's' verb reply, advertising support
+PROBE = f'\x1b_25a1;s;fmt=glyf,colrv0\x1b\\{CPR}'
+# separates the terminal queries a child wrote from the result it reports back
+SENTINEL = '\x1e'
+# 257 distinct codepoints, one more than a single query round-trip carries
+LONG_TEXT = ''.join(chr(cp) for cp in
+                    range(0x2500, 0x2500 + _FONT_QUERY_CHUNK_SIZE + 1))
+# a result to exercise FontCoverage itself: A covered, B not, C by two sources,
+# D unanswered, E never queried
+SAMPLE = FontCoverage(sources={0x41: 'system', 0x42: '', 0x43: 'system,glossary'},
+                      unknown={0x44: 'no reply'}, protocol='glyph')
+
+
+def mintty(*codepoints):
+    """Build a mintty OSC 7771 reply naming *codepoints* as covered."""
+    covered = ''.join(f';{cp}' for cp in codepoints)
+    return f'\x1b]7771;!{covered}\x07{CPR}'
+
+
+def glyph(*pairs):
+    """Build a Glyph Protocol 'q' verb reply of (codepoint, status) *pairs*."""
+    return ''.join(f'\x1b_25a1;q;cp={cp:x};status={status}\x1b\\'
+                   for cp, status in pairs) + CPR
+
+
+def run(replies, *texts, name='run', parent=None, **kwargs):
+    """Query a terminal answering *replies*, once per text, in a child process."""
+    # returns (coverages, written): the result of each get_font_coverage call, and
+    # the bytes the child wrote to its terminal.  Results cross the fork as JSON,
+    # past SENTINEL, so that assertions may live here rather than in the child.
+    def child(term):
+        results = []
+        term.ungetch(replies)
+        for text in texts:
+            coverage = term.get_font_coverage(text, **dict({'timeout': 0.01}, **kwargs))
+            results.append([coverage.protocol, coverage.sources, coverage.unknown])
+        return (SENTINEL + json.dumps(results)).encode()
+
+    written, _, payload = pty_test(child, parent, test_name=name).partition(SENTINEL)
+    return [FontCoverage(sources={int(cp): src for cp, src in sources.items()},
+                         unknown={int(cp): why for cp, why in unknown.items()},
+                         protocol=protocol)
+            for protocol, sources, unknown in json.loads(payload)], written
+
+
+@pytest.mark.parametrize('kwargs', [
+    {'force_styling': True, 'is_a_tty': False},
+    {'force_styling': False},
+], ids=['not-a-tty', 'no-styling'])
+def test_no_terminal_to_ask(kwargs):
+    """An empty, falsey result when there is no styled tty to query."""
+    term = TestTerminal(stream=io.StringIO(), **kwargs)
+    coverage = term.get_font_coverage('abc', timeout=0.01)
+    assert not coverage and coverage.protocol is None
+
+
+@pytest.mark.parametrize('replies, text', [
+    ('', 'A'),                     # not even a CPR comes back
+    (NO_REPLY + NO_REPLY, 'A'),    # both protocols probed, both silent
+    (mintty(65), ''),              # nothing asked about, nothing learned
+], ids=['no-reply', 'both-silent', 'empty-text'])
+def test_falsey_result(replies, text):
+    """Nothing is known, and the result says so."""
+    (coverage,), _ = run(replies, text, name='test_falsey_result')
+    assert not coverage
+    assert coverage.sources == {} and coverage.unknown == {}
+
+
+def test_probes_are_not_repeated():
+    """Once both protocols are known silent, nothing is ever sent again."""
+    coverages, written = run(NO_REPLY + NO_REPLY, 'A', 'BCD',
+                             name='test_probes_are_not_repeated')
+    assert not any(coverages)
+    assert written.count('\x1b]7771;?') == 1
+    assert written.count('\x1b_25a1;s\x1b\\') == 1
+
+
+@pytest.mark.parametrize('replies, text, sources', [
+    # mintty names the covered codepoints, omitting the rest, and names no source of
+    # its own, so 'system' stands for the font it answers about
+    (mintty(65, 66, 67), 'ABC', {65: 'system', 66: 'system', 67: 'system'}),
+    (mintty(65, 67), 'ABC', {65: 'system', 66: '', 67: 'system'}),
+    (mintty(), 'AB', {65: '', 66: ''}),
+    (mintty(0x1f600), '\U0001f600', {0x1f600: 'system'}),
+    # the Glyph Protocol names which sources cover each codepoint
+    (NO_REPLY + PROBE + glyph((65, 'system'), (66, ''), (67, 'system,glossary')),
+     'ABC', {65: 'system', 66: '', 67: 'system,glossary'}),
+    (NO_REPLY + PROBE + glyph((0xe0a0, 'glossary')), '', {0xe0a0: 'glossary'}),
+    # a zero status is success naming no source: uncovered, and not an error
+    (NO_REPLY + PROBE + glyph((65, '0')), 'A', {65: ''}),
+], ids=['mintty-all', 'mintty-partial', 'mintty-none', 'mintty-beyond-bmp',
+        'glyph-sources', 'glyph-glossary-only', 'glyph-zero-status'])
+def test_sources(replies, text, sources):
+    """Coverage is reported per codepoint, keeping the source that covers it."""
+    (coverage,), _ = run(replies, text, name='test_sources')
+    assert coverage.sources == sources
+    assert coverage.unknown == {}
+    assert coverage.protocol == ('mintty' if replies.startswith('\x1b]') else 'glyph')
+
+
+@pytest.mark.parametrize('probe', [
+    PROBE,                              # formats advertised
+    f'\x1b_25a1;s;fmt=\x1b\\{CPR}',     # none advertised
+    f'\x1b_25a1;s;\x1b\\{CPR}',         # no key=value pair at all
+], ids=['formats', 'empty-fmt', 'valueless'])
+def test_glyph_probe_variants(probe):
+    """Any 's' reply is support: the 'q' verb does not depend on 'fmt'."""
+    (coverage,), _ = run(NO_REPLY + probe + glyph((65, 'system')), 'A',
+                         name='test_glyph_probe_variants')
+    assert coverage.protocol == 'glyph' and coverage.covers('A')
+
+
+@pytest.mark.parametrize('replies, text, written', [
+    # each distinct codepoint named once, in decimal, ascending
+    (mintty(65, 66), 'BABA', '\x1b]7771;?;65;66\x07'),
+    # one APC per codepoint, in hex
+    (NO_REPLY + PROBE + glyph((65, 'system'), (0xe0a0, 'system')), 'A\ue0a0',
+     '\x1b_25a1;q;cp=41\x1b\\\x1b_25a1;q;cp=e0a0\x1b\\'),
+], ids=['mintty', 'glyph'])
+def test_query_shape(replies, text, written):
+    """The query names the codepoints in the form each protocol expects."""
+    assert written in run(replies, text, name='test_query_shape')[1]
+
+
+@pytest.mark.parametrize('reply, unknown', [
+    # an error reply names its reason, and leaves the batch otherwise unharmed ...
+    ('\x1b_25a1;q;cp=41;status=2;reason=out_of_namespace\x1b\\'
+     '\x1b_25a1;q;cp=42;status=system\x1b\\' + CPR, {65: 'out_of_namespace'}),
+    # ... or falls back to naming its status
+    ('\x1b_25a1;q;cp=41;status=7\x1b\\'
+     '\x1b_25a1;q;cp=42;status=system\x1b\\' + CPR, {65: 'status=7'}),
+    # no reply for this codepoint at all
+    (glyph((66, 'system')), {65: 'no reply'}),
+    # no reply to the whole query
+    (NO_REPLY, {65: 'no reply', 66: 'no reply'}),
+], ids=['error-reason', 'error-status', 'missing-one', 'missing-all'])
+def test_unknown(reply, unknown):
+    """An unanswered codepoint is neither covered nor uncovered."""
+    (coverage,), _ = run(NO_REPLY + PROBE + reply, 'AB', name='test_unknown')
+    assert coverage.supported is True
+    assert coverage.unknown == unknown
+    assert not set(unknown) & (coverage.covered | coverage.uncovered)
+
+
+def test_unknown_is_not_asked_again():
+    """A codepoint the terminal refused is not re-queried without force."""
+    error = '\x1b_25a1;q;cp=41;status=1;reason=malformed\x1b\\' + CPR
+    coverages, written = run(NO_REPLY + PROBE + error, 'A', 'A',
+                             name='test_unknown_is_not_asked_again')
+    assert all(coverage.unknown == {65: 'malformed'} for coverage in coverages)
+    assert written.count('\x1b_25a1;q;cp=41\x1b\\') == 1
+
+
+@pytest.mark.parametrize('answered', [True, False], ids=['answered', 'unanswered'])
+def test_chunking(answered):
+    """257 codepoints are asked for in a chunk of 256 and a chunk of one."""
+    first = [ord(char) for char in LONG_TEXT[:_FONT_QUERY_CHUNK_SIZE]]
+    last = ord(LONG_TEXT[-1])
+    (coverage,), _ = run(mintty(*first) + (mintty(last) if answered else NO_REPLY),
+                         LONG_TEXT, name='test_chunking')
+    # the first chunk is good either way, only the second may be lost
+    assert coverage.covered == set(first) | ({last} if answered else set())
+    assert coverage.unknown == ({} if answered else {last: 'no reply'})
+
+
+def test_only_new_codepoints_are_queried():
+    """A repeat or overlapping call asks only about what is not yet known."""
+    # a second round-trip for 'A' or 'B' could only time out and be unknown
+    coverages, written = run(mintty(65, 66) + mintty(67), 'AB', 'BAB', 'ABC',
+                             name='test_only_new_codepoints_are_queried')
+    assert all(coverage.covers(text)
+               for coverage, text in zip(coverages, ('AB', 'BAB', 'ABC')))
+    assert '\x1b]7771;?;65;66\x07' in written
+    assert '\x1b]7771;?;67\x07' in written
+
+
+def test_uncovered_is_cached_too():
+    """A negative answer is remembered, and not asked for twice."""
+    coverages, written = run(mintty(65), 'AB', 'BB', name='test_uncovered_is_cached_too')
+    assert all(coverage.uncovered == {66} for coverage in coverages)
+    assert written.count('\x1b]7771;?') == 1
+
+
+def test_result_is_scoped_to_the_text_asked_about():
+    """A cached codepoint outside the text is not reported back."""
+    coverages, _ = run(mintty(65, 66), 'AB', 'A',
+                       name='test_result_is_scoped_to_the_text_asked_about')
+    assert coverages[1].sources == {65: 'system'}
+
+
+def test_force_discards_cache():
+    """force=True re-probes the protocol and re-asks every codepoint."""
+    def child(term):
+        term.ungetch(mintty(65) + mintty(65, 66))
+        assert term.get_font_coverage('AB', timeout=0.01).uncovered == {66}
+        assert term.get_font_coverage(
+            'AB', timeout=0.01, force=True).covered == {65, 66}
+        return b'OK'
+
+    assert 'OK' in pty_test(child, test_name='test_force_discards_cache')
+
+
+def test_force_discards_unknown():
+    """force=True asks again about a codepoint the terminal refused."""
+    def child(term):
+        # the first exchange is buffered, the second is answered live below: the two
+        # cannot share a buffer, because reading is greedy and the first call would
+        # swallow the second call's replies
+        term.ungetch(NO_REPLY + PROBE +
+                     '\x1b_25a1;q;cp=41;status=1;reason=malformed\x1b\\' + CPR)
+        assert term.get_font_coverage('A', timeout=0.01).unknown == {65: 'malformed'}
+        coverage = term.get_font_coverage('A', timeout=1.0, force=True)
+        assert coverage.unknown == {} and coverage.covered == {65}
+        return b'OK'
+
+    def parent(master_fd):
+        # force=True re-probes from scratch: mintty, then 's', then 'q'.  Each marker
+        # appears twice, once for the buffered first call and once for this one.
+        data, stime = b'', time.time()
+        for marker, reply in ((b'\x1b]7771;?', CPR),
+                              (b'\x1b_25a1;s\x1b\\', PROBE),
+                              (b'\x1b_25a1;q;cp=41\x1b\\', glyph((65, 'system')))):
+            while data.count(marker) < 2:
+                if (remaining := 2.0 - (time.time() - stime)) <= 0:
+                    return
+                if select.select([master_fd], [], [], remaining)[0]:
+                    data += os.read(master_fd, 4096)
+            os.write(master_fd, reply.encode())
+
+    assert 'OK' in pty_test(child, parent, test_name='test_force_discards_unknown')
+
+
+@pytest.mark.parametrize('coverage, covered, uncovered', [
+    (SAMPLE, {0x41, 0x43}, {0x42}),
+    (FontCoverage(), set(), set()),
+], ids=['answered', 'empty'])
+def test_covered_and_uncovered_partition_sources(coverage, covered, uncovered):
+    """Every source entry is either covered or uncovered, never both."""
+    assert (coverage.covered, coverage.uncovered) == (covered, uncovered)
+    assert coverage.covered | coverage.uncovered == set(coverage.sources)
+
+
+def test_empty_coverage_is_falsey():
+    """An unsupported result is falsey and reports nothing."""
+    coverage = FontCoverage()
+    assert not coverage and coverage.supported is False
+    assert coverage.protocol is None and coverage.unknown == {}
+    assert coverage.covers('') is True and not coverage.covers('A')
+
+
+@pytest.mark.parametrize('item, expected', [
+    (0x41, True), ('A', True),        # covered, by codepoint or by character
+    (0x42, False), ('B', False),      # uncovered
+    (0x44, False), ('D', False),      # unanswered is not coverage
+    (0x45, False), ('E', False),      # never queried
+])
+def test_coverage_contains(item, expected):
+    """Membership works by codepoint and by single character alike."""
+    assert (item in SAMPLE) is expected
+
+
+@pytest.mark.parametrize('item', ['AB', '', None, 1.5, b'A', ('A',)],
+                         ids=['too-long', 'empty', 'none', 'float', 'bytes', 'tuple'])
+def test_coverage_contains_rejects_non_codepoints(item):
+    """A value that cannot be a codepoint raises, rather than answering False."""
+    with pytest.raises(TypeError, match='must be an integer or a string of length 1'):
+        assert item in SAMPLE
+
+
+@pytest.mark.parametrize('text, expected', [
+    ('A', True), ('AAA', True), ('AC', True),
+    ('AB', False),   # uncovered
+    ('AD', False),   # unanswered
+    ('AE', False),   # never queried
+])
+def test_coverage_covers_requires_every_codepoint(text, expected):
+    """covers() is all-or-nothing across the text given."""
+    assert SAMPLE.covers(text) is expected
+
+
+@pytest.mark.parametrize('other, equal', [
+    (FontCoverage(sources={0x41: 'system'}, protocol='mintty'), True),
+    (FontCoverage(sources={0x41: ''}, protocol='mintty'), False),
+    (FontCoverage(sources={0x41: 'system'}, protocol='glyph'), False),
+    (FontCoverage(sources={0x41: 'system'}, unknown={0x42: 'no reply'},
+                  protocol='mintty'), False),
+    ('not a coverage', False),
+])
+def test_coverage_equality(other, equal):
+    """Results compare by value, and do not compare with foreign types."""
+    assert (FontCoverage(sources={0x41: 'system'}, protocol='mintty') == other) is equal
+
+
+def test_coverage_repr():
+    """The repr describes a result by count."""
+    assert repr(SAMPLE) == (
+        "FontCoverage(protocol='glyph', covered=2, uncovered=1, unknown=1)")
+
+
+def test_coverage_equality_returns_notimplemented():
+    """Comparison with a foreign type defers, rather than claiming inequality."""
+    # returning NotImplemented rather than False is what lets the reflected
+    # comparison run, so the dunder is called deliberately here
+    # pylint: disable-next=unnecessary-dunder-call
+    assert FontCoverage().__eq__('not a coverage') is NotImplemented
+
+
+@pytest.mark.parametrize('text, expected', [
+    ('\x1b]7771;!;65;66;67\x07', ';65;66;67'),
+    ('\x1b]7771;!\x07', ''),                    # nothing covered
+    ('\x1b]7771;!;128512\x1b\\', ';128512'),    # ST terminates, and past the BMP
+    ('\x1b]7771;?;65\x07', None),               # a query, not a reply
+])
+def test_mintty_response_pattern(text, expected):
+    """_RE_MINTTY_FONT_RESPONSE parses the covered codepoint list."""
+    match = _RE_MINTTY_FONT_RESPONSE.search(text)
+    assert (match.group(1) if match else None) == expected
+
+
+@pytest.mark.parametrize('text, expected', [
+    ('\x1b_25a1;q;cp=41;status=system\x1b\\', ('41', 'system', None)),
+    ('\x1b_25a1;q;cp=42;status=\x1b\\', ('42', '', None)),
+    ('\x1b_25a1;q;cp=43;status=system,glossary\x1b\\', ('43', 'system,glossary', None)),
+    # the reason of an error reply is captured, and kept out of the status
+    ('\x1b_25a1;q;cp=e000;status=2;reason=out_of_namespace\x1b\\',
+     ('e000', '2', 'out_of_namespace')),
+])
+def test_glyph_q_response_pattern(text, expected):
+    """_RE_GLYPH_PROTOCOL_Q_RESPONSE parses cp, status and reason."""
+    assert _RE_GLYPH_PROTOCOL_Q_RESPONSE.search(text).groups() == expected
+
+
+@pytest.mark.parametrize('text, expected', [
+    ('\x1b_25a1;s;fmt=glyf,colrv0\x1b\\', ';fmt=glyf,colrv0'),
+    ('\x1b_25a1;s;fmt=\x1b\\', ';fmt='),
+    ('\x1b_25a1;s\x1b\\', None),                       # a bare verb
+    ('\x1b_25a1;q;cp=41;status=system\x1b\\', None),    # another verb's reply
+])
+def test_glyph_s_response_pattern(text, expected):
+    """_RE_GLYPH_PROTOCOL_S_RESPONSE captures the advertised parameters."""
+    match = _RE_GLYPH_PROTOCOL_S_RESPONSE.search(text)
+    assert (match.group(1) if match else None) == expected
+
+
+@pytest.mark.parametrize('kwargs', [
+    {'force_styling': True, 'is_a_tty': False},
+    {'force_styling': False},
+], ids=['not-a-tty', 'no-styling'])
+def test_query_boundary_multiple_no_terminal(kwargs):
+    """_query_boundary_multiple returns None without writing anything."""
+    term = TestTerminal(stream=io.StringIO(), **kwargs)
+    term._is_a_tty = kwargs.get('is_a_tty', True)
+    assert term._query_boundary_multiple(
+        'x', _RE_GLYPH_PROTOCOL_Q_RESPONSE, 0.01) is None
+
+
+def test_query_boundary_multiple_pushes_back_trailing_input():
+    """Keystrokes arriving after the boundary are given back to inkey()."""
+    def child(term):
+        term.ungetch('\x1b_25a1;q;cp=41;status=system\x1b\\' + CPR + 'xyz')
+        matches = term._query_boundary_multiple(
+            '', _RE_GLYPH_PROTOCOL_Q_RESPONSE, 0.01)
+        assert [match.group(1) for match in matches] == ['41']
+        with term.cbreak():
+            assert ''.join(term.inkey(timeout=0.01) for _ in range(3)) == 'xyz'
+        return b'OK'
+
+    assert 'OK' in pty_test(
+        child, test_name='test_query_boundary_multiple_pushes_back_trailing_input')
+
+
+def test_query_boundary_multiple_without_replies():
+    """A bare boundary yields an empty list, distinct from None."""
+    def child(term):
+        term.ungetch(CPR)
+        assert term._query_boundary_multiple(
+            '', _RE_GLYPH_PROTOCOL_Q_RESPONSE, 0.01) == []
+        return b'OK'
+
+    assert 'OK' in pty_test(
+        child, test_name='test_query_boundary_multiple_without_replies')


### PR DESCRIPTION
Support "tofu detection" as documented and tested, and by example ``bin/detect-tofus.py``.

mintty is a son of a bitch.. it takes a lot of customization [to avoid conhost.exe](https://github.com/mintty/mintty/wiki/Tips#inputoutput-interaction-with-alien-programs), otherwise it won't work. And then it reports no tofu's at all, even when visually there are definitely tens of thousands. And, many of the grapheme tests of ucs-detect corrupt the font output, lots of strange draw artifacts that persist, tofus, and VS16, emoji ZWJ etc. are all corrupted by display.. despite my efforts to install unifont, it can't seem to handle multiple or fallback fonts correctly.

I will document mintty's egregious behaviors in ucs-detect, and since the code works I'll keep it, but I wouldn't recommend mintty for unicode!