### PR TITLE
XTGETTCAP improvements

### DIFF
--- a/blessed/__init__.py
+++ b/blessed/__init__.py
@@ -15,4 +15,4 @@ else:
 from blessed.line_editor import LineEditor, LineHistory
 
 __all__ = ('Terminal', 'LineEditor', 'LineHistory')
-__version__ = "1.49.0"
+__version__ = "1.50.0"

--- a/blessed/_capabilities.py
+++ b/blessed/_capabilities.py
@@ -263,7 +263,8 @@ XTGETTCAP_CAPABILITIES = (
     ("cvvis", "Very visible cursor"),
     # And here is where blessed's integration ends. All remaining capabilities, for blessed's
     # purposes, are informational only. Used by the downstream 'ucs-detect' tool for auditing and
-    # fingerprinting purposes, like "kitty-query-clipboard_control".
+    # fingerprinting purposes, like "kitty-query-clipboard_control" but not used by blessed
+    # directly.
     #
     # Remaining numeric capabilities
     ("colors", "Max colors on screen"),

--- a/blessed/keyboard.py
+++ b/blessed/keyboard.py
@@ -24,12 +24,24 @@ from blessed.mouse import (RE_PATTERN_MOUSE_SGR,
                            MouseSGREvent,
                            MouseLegacyEvent)
 from blessed.dec_modes import DecPrivateMode
+from blessed._capabilities import TermcapResponse
 
 _T = TypeVar('_T', bound='Keystroke')
 
-TERMINAL_QUERY_TIMEOUT_SECONDS = 1.0
-"""Default timeout in seconds for terminal query operations (XTGETTCAP, OSC, DCS, etc.)."""
-
+# All of our queries should be replied to, even ones that are not supported, thanks to our "query
+# with CPR boundary" pattern, which all VT100 terminals perform automatic reply for.  And so we
+# should be able to await a response indefinitely.
+#
+# However, automatic scripts can report to be a terminal through their protocol, like 'ssh -t', or
+# by using a pty(7), but lack the terminal code to detect and respond to CPR. Common examples are
+# tcl expect(1) scripts, or python pexpect.  Their use will always incur artificial delays here for
+# that reason, and it's a pitfall for many in QA automation, and a common "are you human?" check
+# used by public telnet servers. Use this environment value for any such special condition, either
+# 'inf' for high-latency networks, or '0' for automation.
+TERMINAL_QUERY_TIMEOUT_SECONDS = float(
+    os.environ.get(
+        'BLESSED_QUERY_TIMEOUT_SECONDS',
+        '5.0') or '5.0')
 
 # DEC event namedtuples
 BracketedPasteEvent = namedtuple('BracketedPasteEvent', 'text')
@@ -37,7 +49,6 @@ BracketedPasteEvent = namedtuple('BracketedPasteEvent', 'text')
 FocusEvent = namedtuple('FocusEvent', 'gained')
 SyncEvent = namedtuple('SyncEvent', 'begin')
 ResizeEvent = namedtuple('ResizeEvent', 'height_chars width_chars height_pixels width_pixels')
-
 
 # Keyboard protocol namedtuples
 KittyKeyEvent = namedtuple('KittyKeyEvent',
@@ -57,6 +68,7 @@ RE_PATTERN_KITTY_KB_PROTOCOL = re.compile(
     r'(?::(?P<event_type>\d+))?'
     r'(?:;(?P<text_codepoints>[\d:]+))?'
     r'u')
+
 # Legacy CSI modifiers: ESC [ 1 ; modifiers [ABCDEFHPQRS]
 RE_PATTERN_LEGACY_CSI_MODIFIERS = re.compile(
     r'\x1b\[1;(?P<mod>\d+)(?::(?P<event>\d+))?(?P<final>[ABCDEFHPQRS])')
@@ -1174,6 +1186,16 @@ class Keystroke(str):
         return (-1, -1)
 
     @property
+    def xtgettcap(self) -> Dict[str, str]:
+        """
+        Capabilities reported by an XTGETTCAP response.
+
+        :rtype: dict
+        :returns: mapping of terminal capability name to value.
+        """
+        return TermcapResponse.parse_capabilities(self)
+
+    @property
     def text(self) -> Optional[str]:
         """
         Pasted text for bracketed paste events.
@@ -1425,6 +1447,7 @@ def resolve_sequence(text: str,
         _match_legacy_csi_letter_form,
         _match_legacy_csi_tilde_form,
         _match_legacy_ss3_fkey_form,
+        _match_xtgettcap_response,
         _match_cpr_response]
     if capture_cpr:
         # prioritize capturing CPR_RESPONSE over legacy CSI Modifiers
@@ -1570,6 +1593,21 @@ def _match_dec_event(text: str,
         match = pattern.match(text)
         if match:
             return Keystroke(ucs=match.group(0), mode=mode, match=match)
+    return None
+
+
+def _match_xtgettcap_response(text: str) -> Optional[Keystroke]:
+    """
+    Match XTGETTCAP reply: ESC P 1 + r <hex> = <hex> ESC backslash.
+
+    A terminal could answer an XTGETTCAP query long after it has timed out, on a high latency link.
+    Matching it here allows late replies in response to xtgettcap at class initialization to be
+    processed, and are not returned by any later call inkey().
+    """
+    # pylint: disable=protected-access
+    match = TermcapResponse._RE_XTGETTCAP_RESPONSE.match(text)
+    if match:
+        return Keystroke(ucs=match.group(0), name='XTGETTCAP_RESPONSE')
     return None
 
 

--- a/blessed/terminal.py
+++ b/blessed/terminal.py
@@ -332,16 +332,26 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
     def __init__xtgettcap(self) -> TermcapResponse:
         """Probe for core XTGETTCAP capabilities."""
+        # XTGETTCAP provides excellent communication of the terminal's self-reported 'TERM' (TN),
+        # and so it is done at class initialization.  However, some prominent terminals by Microsoft
+        # and Apple erroneously "leak" VT100 Mode DCS queries in error, meaning the hexadecimal
+        # ASCII payloads meant for the terminal to process are displayed as visible text to the
+        # user. And so an XTGETTCAP query is avoided for those terminals when identifiable.
         _xtgettcap_cache = TermcapResponse(supported=False)
-        # These prominent terminals "leak" VT100 Mode DCS queries, meaning the hexedecimal ascii
-        # payloads meant for the terminal to process are displayed as visible text to the user.  Try
-        # our best to avoid to query them, but these variables are not forwarded over SSH.
         if os.environ.get('ANSICON') or os.environ.get('ConEmuANSI'):
             self.errors.append('XTGETTCAP probe: skipped, ansicon')
             return _xtgettcap_cache
         if os.environ.get('TERM_PROGRAM') == 'Apple_Terminal':
             self.errors.append('XTGETTCAP probe: skipped, Terminal.app')
             return _xtgettcap_cache
+        if IS_WINDOWS and not (os.environ.get('TERM') or os.environ.get('WT_SESSION')):
+            if sys.getwindowsversion().build < 22000:  # pylint: disable=no-member
+                # early "modern" conhost.exe (cmd.exe) parses VT100 sequences but not DCS.  fixed by
+                # https://github.com/microsoft/terminal/pull/6328 and never backported.  Build
+                # number is approximate.
+                self.errors.append('XTGETTCAP probe: skipped, bad conhost.exe')
+                return _xtgettcap_cache
+
         if (self.is_a_tty and self._keyboard_fd is not None):
             try:
                 _xtgettcap_cache = self._xtgettcap_batch(
@@ -358,10 +368,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         """Determine terminal 'kind' jinxed.setupterm() capability database."""
         # Previous to 1.40, blessed could fallback to 'dumb' when it could not find a meaningful
         # type, but now kind_fallback='xterm-256color' is always guaranteed available and used
-        # instead of 'dumb'.
-        #
-        # I believe now xterm-256 sequences are safe as unknown fallback for the year 2026. If dumb
-        # *is*, use NO_COLOR or force_styling=False which has the same general result.
+        # instead of 'dumb'.  I believe now xterm-256 sequences are safe as unknown fallback for the
+        # year 2026. Use NO_COLOR or force_styling=False to force the same result.
         tn_kind = self._xtgettcap_cache.capabilities.get('TN')
         term_kind = (jinxed.get_term(self._init_descriptor)
                      if IS_WINDOWS and self._init_descriptor is not None
@@ -640,10 +648,12 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         # Add DEC event prefixes (mouse, bracketed paste, focus tracking) These
         # are not in the keymap but need to be recognized as valid "prefixes",
         # so that they are *not* detected as a 'metaSendsEscape' sequence until
-        # after esc_delay has elapsed.
+        # after esc_delay has elapsed -- like Alt+M (\x1b[M), Alt+2 ('\x1b[2')
+        # and Alt+Shift+P ('\x1bP') ! Use kitty keyboard protocol if it matters.
         self._keymap_prefixes.update([
             '\x1b[M',     # Legacy mouse (needs 3 more bytes)
             '\x1b[<',     # SGR mouse (variable length)
+            '\x1bP',      # DCS, an XTGETTCAP reply arriving after its query timed out
             '\x1b[200',   # Bracketed paste start and its starting prefixes,
             '\x1b[20',
             '\x1b[2'])
@@ -960,6 +970,8 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
                 self, _RE_CPR_BOUNDARY.pattern, timeout)
 
             if cpr_match is None:
+                # re-buffer keyboard data, if any
+                self.ungetch(data)
                 return None
 
             data = data[:cpr_match.start()] + data[cpr_match.end():]
@@ -4334,6 +4346,17 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         # buffer any remaining text received
         self.ungetch(ucs[len(ks):])
 
+        # Detect very late capability replies arrived after TERMINAL_QUERY_TIMEOUT_SECONDS elapsed.
+        # Do not return as keystroke, Fold into the cache and continue waiting for real input using
+        # recursion.
+        if ks.name == 'XTGETTCAP_RESPONSE':
+            self.errors.append(f'errant/delayed XTGETTCAP_RESPONSE {str(ks)!r}')
+            if self.does_styling and (late_caps := ks.xtgettcap):
+                self._update_xtgettcap_cache(
+                    TermcapResponse(supported=True, capabilities=late_caps))
+            return self.inkey(timeout=_time_left(stime, timeout),
+                              esc_delay=esc_delay, capture_cpr=capture_cpr)
+
         # Update preferred size cache if this is a resize event
         if ks._mode == _DecPrivateMode.IN_BAND_WINDOW_RESIZE:  # pylint: disable=protected-access
             event_vals = ks._mode_values  # pylint: disable=protected-access
@@ -4390,6 +4413,7 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
         """
         # pylint: disable=too-complex,too-many-branches
         loop = asyncio.get_running_loop()
+        stime = time.time()
 
         # drain keyboard buffer (non-blocking)
         ucs = self.flushinp()
@@ -4453,6 +4477,18 @@ class Terminal():  # pylint: disable=attribute-defined-outside-init
 
         # buffer any remaining text
         self.ungetch(ucs[len(ks):])
+
+        # What if an XTGETTCAP reply from get_xtgettcap(), or, made at class-initialization arrives
+        # after timeout? Fold it into the response cache and continue awaiting *user* input.
+        # Conservatively chose not re-initialize self._jinxed_term on latent 'TN' or
+        # self._number_of_colors on 'RGB' responses, though.
+        if ks.name == 'XTGETTCAP_RESPONSE':
+            self.errors.append(f'errant/delayed XTGETTCAP_RESPONSE {str(ks)!r}')
+            if self.does_styling and (late_caps := ks.xtgettcap):
+                self._update_xtgettcap_cache(
+                    TermcapResponse(supported=True, capabilities=late_caps))
+            return await self.async_inkey(timeout=_time_left(stime, timeout),
+                                          esc_delay=esc_delay, capture_cpr=capture_cpr)
 
         # update preferred size cache if this is a resize event
         if ks._mode == _DecPrivateMode.IN_BAND_WINDOW_RESIZE:  # pylint: disable=protected-access

--- a/blessed/win_terminal.py
+++ b/blessed/win_terminal.py
@@ -376,13 +376,22 @@ class Terminal(_Terminal):
             return
 
         if self._keyboard_fd is None:
+            # dummy hook, for systems without mouse support
             yield
             return
 
         filehandle = msvcrt.get_osfhandle(self._keyboard_fd)
         save_mode = win32.get_console_mode(filehandle)
+        if not save_mode & win32.ENABLE_EXTENDED_FLAGS:
+            # cbreak() and raw() set a console mode without any of the "private" flags, after
+            # which QuickEdit is no longer reported by get_console_mode(), restore its default.
+            save_mode |= win32.ENABLE_EXTENDED_FLAGS | win32.ENABLE_QUICK_EDIT_MODE
+        # The console host consumes mouse events for text selection while "QuickEdit mode" is
+        # enabled, it must be disabled for mouse events to be received.  ENABLE_EXTENDED_FLAGS
+        # must be set in the same call, or the QuickEdit bit is otherwise ignored.
         win32.set_console_mode(
-            filehandle, save_mode | win32.ENABLE_MOUSE_INPUT)
+            filehandle,
+            (save_mode | win32.ENABLE_MOUSE_INPUT) & ~win32.ENABLE_QUICK_EDIT_MODE)
         self._native_mouse = True
         self._prev_button_state = 0
         self._dec_mode_cache[

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,11 @@
 Version History
 ===============
 
+1.50
+  * bugfix: do not query XTGETTCAP at class initialization for Windows Server 2022, :ghpull:`409`.
+  * improve: :meth:`~Terminal.inkey` no longer captures latent XTGETTCAP responses as keystrokes,
+    and increase global ``TERMINAL_QUERY_TIMEOUT_SECONDS`` from 1 to 2 seconds, :ghpull:`409`.
+
 1.49
   * introduce: :meth:`~Terminal.get_font_coverage` reports codepoints the terminal font has a glyph
     for, by mintty's ``OSC 7771`` Font Glyph Coverage Enquiry or the ``APC 25a1`` Glyph Protocol,

--- a/docs/location.rst
+++ b/docs/location.rst
@@ -125,8 +125,8 @@ responses asynchronously as keyboard input events.
 
 Although :meth:`~Terminal.inkey` is capable of receiving *most* Cursor Position Report (CPR)
 sequences as Keystroke of name ``CPR_RESPONSE``, Some coordinate responses are in conflict with
-the "F3" key of the DEC vt220, but few very terminals transmit them in this conflicting form. If not
-bound or legacy vt220 key compatibility is not required, but asynchronous receipt of CPR Responses
+the "F3" key of the DEC vt220, but few very terminals transmit them in this conflicting form. If
+legacy vt220 key compatibility is not required, but asynchronous receipt of CPR Responses
 with correct coordinates are, use :meth:`~Terminal.inkey` argument ``capture_cpr=True``.
 
 In the following example, keyboard input is rapidly polled for and displayed,

--- a/tests/test_async_inkey.py
+++ b/tests/test_async_inkey.py
@@ -345,7 +345,7 @@ def test_async_read_byte_deadline_same_iteration_no_loss():
                     term._async_read_byte(loop, timeout=0.1))
             finally:
                 loop.close()
-            assert result == b'x', f'byte lost: _async_read_byte returned {result!r}'
+            assert result == b'x'
             return b'OK'
 
     def parent(master_fd):
@@ -380,3 +380,42 @@ def test_async_read_byte_deadline_wins_byte_stays():
 
     output = pty_test(child, parent, 'test_async_read_byte_deadline_wins_byte_stays')
     assert output == 'OK'
+
+
+def test_async_inkey_consumes_late_xtgettcap_response():
+    """async_inkey() consumes a late XTGETTCAP reply, returning the keystroke behind it."""
+    def child(term):
+        term.ungetch('\x1bP1+r524742=382f382f38\x1b\\n')
+        loop = asyncio.new_event_loop()
+        try:
+            ks = loop.run_until_complete(term.async_inkey(timeout=0))
+        finally:
+            loop.close()
+        assert str(ks) == 'n'
+        assert term._xtgettcap_cache.capabilities['RGB'] == '8/8/8'
+        assert term.errors[-1] == (
+            r"errant/delayed XTGETTCAP_RESPONSE '\x1bP1+r524742=382f382f38\x1b\\'")
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_async_inkey_consumes_late_xtgettcap_response')
+    assert 'OK' in output
+
+
+def test_async_inkey_late_xtgettcap_response_without_styling():
+    """async_inkey() decodes a late XTGETTCAP reply when styling is disabled."""
+    def child(term):
+        term._does_styling = False
+        term.ungetch('\x1bP1+r524742=382f382f38\x1b\\')
+        loop = asyncio.new_event_loop()
+        try:
+            assert loop.run_until_complete(term.async_inkey(timeout=0)) == ''
+        finally:
+            loop.close()
+        assert term.errors[-1] == (
+            r"errant/delayed XTGETTCAP_RESPONSE '\x1bP1+r524742=382f382f38\x1b\\'")
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_async_inkey_late_xtgettcap_response_without_styling')
+    assert 'OK' in output

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -184,7 +184,7 @@ def test_parameterizing_string_type_error(monkeypatch):
     # ensure TypeError when given a string raises custom exception
     try:
         pstr('XYZ')
-        assert False, "previous call should have raised TypeError"
+        assert False
     except TypeError as err:
         assert err.args[0] == (
             "Unknown terminal capability, 'cap-name', or, TypeError "
@@ -194,7 +194,7 @@ def test_parameterizing_string_type_error(monkeypatch):
     # ensure TypeError when given an integer raises its natural exception
     try:
         pstr(0)
-        assert False, "previous call should have raised TypeError"
+        assert False
     except TypeError as err:
         assert err.args[0] == "custom_err"
 
@@ -312,7 +312,7 @@ def test_resolve_capability(monkeypatch):
 
     # given, where does_styling is False
     def raises_exception(*args):
-        assert False, "Should not be called"
+        assert False
 
     term.does_styling = False
     monkeypatch.setattr(jinxed, 'tigetstr', raises_exception)

--- a/tests/test_full_keyboard.py
+++ b/tests/test_full_keyboard.py
@@ -386,7 +386,7 @@ def test_esc_delay_cbreak_nonprefix_sequence():
 
     assert key_name == 'KEY_ALT_A'
     assert math.floor(time.time() - stime) == 0.0
-    assert 0 <= int(duration_ms) <= 10, duration_ms
+    assert 0 <= int(duration_ms) <= 10
 
 
 def test_flushinp_timeout_with_continuous_input():
@@ -934,12 +934,12 @@ def test_esc_delay_long_sequence_prefix_slow_complete():
             os.write(master_fd, bytes([byte]))
 
     output = pty_test(child, parent, 'test_esc_delay_long_sequence_prefix_slow_complete')
-    key_name, key_code, remaining, duration_ms = output.split('|')
+    key_name, _key_code, remaining, duration_ms = output.split('|')
 
     # Even though sent 1 byte at-a-time, our resolver should notice the
     # prefix chain (\x1b -> \x1b[ -> \x1b[1 -> \x1b[15) and wait for completion
     # so long as each byte arrives before esc_delay has elapsed
-    assert key_name == 'KEY_F5', (key_name, key_code, remaining, duration_ms)
+    assert key_name == 'KEY_F5', (key_name, _key_code, remaining, duration_ms)
     assert remaining == "''"
     # Duration should be at least the time to receive all bytes, but faster than full esc_delay
     # (since we recognize the complete pattern before the delay expires)

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -157,8 +157,7 @@ def test_stdout_notty_kb_is_None():
             term = TestTerminal()
             assert term._keyboard_fd is None
             # pylint: disable=use-a-generator
-            assert any(['stream not a TTY' in err
-                        for err in term.errors]), term.errors
+            assert any(['stream not a TTY' in err for err in term.errors])
     child()
 
 
@@ -440,6 +439,34 @@ def test_cpr_response(seq, capture_cpr, expected_name, expected_yx):
     assert ks.cpr_xy == (expected_yx[1], expected_yx[0])
     assert ks.is_sequence
     assert ks.uses_keyboard_protocol == expected_kb_proto
+
+
+@pytest.mark.parametrize("seq,expected_caps", [
+    # supported reply, 'TN' (terminal name) = 'xterm'
+    ('\x1bP1+r544e=787465726d\x1b\\', {'TN': 'xterm'}),
+    # supported reply, 'RGB' = '8/8/8'
+    ('\x1bP1+r524742=382f382f38\x1b\\', {'RGB': '8/8/8'}),
+    # unsupported reply (leading '0') reports no capabilities
+    ('\x1bP0+r544e\x1b\\', {}),
+    # VTE-style malformed empty reply
+    ('\x1bP0+r\x1b\\', {}),
+])
+def test_xtgettcap_response(seq, expected_caps):
+    """XTGETTCAP response matched as single XTGETTCAP_RESPONSE keystroke."""
+    from blessed.keyboard import resolve_sequence
+    ks = resolve_sequence(seq, collections.OrderedDict(), {})
+    assert str(ks) == seq
+    assert ks.name == 'XTGETTCAP_RESPONSE'
+    assert ks.xtgettcap == expected_caps
+    assert ks.is_sequence
+
+
+def test_xtgettcap_not_a_response():
+    """Keystroke.xtgettcap is empty for any non-XTGETTCAP keystroke."""
+    from blessed.keyboard import resolve_sequence
+    ks = resolve_sequence('\x1b[3;4R', collections.OrderedDict(), {})
+    assert ks.name == 'CPR_RESPONSE'
+    assert ks.xtgettcap == {}
 
 
 @pytest.mark.parametrize("sequence,expected_name", [

--- a/tests/test_kitty_protocol.py
+++ b/tests/test_kitty_protocol.py
@@ -1433,7 +1433,7 @@ def test_kitty_negotiation_timing_cached_failure():
         assert flags1 is None
         assert term._kitty_kb_first_query_failed is True
         elapsed_ms = (time.time() - stime) * 1000
-        assert 24 <= elapsed_ms <= 60, elapsed_ms
+        assert 24 <= elapsed_ms <= 60
 
         # any subsequent calls return immediately (as failed)
         stime = time.time()
@@ -1461,7 +1461,7 @@ def test_kitty_negotiation_force_True_incurs_second_timeout():
         elapsed_ms = (time.time() - stime) * 1000
 
         assert flags2 is None
-        assert 20 <= elapsed_ms <= 60, elapsed_ms
+        assert 20 <= elapsed_ms <= 60
         return b'OK'
 
     assert 'OK' in pty_test(

--- a/tests/test_length_sequence.py
+++ b/tests/test_length_sequence.py
@@ -590,8 +590,7 @@ def test_sequence_is_movement_false(any_term):
         assert len(term.italic) == measure_length(term.italic, term)
         assert len(term.strikethrough) == measure_length(term.strikethrough, term)
         assert len(term.overline) == measure_length(term.overline, term)
-        assert (len(term.standout) == measure_length(term.standout, term)
-                ), (term.standout, term._wont_move)
+        assert len(term.standout) == measure_length(term.standout, term)
 
     child(any_term)
 

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -153,8 +153,7 @@ def test_horizontal_location(any_term):
             (unicode_cap('sc', t) or '\x1b[s',
              _hpa,
              unicode_cap('rc', t) or '\x1b[u'))
-        assert (t.stream.getvalue() == expected_output), (
-            repr(t.stream.getvalue()), repr(expected_output))
+        assert t.stream.getvalue() == expected_output
 
     child(any_term)
 
@@ -449,18 +448,18 @@ def test_nice_formatting_errors(any_term):
         t = TestTerminal(kind=kind)
         try:
             t.bold_misspelled('hey')
-            assert not t.is_a_tty, 'Should have thrown exception'
+            assert not t.is_a_tty
         except TypeError as e:
             assert 'Unknown terminal capability,' in e.args[0]
         try:
             t.bold_misspelled('hey')  # unicode
-            assert not t.is_a_tty, 'Should have thrown exception'
+            assert not t.is_a_tty
         except TypeError as e:
             assert 'Unknown terminal capability,' in e.args[0]
 
         try:
             t.bold_misspelled(None)  # an arbitrary non-string
-            assert not t.is_a_tty, 'Should have thrown exception'
+            assert not t.is_a_tty
         except TypeError as e:
             assert 'Unknown terminal capability,' not in e.args[0]
 
@@ -468,9 +467,9 @@ def test_nice_formatting_errors(any_term):
             # PyPy fails to toss an exception, Why?!
             try:
                 t.bold_misspelled('a', 'b')  # >1 string arg
-                assert not t.is_a_tty, 'Should have thrown exception'
+                assert not t.is_a_tty
             except TypeError as e:
-                assert 'Unknown terminal capability,' in e.args[0], e.args
+                assert 'Unknown terminal capability,' in e.args[0]
 
     child(any_term)
 

--- a/tests/test_win_terminal.py
+++ b/tests/test_win_terminal.py
@@ -336,21 +336,24 @@ def test_drain_tracks_button_state():
     child()
 
 
+# Console mode 0x0201 is ENABLE_PROCESSED_INPUT | ENABLE_VIRTUAL_TERMINAL_INPUT, as set by
+# cbreak().  mouse_enabled() adds ENABLE_MOUSE_INPUT (0x0010) and ENABLE_EXTENDED_FLAGS (0x0080)
+# while clearing ENABLE_QUICK_EDIT_MODE (0x0040), which is restored on exit.
 _NATIVE_CTX_PARAMS = pytest.mark.parametrize(
-    "ctx_method,probe_method,flag,dec_mode,enable_bit", [
+    "ctx_method,probe_method,flag,dec_mode,expected_modes", [
         ('mouse_enabled', 'does_mouse', '_native_mouse',
-         DecPrivateMode.MOUSE_EXTENDED_SGR if IS_WINDOWS else 0,
-         win32.ENABLE_MOUSE_INPUT if IS_WINDOWS else 0),
+         DecPrivateMode.MOUSE_EXTENDED_SGR if IS_WINDOWS else 0, (0x0291, 0x02c1)),
         ('notify_on_resize', 'does_inband_resize', '_native_resize',
-         DecPrivateMode.IN_BAND_WINDOW_RESIZE if IS_WINDOWS else 0,
-         win32.ENABLE_WINDOW_INPUT if IS_WINDOWS else 0),
+         DecPrivateMode.IN_BAND_WINDOW_RESIZE if IS_WINDOWS else 0, (0x0209, 0x0201)),
     ])
 
 
 @_NATIVE_CTX_PARAMS
 def test_native_fallback_sets_and_clears(
-        ctx_method, probe_method, flag, dec_mode, enable_bit):
+        ctx_method, probe_method, flag, dec_mode, expected_modes):
     """Test native fallback enables console mode and cleans up on exit."""
+    expected_set, expected_restore = expected_modes
+
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)
         term._keyboard_fd = 0
@@ -367,18 +370,39 @@ def test_native_fallback_sets_and_clears(
             with getattr(term, ctx_method)():
                 assert getattr(term, flag) is True
                 assert cache_key in term._dec_mode_cache
-                mock_set.assert_called_with(42, 0x0201 | enable_bit)
+                mock_set.assert_called_with(42, expected_set)
 
             assert getattr(term, flag) is False
             assert len(term._event_buf) == 0
             assert cache_key not in term._dec_mode_cache
-            assert mock_set.call_args_list[-1] == mock.call(42, 0x0201)
+            assert mock_set.call_args_list[-1] == mock.call(42, expected_restore)
+    child()
+
+
+def test_mouse_enabled_preserves_disabled_quick_edit():
+    """Test mouse_enabled() does not re-enable QuickEdit mode that was already disabled."""
+    def child():
+        term = TestTerminal(stream=io.StringIO(), force_styling=True)
+        term._keyboard_fd = 0
+
+        with mock.patch.object(type(term), 'does_mouse',
+                               return_value=False, create=True), \
+                mock.patch('blessed.win_terminal.msvcrt.get_osfhandle',
+                           return_value=42), \
+                mock.patch.object(
+                win32, 'get_console_mode',
+                return_value=0x0281), \
+                mock.patch.object(win32, 'set_console_mode') as mock_set:
+            with term.mouse_enabled():
+                mock_set.assert_called_with(42, 0x0291)
+
+            assert mock_set.call_args_list[-1] == mock.call(42, 0x0281)
     child()
 
 
 @_NATIVE_CTX_PARAMS
 def test_native_fallback_no_keyboard_fd(
-        ctx_method, probe_method, flag, dec_mode, enable_bit):
+        ctx_method, probe_method, flag, dec_mode, expected_modes):
     """Test native fallback yields without action when keyboard fd is None."""
     def child():
         term = TestTerminal(stream=io.StringIO(), force_styling=True)

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -46,7 +46,7 @@ def test_SequenceWrapper_invalid_width():
         except ValueError as err:
             assert err.args[0] == f"invalid width {WIDTH}({type(WIDTH)}) (must be integer > 0)"
         else:
-            assert False, 'Previous stmt should have raised exception.'
+            assert False
             del my_wrapped  # assigned but never used
 
     child()
@@ -295,16 +295,10 @@ def test_break_on_hyphens():
                 result_stripped = [term.strip_seqs(line) for line in result_colored]
 
                 # Plain text should match stdlib exactly
-                assert result_plain == expected, (
-                    f"Plain text mismatch for {text!r} at width={width}, "
-                    f"break_on_hyphens={break_hyphens}: {result_plain} != {expected}"
-                )
+                assert result_plain == expected
 
                 # Colored text should match when sequences are stripped
-                assert result_stripped == expected, (
-                    f"Colored text mismatch for {text!r} at width={width}, "
-                    f"break_on_hyphens={break_hyphens}: {result_stripped} != {expected}"
-                )
+                assert result_stripped == expected
 
     child()
 

--- a/tests/test_xtgettcap.py
+++ b/tests/test_xtgettcap.py
@@ -971,8 +971,7 @@ def test_does_kitty_query_supported():
         resp = f'\x1bP1+r{hex_cap}={hex_val}\x1b\\'
         cpr = '\x1b[10;20R'
         term.ungetch(resp + cpr)
-        result = term.does_kitty_query(timeout=0.1)
-        assert result is True, (term._xtgettcap_cache, term.does_styling)
+        assert term.does_kitty_query(timeout=0.1)
         assert term._xtgettcap_cache is not None
         assert term._xtgettcap_cache.capabilities.get('kitty-query-name') == 'kitty'
         return b'OK'
@@ -1215,7 +1214,116 @@ def test_query_boundary_multiple_unqueryable():
     """_query_boundary_multiple() returns None without a tty, or without styling."""
     term = TestTerminal(stream=io.StringIO(), force_styling=True)
     query = ('', TermcapResponse._RE_XTGETTCAP_RESPONSE, 0)
-    assert term._query_boundary_multiple(*query) is None, 'not a tty'
+    assert term._query_boundary_multiple(*query) is None
     term._is_a_tty = True
     term._does_styling = False
-    assert term._query_boundary_multiple(*query) is None, 'no styling'
+    assert term._query_boundary_multiple(*query) is None
+
+
+def test_query_boundary_multiple_timeout_rebuffers_input():
+    """_query_boundary_multiple() re-buffers input when CPR boundary never arrives."""
+    def child(term):
+        term.ungetch('KEYS')
+        assert term._query_boundary_multiple(
+            '', TermcapResponse._RE_XTGETTCAP_RESPONSE, timeout=0.01) is None
+        assert term.flushinp() == 'KEYS'
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_query_boundary_multiple_timeout_rebuffers_input')
+    assert 'OK' in output
+
+
+@pytest.mark.parametrize('env,build,skipped', [
+    ({}, 20348, True),
+    ({}, 26100, False),
+    ({'WT_SESSION': 'e6c4c1a9'}, 20348, False),
+    ({'TERM': 'xterm-256color'}, 20348, False),
+])
+def test_xtgettcap_skip_early_conhost(env, build, skipped):
+    """XTGETTCAP init probe skipped only for Windows console builds that leak DCS."""
+    with mock.patch.dict(os.environ, env, clear=True), \
+            mock.patch('blessed.terminal.IS_WINDOWS', True), \
+            mock.patch('blessed.terminal.get_console_input_encoding', create=True,
+                       return_value='UTF-8'), \
+            mock.patch.object(sys, 'getwindowsversion', create=True,
+                              return_value=mock.Mock(build=build)), \
+            mock.patch('os.isatty', return_value=True), \
+            mock.patch.object(Terminal, '_xtgettcap_batch',
+                              return_value=TermcapResponse(supported=False)) as mock_batch:
+        t = Terminal(stream=sys.__stdout__, force_styling=True)
+        assert any('conhost' in err for err in t.errors) is skipped
+        assert mock_batch.called is not skipped
+
+
+def test_xtgettcap_partial_response_defers():
+    """A partial XTGETTCAP reply resolves as bare KEY_ESCAPE, so inkey() awaits the rest."""
+    from blessed.keyboard import resolve_sequence
+    term = TestTerminal(stream=io.StringIO(), force_styling=True)
+    ks = resolve_sequence('\x1bP1+r524742', term._keymap, term._keycodes,
+                          term._keymap_prefixes, final=False)
+    assert (ks.name, len(ks)) == ('KEY_ESCAPE', 1)
+
+
+def test_xtgettcap_late_response_updates_cache():
+    """XTGETTCAP response arriving after probe timeout populates the capability cache."""
+    def child(term):
+        tn_before = term._xtgettcap_cache.capabilities['TN']
+        term.ungetch('\x1bP1+r524742=382f382f38\x1b\\')
+        assert term.inkey(timeout=0) == ''
+        assert term._xtgettcap_cache.capabilities['RGB'] == '8/8/8'
+        assert term._xtgettcap_cache.capabilities['TN'] == tn_before
+        assert term.errors[-1] == (
+            r"errant/delayed XTGETTCAP_RESPONSE '\x1bP1+r524742=382f382f38\x1b\\'")
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_xtgettcap_late_response_updates_cache')
+    assert 'OK' in output
+
+
+def test_xtgettcap_late_response_precedes_keystroke():
+    """A late XTGETTCAP response is consumed silently, yielding the keystroke behind it."""
+    def child(term):
+        term.ungetch('\x1bP1+r524742=382f382f38\x1b\\n')
+        assert term.inkey(timeout=0) == 'n'
+        assert term._xtgettcap_cache.capabilities['RGB'] == '8/8/8'
+        assert term.errors[-1] == (
+            r"errant/delayed XTGETTCAP_RESPONSE '\x1bP1+r524742=382f382f38\x1b\\'")
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_xtgettcap_late_response_precedes_keystroke')
+    assert 'OK' in output
+
+
+def test_xtgettcap_late_response_without_styling():
+    """XTGETTCAP response is decoded without error when styling is disabled."""
+    def child(term):
+        term._does_styling = False
+        term.ungetch('\x1bP1+r524742=382f382f38\x1b\\')
+        assert term.inkey(timeout=0) == ''
+        assert term.errors[-1] == (
+            r"errant/delayed XTGETTCAP_RESPONSE '\x1bP1+r524742=382f382f38\x1b\\'")
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_xtgettcap_late_response_without_styling')
+    assert 'OK' in output
+
+
+def test_xtgettcap_late_failure_response_does_not_set_supported():
+    """A late 'ESC P 0 + r' failure reply reports no capabilities and no support."""
+    def child(term):
+        term._xtgettcap_cache = TermcapResponse(supported=False)
+        term.ungetch('\x1bP0+r524742\x1b\\')
+        assert term.inkey(timeout=0) == ''
+        assert term._xtgettcap_cache.supported is False
+        assert term._xtgettcap_cache.capabilities == {}
+        assert term.errors[-1] == (
+            r"errant/delayed XTGETTCAP_RESPONSE '\x1bP0+r524742\x1b\\'")
+        return b'OK'
+
+    output = pty_test(child, parent_func=None,
+                      test_name='test_xtgettcap_late_failure_response_does_not_set_supported')
+    assert 'OK' in output


### PR DESCRIPTION
* bugfix: do not query XTGETTCAP at class initialization for Windows Server 2022, Closes #408.
* bugfix: disable QuickEdit when ``mouse_enabled()`` so that mouse events are captured for Windows Server 2022-era consoles
* improve: ``inkey()`` no longer returns late XTGETTCAP responses as ``Keystrokes``, and increase global ``TERMINAL_QUERY_TIMEOUT_SECONDS`` from 1 to 5 seconds.